### PR TITLE
[FIX]l10n_ve_accountant#8030

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.9",
+    "version": "17.0.0.0.10",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -307,12 +307,12 @@ class AccountMove(models.Model):
         computes the foreign debit and foreign credit of the line_ids fields (journal entries) when
         the move is edited.
         """
-
-        if 'name' in vals:
+        
+        if 'name' in vals and vals['name'] != "/":
             existing_record = self.search([('name', '=', vals['name']), ('id', '!=', self.id)], limit=1)
             if existing_record:
                 raise ValidationError(_("The operation cannot be completed: Another entry with the same name already exists."))
-
+            
         if vals.get("foreign_rate", False):
             for move in self:
                 vals.update({"last_foreign_rate": move.foreign_rate})


### PR DESCRIPTION
Problema:
-Al cambiar el diario de una factura que venía desde una orden de venta, lanzaba un error de validación que mostraba "Ya existe un asiento con este nombre"

Solución:
-En el método Write del account.move, hay una validación que evalúa si ya existe un asiento con el mismo nombre. Se agregó que si el asiento tiene como nombre "/", lo cual demuestra que es un borrador, no salte esta validación.

Ticket[x]
Tarea[]

Enlace:
https://binaural.odoo.com/web#id=8030&cids=2&menu_id=293&action=389&model=helpdesk.ticket&view_type=form