### PR TITLE
FIX-l10n_ve_accountant#7688

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.7",
+    "version": "17.0.0.0.8",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.8",
+    "version": "17.0.0.0.9",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -51,7 +51,6 @@ class AccountMove(models.Model):
         digits=(16, 15),
         default=0.0,
         store=True,
-        readonly=False,
         index=True,
     )
 

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -43,7 +43,6 @@ class AccountMove(models.Model):
         digits="Tasa",
         default=0.0,
         store=True,
-        readonly=False,
         tracking=True,
     )
     foreign_inverse_rate = fields.Float(


### PR DESCRIPTION
Tarea (Link):https://binaural.odoo.com/web#id=7688&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form

problema:no permite visualizar la tasa de la factura de proveedores al hacer click en el campo monto alterno bs solucion:elimine el readonly del backend y unicamente lo deje en la vista y esto permite que se muestre siempre el valor de la tasa