### PR TITLE
[FIX]l10n_ve_stock_account#7952

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "17.0.1.1.10",
+    "version": "17.0.1.1.13",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.0.13",
+    "version": "17.0.0.0.19",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -950,6 +950,7 @@ class StockPicking(models.Model):
                     ("type_delivery_step", "!=", "int"),
                     ("transfer_reason_id.code", "!=", "self_consumption"),
                     ("state_guide_dispatch", "=", "to_invoice"),
+                    ('sale_id.document', '!=', 'invoice')
                 ]
             )
         )

--- a/l10n_ve_stock_account/views/stock_picking_guide_dispatch_views.xml
+++ b/l10n_ve_stock_account/views/stock_picking_guide_dispatch_views.xml
@@ -103,6 +103,7 @@
                 ('state', '=', 'done'),
                 ('type_delivery_step', 'in', ['out', 'int']),
                 ('transfer_reason_id.code', '!=', 'self_consumption'),
+                ('sale_id.document', '!=', 'invoice'),
             '|',
                 ('type_delivery_step', '=', 'out'),
             '&amp;',


### PR DESCRIPTION
Problema:

-Se había eliminado completamente el flujo de picking cuando el sale order tenía como documento de tipo factura.
-Se requiere dejar de ver tanto en el cintillo de alerta para las guias de despacho sin facturar, y en la vista tree de reporte de las mismas, aquellos pickings que provienen de un sale.order que tiene como documento de tipo factura.
Solución:
-Se elimina la herencia y modificación de la función _action_launch_stock_rule.

-Se agrega en el domain del action para la vista del reporte, que filtre por aquellas que en su sale_id.document diferente de 'invoice'.

-Se agrega en el search de pickings_combined para que filtre por sale_id.document diferente de 'invoice'.

Ticket [x]
Tarea [x]

Enlace:
https://binaural.odoo.com/web#id=7952&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form