### PR TITLE
UPDATE: l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/data/fees_retention_data.xml
+++ b/l10n_ve_payment_extension/data/fees_retention_data.xml
@@ -7,7 +7,7 @@
             <field name="percentage">3</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <!-- <field name="tax_unit_ids">1</field> -->
+            <field name="tax_unit_ids">1</field>
         </record>
 
         <record id="fees_retention_data_percentage_one_l10n_ve_payment_extension" model="fees.retention">
@@ -16,7 +16,7 @@
             <field name="percentage">5</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <!-- <field name="tax_unit_ids">1</field> -->
+            <field name="tax_unit_ids">1</field>
         </record>
 
         <record id="fees_retention_data_percentage_two_l10n_ve_payment_extension" model="fees.retention">
@@ -25,7 +25,7 @@
             <field name="percentage">34</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <!-- <field name="tax_unit_ids">1</field> -->
+            <field name="tax_unit_ids">1</field>
         </record>
 
         <record id="fees_retention_data_substrat_second_l10n_ve_payment_extension" model="fees.retention">
@@ -34,7 +34,7 @@
             <field name="percentage">1</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <!-- <field name="tax_unit_ids">1</field> -->
+            <field name="tax_unit_ids">1</field>
         </record>
 
         <record id="fees_retention_data_l10n_ve_percentage_three_payment_extension" model="fees.retention">
@@ -43,7 +43,7 @@
             <field name="percentage">2</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <!-- <field name="tax_unit_ids">1</field> -->
+            <field name="tax_unit_ids">1</field>
         </record>
 
         <record id="fees_retention_data_percentage_four_l10n_ve_payment_extension" model="fees.retention">
@@ -52,7 +52,7 @@
             <field name="percentage">3</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <!-- <field name="tax_unit_ids">1</field> -->
+            <field name="tax_unit_ids">1</field>
         </record>
 
         <record id="fees_retention_data_percentage_five_l10n_ve_payment_extension" model="fees.retention">
@@ -61,7 +61,7 @@
             <field name="percentage">0</field>
             <field name="status">True</field>
             <field name="accumulated_rate">True</field>
-            <!-- <field name="tax_unit_ids">1</field> -->
+            <field name="tax_unit_ids">1</field>
             <field name="accumulated_rate_ids" eval="[
                 (0,0,{
                     'name': 0.15,


### PR DESCRIPTION
.- Fueron descomentados los tax_unit_ids del data fees_retention, esto debido a que para hacer el registro con saldos iniciales, se debe asignar el tax_unit.