### PR TITLE
Feat l10n ve invoice#46914

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.0.9",
+    "version": "17.0.0.0.10",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.0.8",
+    "version": "17.0.0.0.9",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.0.8",
+    "version": "17.0.0.0.7",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.0.7",
+    "version": "17.0.0.0.8",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
@@ -15,6 +15,7 @@
         "l10n_ve_contact",
         "l10n_ve_tax",
         "od_journal_sequence",
+        "account_debit_note",
     ],
     "data": [
         "security/l10n_ve_invoice_groups.xml",
@@ -29,6 +30,7 @@
         "views/res_config_settings.xml",
         "views/menu.xml",
         "wizard/accounting_reports_views.xml",
+        "views/account_debit_note_view.xml",
     ],
     "images": ["static/description/icon.png"],
     "application": True,

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250321\n"
+"Project-Id-Version: Odoo Server 17.0+e-20250311\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-27 15:55+0000\n"
-"PO-Revision-Date: 2025-03-27 15:55+0000\n"
+"POT-Creation-Date: 2025-04-14 09:27+0000\n"
+"PO-Revision-Date: 2025-04-14 09:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -186,11 +186,9 @@ msgid "Accounting Reports"
 msgstr "Informes contables"
 
 #. module: l10n_ve_invoice
-#. odoo-python
-#: code:addons/l10n_ve_invoice/models/account_move.py:0
-#, python-format
-msgid "An invoice with the Control Number already exists: %s"
-msgstr "Ya existe una factura con el Número de Control: %s"
+#: model:ir.model,name:l10n_ve_invoice.model_account_debit_note
+msgid "Add Debit Note wizard"
+msgstr "Asistente para agregar nota de débito"
 
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.report_freeform_document
@@ -270,6 +268,11 @@ msgid "Date Start"
 msgstr "Fecha de Inicio"
 
 #. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_account_move_form_l10n_ve_invoice
+msgid "Debit note"
+msgstr "Notas de Débito"
+
+#. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_wizard_accounting_reports__display_name
 msgid "Display Name"
 msgstr "Nombre"
@@ -277,6 +280,11 @@ msgstr "Nombre"
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.report_freeform_document
 msgid "FACTURA"
+msgstr ""
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_res_config_settings__auto_select_debit_note_journal
+msgid "Filter Journal Debit Note"
 msgstr ""
 
 #. module: l10n_ve_invoice
@@ -449,6 +457,11 @@ msgid "Sale Book"
 msgstr "Libro de Ventas"
 
 #. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_res_config_settings_l10n_ve_invoice
+msgid "Selecciona automáticamente el diario de notas de débito."
+msgstr ""
+
+#. module: l10n_ve_invoice
 #: model:ir.model.fields,help:l10n_ve_invoice.field_account_bank_statement_line__correlative
 #: model:ir.model.fields,help:l10n_ve_invoice.field_account_move__correlative
 #: model:ir.model.fields,help:l10n_ve_invoice.field_account_payment__correlative
@@ -529,6 +542,13 @@ msgstr ""
 #. module: l10n_ve_invoice
 #: model:ir.model,name:l10n_ve_invoice.model_wizard_accounting_reports
 msgid "Wizard para generar reportes de libro de compra y ventas"
+msgstr ""
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+#, python-format
+msgid "Ya existe una factura con el Número de Control: %s"
 msgstr ""
 
 #. module: l10n_ve_invoice

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e-20250311\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-14 09:27+0000\n"
-"PO-Revision-Date: 2025-04-14 09:27+0000\n"
+"POT-Creation-Date: 2025-04-16 15:00+0000\n"
+"PO-Revision-Date: 2025-04-16 15:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -49,6 +49,14 @@ msgid ""
 "<span><strong>CONTRIBUYENTE FORMAL</strong></span>\n"
 "                                <br/>"
 msgstr ""
+
+#. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_res_config_settings_l10n_ve_invoice
+msgid ""
+"<span>Assists the user in selecting the appropriate journals when applying a"
+" debit note.</span>"
+msgstr ""
+"<span>Asiste al usuario en la elección de los diarios adecuados al aplicar una nota de débito.</span>"
 
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.report_freeform_document
@@ -455,11 +463,6 @@ msgstr "Reporte en moneda del sistema"
 #: model:ir.ui.menu,name:l10n_ve_invoice.account_report_sale_menu
 msgid "Sale Book"
 msgstr "Libro de Ventas"
