### PR TITLE
FIX #8012: odoo_venezuela

### DIFF
--- a/l10n_ve_contact/__manifest__.py
+++ b/l10n_ve_contact/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Contacts/Contacts",
-    "version": "17.0.0.0.2",
+    "version": "17.0.0.0.3",
     "depends": ["base", "contacts", "l10n_ve_rate", "l10n_ve_location"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_ve_contact/models/res_partner.py
+++ b/l10n_ve_contact/models/res_partner.py
@@ -183,20 +183,3 @@ class ResPartner(models.Model):
             for record in self:
                 record.name = name
     
-    @api.constrains('name')
-    def _check_name(self):
-        for record in self:
-            if not re.match(r'^[a-zA-Z0-9 .,()-]+$', record.name):
-                raise ValidationError(_("The name contains a character that is not allowed for registration."))
-    
-    @api.constrains('street')
-    def _check_address(self):
-        for record in self:
-            if not re.match(r'^[a-zA-Z0-9 .,()-]+$', record.street):
-                raise ValidationError(_("The address contains a character that is not allowed for registration."))
-    
-    @api.constrains('street2')
-    def _check_address2(self):
-        for record in self:
-            if not re.match(r'^[a-zA-Z0-9 .,()-]+$', record.street2):
-                raise ValidationError(_("The address contains a character that is not allowed for registration."))

--- a/l10n_ve_iot_mf/__manifest__.py
+++ b/l10n_ve_iot_mf/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "license": "LGPL-3",
     "category": "Accounting",
-    "version": "17.0.0.0.6",
+    "version": "17.0.0.0.7",
     "author": "binaural-dev",
     "website": "https://binauraldev.com",
     "depends": [

--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.1",
+    "version": "17.0.0.0.2",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/views/pos_config_view.xml
+++ b/l10n_ve_pos/views/pos_config_view.xml
@@ -4,11 +4,11 @@
         <field name="model">pos.config</field>
         <field name="inherit_id" ref="point_of_sale.pos_config_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='iface_print_via_proxy']" position="attributes">
+            <xpath expr="//div[@class='row'][3]/label[@class='col-lg-4 o_light_label'][1]" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
 
-            <xpath expr="//label[@for='iface_print_via_proxy']" position="attributes">
+            <xpath expr="//div[@class='row'][3]/field[1]" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
         </field>

--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.0.2",
     "category": "Accounting",
     "summary": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
     "description": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",

--- a/l10n_ve_pos_mf/static/src/js/PosState.js
+++ b/l10n_ve_pos_mf/static/src/js/PosState.js
@@ -69,7 +69,7 @@ patch(PosStore.prototype, {
       let client = order.get_partner()
 
       invoice['partner_id']['vat'] = client.prefix_vat + client.vat
-      invoice['partner_id']['name'] = client.name
+      invoice['partner_id']['name'] = this.normalizeProductName(client.name)
       invoice['partner_id']['address'] = client.address || false
       invoice['partner_id']['phone'] = client.phone || false
     }
@@ -128,7 +128,7 @@ patch(PosStore.prototype, {
           price_unit: amount,
           discount: el.get_discount(),
           quantity: Math.abs(el.quantity),
-          name: el.product.display_name,
+          name: this.normalizeProductName(el.product.display_name),
           code: el.product.default_code,
           tax: el.get_taxes().length > 0 ? el.get_taxes()[0]['fiscal_code'] : 0
         }
@@ -147,6 +147,19 @@ patch(PosStore.prototype, {
     return invoice
   },
 
+  normalizeProductName(text) {
+    if (!text) return "";
+
+    const normalized = text.normalize("NFKD");
+    const noSpecialChars = normalized
+        .replace(/[\u0300-\u036f]/g, "")  
+        .replace(/[^\w\s]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+
+    return noSpecialChars;
+  },
+  
   async print_out_invoice(data) {
     
     const fdm = this.useFiscalMachine();

--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "17.0.0.0.1",
+    "version": "17.0.0.0.2",
     "depends": [
         "stock",
         "l10n_ve_tax",

--- a/l10n_ve_stock/i18n/es_VE.po
+++ b/l10n_ve_stock/i18n/es_VE.po
@@ -655,15 +655,6 @@ msgstr "La Disponibilidad del Producto para la Venta."
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/product_template.py:0
-#, python-format
-msgid "The name contains a character that is not allowed for registration."
-msgstr ""
-"El nombre contiene al menos un carácter que no está permitido para el "
-"registro"
-
-#. module: l10n_ve_stock
-#. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_location.py:0
 #, python-format
 msgid "The priority must be greater than 0."

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -110,9 +110,3 @@ class ProductTemplate(models.Model):
         domain = [('free_qty', operator, value)]
         product_variant_query = self.env['product.product'].sudo()._search(domain)
         return [('product_variant_ids', 'in', product_variant_query)]
-
-    @api.constrains('name')
-    def _check_name(self):
-        for record in self:
-            if not re.match(r'^[a-zA-Z0-9 .,()-]+$', record.name):
-                raise ValidationError(_("The name contains a character that is not allowed for registration."))


### PR DESCRIPTION
.- Se eliminó la restricción de caracteres para los nombres de clientes y productos. Se implementó una función que normaliza los textos, removiendo caracteres especiales y reemplazando acentos antes del envío a la impresora fiscal, previniendo así errores de impresión.

Tarea (Link):
https://binaural.odoo.com/web\#id\=8012\&cids\=2\&menu_id\=302\&action\=386\&model\=helpdesk.ticket\&view_type\=form

Tarea de proyecto []
Ticket de soporte [x]