### PR TITLE
Descripción

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.1.0.8",
+    "version": "17.0.1.0.9",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -696,8 +696,11 @@ class AccountMove(models.Model):
         """
         Onchange the foreign rate and compute the foreign inverse rate
         """
-        if self.foreign_inverse_rate <= 0:
-            raise ValidationError(_("The rate entered cannot be negative"))
+        if self.foreign_inverse_rate < 0:
+            raise ValidationError(_("The rate entered cannot be negative."))
+        elif self.foreign_inverse_rate == 0:
+            raise ValidationError(_("The rate entered cannot be zero."))
+
 
     def _get_payments(self, line_ids):
         self.ensure_one()


### PR DESCRIPTION
Este PR añade validaciones para el campo foreign_inverse_rate en el modelo account.move:

Tasa Negativa: Muestra un error si la tasa es negativa. Tasa Cero: Muestra un error si la tasa es cero.
Problema que Soluciona
Previene entradas inválidas en foreign_inverse_rate, evitando errores en el procesamiento y confusión para los usuarios.

Cómo Probar el Cambio
Abre el formulario con foreign_inverse_rate.
Ingresa un valor negativo y verifica el mensaje de error. Ingresa cero y verifica el mensaje de error.
Asegúrate de que los valores válidos funcionen correctamente.