-
-#. module: l10n_ve_invoice
-#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_res_config_settings_l10n_ve_invoice
-msgid "Selecciona automáticamente el diario de notas de débito."
-msgstr ""
 
 #. module: l10n_ve_invoice
 #: model:ir.model.fields,help:l10n_ve_invoice.field_account_bank_statement_line__correlative

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e-20250311\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-16 15:00+0000\n"
-"PO-Revision-Date: 2025-04-16 15:00+0000\n"
+"POT-Creation-Date: 2025-05-21 00:22+0000\n"
+"PO-Revision-Date: 2025-05-21 00:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -56,7 +56,8 @@ msgid ""
 "<span>Assists the user in selecting the appropriate journals when applying a"
 " debit note.</span>"
 msgstr ""
-"<span>Asiste al usuario en la elección de los diarios adecuados al aplicar una nota de débito.</span>"
+"<span>Asiste al usuario en la elección de los diarios adecuados al aplicar "
+"una nota de débito.</span>"
 
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.report_freeform_document
@@ -199,6 +200,25 @@ msgid "Add Debit Note wizard"
 msgstr "Asistente para agregar nota de débito"
 
 #. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+#, python-format
+msgid "An invoice already exists with the Control Number: %s"
+msgstr "Ya existe una factura con el Número de Control: %s"
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+#, python-format
+msgid "An invoice cannot have a line with a price of zero"
+msgstr ""
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_res_company__auto_select_debit_note_journal
+msgid "Auto Select Debit Note Journal"
+msgstr ""
+
+#. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.report_freeform_document
 msgid "BORRADOR"
 msgstr ""
@@ -210,6 +230,8 @@ msgstr "Libro de Compras"
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
+#: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
 #: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
 #: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
 #, python-format
@@ -238,6 +260,7 @@ msgstr "Configuración de Facturación: General"
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid ""
@@ -288,6 +311,11 @@ msgstr "Nombre"
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.report_freeform_document
 msgid "FACTURA"
+msgstr ""
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_debit_note__filter_enabled
+msgid "Filter Enabled"
 msgstr ""
 
 #. module: l10n_ve_invoice
@@ -517,6 +545,7 @@ msgstr "Mostrar total en USD en forma libre"
 #. module: l10n_ve_invoice
 #. odoo-python
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid ""
 "The correlative must be unique per journal when using a contingency journal"
@@ -526,6 +555,7 @@ msgstr ""
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "The sale's series sequence must be in the selected journal."
@@ -556,6 +586,7 @@ msgstr ""
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "You can not add more than %s products to the invoice."

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -293,7 +293,7 @@ msgstr ""
 #. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_res_config_settings__auto_select_debit_note_journal
 msgid "Filter Journal Debit Note"
-msgstr ""
+msgstr "Filtrar por Diario de Débito"
 
 #. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__first_payment_date
@@ -586,3 +586,17 @@ msgstr "Notas de Débito"
 #, python-format
 msgid "An invoice cannot have a line with a price of zero"
 msgstr "Una factura no puede tener una linea con precio en cero"
+#. module: account
+#: model:ir.actions.act_window,name:account.action_move_in_refund_type
+#: model:ir.actions.act_window,name:account.action_move_out_refund_type
+#: model:ir.ui.menu,name:account.menu_action_move_out_refund_type
+#: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
+#: model_terms:ir.ui.view,arch_db:account.view_account_invoice_report_search
+msgid "Credit Notes"
+msgstr "Notas de Crédito"
+
+#. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_account_move_form_l10n_ve_invoice
+msgid "Debit note"
+msgstr "Notas de Débito"
+

--- a/l10n_ve_invoice/models/__init__.py
+++ b/l10n_ve_invoice/models/__init__.py
@@ -2,3 +2,4 @@ from . import account_move
 from . import account_journal
 from . import res_company
 from . import res_config_settings
+from . import account_debit_note

--- a/l10n_ve_invoice/models/account_debit_note.py
+++ b/l10n_ve_invoice/models/account_debit_note.py
@@ -11,7 +11,7 @@ class AccountDebitNote(models.TransientModel):
         filter_enabled = config.get_param('account.move.auto_select_debit_note_journal') == 'True'
 
         if filter_enabled:
