### PR TITLE
FIX #7943: l10n_ve_pos

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.0",
+    "version": "17.0.0.0.1",
     # any module necessary for this one to work correctly
     "depends": [
         "base",
@@ -28,6 +28,7 @@
         "views/res_config_settings.xml",
         "views/pos_payment_views.xml",
         "views/report_saledetails.xml",
+        "views/pos_config_view.xml",
         "security/res_group.xml",
         "wizard/payment_report.xml",
         "report/payment_report.xml",

--- a/l10n_ve_pos/views/pos_config_view.xml
+++ b/l10n_ve_pos/views/pos_config_view.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <record id="view_pos_pos_config_view_form" model="ir.ui.view">
+        <field name="name">l10n.ve.pos.config</field>
+        <field name="model">pos.config</field>
+        <field name="inherit_id" ref="point_of_sale.pos_config_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='iface_print_via_proxy']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
+            <xpath expr="//label[@for='iface_print_via_proxy']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
.- Fue colocado invisible el campo iface_print_via_proxy, esto debido a que el mismo no puede ser eliminado ya que hay vistas en enterprise que lo heredan.

Tarea (Link):
https://binaural.odoo.com/web\#id\=7943\&cids\=2\&menu_id\=302\&action\=386\&model\=helpdesk.ticket\&view_type\=form

Tarea de proyecto []
Ticket de soporte [x]