### PR TITLE
FEAT #47598: l10n_ve_contact

### DIFF
--- a/l10n_ve_contact/__manifest__.py
+++ b/l10n_ve_contact/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Contacts/Contacts",
-    "version": "17.0.0.0.1",
+    "version": "17.0.0.0.2",
     "depends": ["base", "contacts", "l10n_ve_rate", "l10n_ve_location"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_ve_contact/models/res_partner.py
+++ b/l10n_ve_contact/models/res_partner.py
@@ -26,7 +26,7 @@ class ResPartner(models.Model):
 
     street2 = fields.Char(tracking=True)
 
-    country_id = fields.Many2one(tracking=True)
+    country_id = fields.Many2one(tracking=True, default= lambda self: self.env.ref("base.ve"))
 
     state_id = fields.Many2one(tracking=True)
 

--- a/l10n_ve_contact/views/res_partner.xml
+++ b/l10n_ve_contact/views/res_partner.xml
@@ -15,9 +15,6 @@
             <xpath expr="//field[@name='street']" position="attributes">
                 <attribute name="required">1</attribute>
             </xpath>
-            <xpath expr="//field[@name='street2']" position="attributes">
-                <attribute name="required">1</attribute>
-            </xpath>
             <xpath expr="//field[@name='country_id']" position="attributes">
                 <attribute name="required">1</attribute>
             </xpath>


### PR DESCRIPTION
Problema: Se necesita solamente como obligatorio el field correspondiente a calle 1, calle 2 pasará a ser no obligatorio. También se requiere que el país predeterminado sea Venezuela.

Solución:En la vista correspondiente a res_partner, se eliminó el atributo de requerido para el field correspondiente a calle 2, y en el modelo de res_partner, se agregó el atributo default, el cual realiza una llamada al env para que asigne el valor correspondiente a Venezuela.

Tarea (Link):https://github.com/binaural-consultoria/homologacionbs/pull/201

Tarea de proyecto [x]
Ticket de soporte []