-            nd_journal = self.env['account.journal'].search([('code', '=', 'ND')], limit=1)
+            nd_journal = self.env['account.journal'].search([('is_debit', '=', 'True')], limit=1)
             if nd_journal:
                 self.journal_id = nd_journal.id
           

--- a/l10n_ve_invoice/models/account_debit_note.py
+++ b/l10n_ve_invoice/models/account_debit_note.py
@@ -1,0 +1,17 @@
+from odoo import api, models
+
+class AccountDebitNote(models.TransientModel):
+    _inherit = 'account.debit.note'
+    
+
+    @api.onchange('journal_type')
+    def _onchange_journal_filter_by_config(self):
+
+        config = self.env['ir.config_parameter'].sudo()
+        filter_enabled = config.get_param('account.move.auto_select_debit_note_journal') == 'True'
+
+        if filter_enabled:
+            nd_journal = self.env['account.journal'].search([('code', '=', 'ND')], limit=1)
+            if nd_journal:
+                self.journal_id = nd_journal.id
+          

--- a/l10n_ve_invoice/models/account_debit_note.py
+++ b/l10n_ve_invoice/models/account_debit_note.py
@@ -6,6 +6,7 @@ class AccountDebitNote(models.TransientModel):
     
     @api.depends('journal_type')
     def _compute_filter_enabled(self):
-        config = self.company_id.auto_select_debit_note_journal
+        move = self.env['account.move'].browse(self.env.context.get('active_id'))
+        config = move.company_id.auto_select_debit_note_journal
         for record in self:
             record.filter_enabled = config

--- a/l10n_ve_invoice/models/account_debit_note.py
+++ b/l10n_ve_invoice/models/account_debit_note.py
@@ -1,17 +1,11 @@
-from odoo import api, models
+from odoo import api, models,fields
 
 class AccountDebitNote(models.TransientModel):
     _inherit = 'account.debit.note'
+    filter_enabled = fields.Boolean(string='Filter Enabled', compute='_compute_filter_enabled')
     
-
-    @api.onchange('journal_type')
-    def _onchange_journal_filter_by_config(self):
-
+    @api.depends('journal_type')
+    def _compute_filter_enabled(self):
         config = self.env['ir.config_parameter'].sudo()
-        filter_enabled = config.get_param('account.move.auto_select_debit_note_journal') == 'True'
-
-        if filter_enabled:
-            nd_journal = self.env['account.journal'].search([('is_debit', '=', 'True')], limit=1)
-            if nd_journal:
-                self.journal_id = nd_journal.id
-          
+        for record in self:
+            record.filter_enabled = config.get_param('account.move.auto_select_debit_note_journal') == 'True'

--- a/l10n_ve_invoice/models/account_debit_note.py
+++ b/l10n_ve_invoice/models/account_debit_note.py
@@ -6,6 +6,6 @@ class AccountDebitNote(models.TransientModel):
     
     @api.depends('journal_type')
     def _compute_filter_enabled(self):
-        config = self.env['ir.config_parameter'].sudo()
+        config = self.company_id.auto_select_debit_note_journal
         for record in self:
-            record.filter_enabled = config.get_param('account.move.auto_select_debit_note_journal') == 'True'
+            record.filter_enabled = config

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -44,7 +44,7 @@ class AccountMove(models.Model):
             invoices = record.env['account.move'].sudo().search([("correlative","=",correlative),('move_type', 'in',["out_invoice","out_refund"])])
 
             if invoices and record.move_type in ["out_invoice","out_refund"]:
-                raise ValidationError(_("Ya existe una factura con el Número de Control: %s"%correlative))
+                raise ValidationError(_("An invoice already exists with the Control Number: %s" % correlative))
         return super().action_post()
 
     @api.constrains("correlative", "is_contingency")

--- a/l10n_ve_invoice/models/res_company.py
+++ b/l10n_ve_invoice/models/res_company.py
@@ -13,3 +13,4 @@ class ResCompany(models.Model):
     show_total_on_usd_invoice = fields.Boolean(default=True)
     show_tag_on_usd_invoice = fields.Boolean(default=True)
     show_column_default_code_free_form = fields.Boolean(default=True)
+    auto_select_debit_note_journal = fields.Boolean(default=False) 

