### PR TITLE
[FIX]l10n_ve_contact#7995

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.7",
+    "version": "17.0.0.0.10",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -309,12 +309,12 @@ class AccountMove(models.Model):
         computes the foreign debit and foreign credit of the line_ids fields (journal entries) when
         the move is edited.
         """
-
-        if 'name' in vals:
+        
+        if 'name' in vals and vals['name'] != "/":
             existing_record = self.search([('name', '=', vals['name']), ('id', '!=', self.id)], limit=1)
             if existing_record:
                 raise ValidationError(_("The operation cannot be completed: Another entry with the same name already exists."))
-
+            
         if vals.get("foreign_rate", False):
             for move in self:
                 vals.update({"last_foreign_rate": move.foreign_rate})


### PR DESCRIPTION
Problema:
-Al crear un contacto nuevo sin calle 2, se mostraba un error de validación de expresión regular.

Solución:
-En el método _check_address2, se agrega una validación para que no salte el error si se le envía el campo vacío.

ticket[x]
tarea[]