### PR TITLE
FIX #7791: account_move

### DIFF
--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.0.0.3",
+    "version": "17.0.0.0.4",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -143,8 +143,8 @@ class AccountMove(models.Model):
 
         for reverse_credit in reverse_move_credit:
             if (
-                payment_credit.is_igtf
-                and payment_credit.is_igtf_on_foreign_exchange
+
+                payment_credit.is_igtf_on_foreign_exchange
                 and reverse_credit
                 and reverse_credit.bi_igtf > 0
             ):
@@ -160,8 +160,8 @@ class AccountMove(models.Model):
 
         for reverse_debit in reverse_move_debit:
             if (
-                payment_debit.is_igtf
-                and payment_debit.is_igtf_on_foreign_exchange
+                
+                payment_debit.is_igtf_on_foreign_exchange
                 and reverse_debit
                 and reverse_debit.bi_igtf > 0
             ):


### PR DESCRIPTION
problema: Al conciliar una factura, esta generaba un error debido a un campo llamado 'payment_credit.is_igtf' el cual en la homologacion se deja de usar.

Solucion: se elimino de la validacion ese campo, ahora se pueden conciliar normalmente cada factura

tarea: https://binaural.odoo.com/web#id=7791&cids=2&model=helpdesk.ticket&view_type=form