### PR TITLE
- Odoo base recientemente la funcion  `_convert` de `res.currency` la…

### DIFF
--- a/l10n_ve_rate/__manifest__.py
+++ b/l10n_ve_rate/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.0.0.1",
+    "version": "17.0.0.0.2",
     # any module necessary for this one to work correctly
     "depends": ["base", "l10n_ve_base"],
     "data": [

--- a/l10n_ve_rate/models/res_currency.py
+++ b/l10n_ve_rate/models/res_currency.py
@@ -5,7 +5,7 @@ from odoo.exceptions import UserError, ValidationError
 class ResCurrency(models.Model):
     _inherit = "res.currency"
 
-    def _convert(self, from_amount, to_currency, company, date, round=True, custom_rate=0.0):
+    def _convert(self, from_amount, to_currency, company=None, date=None, round=True, custom_rate=0.0):
         """Returns the converted amount of ``from_amount``` from the currency
            ``self`` to the currency ``to_currency`` for the given ``date`` and
            company.
@@ -14,6 +14,10 @@ class ResCurrency(models.Model):
            :param date: The nearest date from which we retriev the conversion rate.
            :param round: Round the result or not
         """
+        if date is None:
+            date = fields.Date.today()
+        if company is None:
+            company = self.rate_ids.company_id
         self, to_currency = self or to_currency, to_currency or self
         assert self, "convert amount from unknown currency"
         assert to_currency, "convert amount to unknown currency"


### PR DESCRIPTION
- Originalmente en esta funcion , los parametros eran opcionales, pero en esta localizacion ahora son necesarios.
- Esto causaba errores cuando Odoo llama a esta función sin enviar ciertos parámetros.
- Se cambió la forma del método para hacer que `company` y `date` sean opcionales.
- Se añadió la asignación de `date` a la fecha actual si no se proporciona.
- Se añadió la asignación de `company` a `self.rate_ids.company_id` si no se proporciona.