--- a/l10n_ve_invoice/models/res_config_settings.py
+++ b/l10n_ve_invoice/models/res_config_settings.py
@@ -25,9 +25,11 @@ class ResConfigSettings(models.TransientModel):
     )
 
     auto_select_debit_note_journal = fields.Boolean(
-        string="Filter Journal Debit Note", config_parameter='account.move.auto_select_debit_note_journal'
-    ) 
-    
+        string="Filter Journal Debit Note", 
+        related="company_id.auto_select_debit_note_journal", 
+        readonly=False
+    )
+
     @api.onchange("group_sales_invoicing_series")
     def onchange_group_sales_invoicing_series(self):
         ir_sequence = self.env["ir.sequence"].sudo()

--- a/l10n_ve_invoice/models/res_config_settings.py
+++ b/l10n_ve_invoice/models/res_config_settings.py
@@ -24,6 +24,10 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.show_column_default_code_free_form", readonly=False
     )
 
+    auto_select_debit_note_journal = fields.Boolean(
+        string="Filter Journal Debit Note", config_parameter='account.move.auto_select_debit_note_journal'
+    ) 
+    
     @api.onchange("group_sales_invoicing_series")
     def onchange_group_sales_invoicing_series(self):
         ir_sequence = self.env["ir.sequence"].sudo()

--- a/l10n_ve_invoice/views/account_debit_note_view.xml
+++ b/l10n_ve_invoice/views/account_debit_note_view.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <data>
+        <record id="view_account_debit_note_inherit" model="ir.ui.view">
+            <field name="name">account.debit.note.form.inherit</field>
+            <field name="model">account.debit.note</field>
+            <field name="inherit_id" ref="account_debit_note.view_account_debit_note"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='journal_id']" position="before">
+                    <field name="filter_enabled" invisible='1'/>
+                </xpath>
+                <xpath expr="//field[@name='journal_id']" position="attributes">
+                    <attribute name="domain">[('is_debit', '=', True)] if filter_enabled else [('type', '=', journal_type)]</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/l10n_ve_invoice/views/account_debit_note_view.xml
+++ b/l10n_ve_invoice/views/account_debit_note_view.xml
@@ -10,6 +10,7 @@
                 </xpath>
                 <xpath expr="//field[@name='journal_id']" position="attributes">
                     <attribute name="domain">[('is_debit', '=', True)] if filter_enabled else [('type', '=', journal_type)]</attribute>
+                    <attribute name='required'>1</attribute>
                 </xpath>
             </field>
         </record>

--- a/l10n_ve_invoice/views/res_config_settings.xml
+++ b/l10n_ve_invoice/views/res_config_settings.xml
@@ -63,6 +63,17 @@
                                 <field name="max_product_invoice" class="oe_inline"/>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-12 o_setting_box" id="l10n_ve_invoice_div_auto_select_debit_note_journal">
+                        <div class="o_setting_left_pane">
+                            <field name="auto_select_debit_note_journal" class="oe_inline"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="auto_select_debit_note_journal" class="oe_inline"/>
+                            <div class="text-muted">
+                                Selecciona automáticamente el diario de notas de débito.
+                            </div>
+                        </div>
+                        </div>
                     </block>
                 </xpath>
             </field>

--- a/l10n_ve_invoice/views/res_config_settings.xml
+++ b/l10n_ve_invoice/views/res_config_settings.xml
@@ -70,7 +70,7 @@
                         <div class="o_setting_right_pane">
                             <label for="auto_select_debit_note_journal" class="oe_inline"/>
                             <div class="text-muted">
-                                Selecciona automáticamente el diario de notas de débito.
+                                <span>Assists the user in selecting the appropriate journals when applying a debit note.</span>
                             </div>
                         </div>
                         </div>


### PR DESCRIPTION
Problema: Se requiere agregar una opción personalizada que ayude al usuario a seleccionar el diario correspondiente a la hora de crear una nota de débito.

Solución:
-Se crea el campo booleano auto_select_debit_note_journal en res_company.
-res.config, se agrega el campo auto_select_debit_note_journal, el cual es booleano y tiene un related auto_select_debit_note_journal de res_company para que la configuración sea multicompañía.
-Se hereda la vista de account_debit_note.view_account_debit_note, y se le modifica el atributo domain, que realizará el filtrado dependiendo del valor que tiene auto_select_debit_note_journal.

Tarea de proyecto [x]
Ticket de soporte []