### PR TITLE
FIX_l10n_ve_stock_account#7987

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.1.0.0",
+    "version": "17.0.0.0.20",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -973,3 +973,6 @@ class StockPicking(models.Model):
             result = result - timedelta(days=1)
 
         return f"Tienes {len(pickings_combined)} guías de despacho sin facturar al {result.strftime('%d-%m-%Y')}. De facturarse en el siguiente periodo el Seniat será Notificado."
+
+def get_foreign_currency_is_vef(self):
+        return self.env.company.currency_foreign_id == self.env.ref("base.VEF")

--- a/l10n_ve_stock_account/report/dispatch_guide_template.xml
+++ b/l10n_ve_stock_account/report/dispatch_guide_template.xml
@@ -237,7 +237,13 @@
                                             t-out="line_values['total_with_tax']"
                                             t-options='{"widget": "float", "precision": o.get_digits()}' 
                                         />
-                                        <t t-out="o.company_id.currency_id.symbol"/>
+                                        <t t-if="o.get_foreign_currency_is_vef()">                                           
+                                            <t t-set="foreign_symbol" t-value="request.env.ref('base.VEF').symbol"/>
+                                            <t t-out="foreign_symbol"/>
+                                        </t>
+                                        <t t-else="">
+                                            <t t-out="o.company_id.currency_id.symbol"/>
+                                        </t>
                                     </td>
                                 </tr>
                             </t>


### PR DESCRIPTION
Problema:
-Cuando la moneda principal es diferente a Bolívares, a la hora de imprimir la guía de despacho, se muestra el total con el símbolo de la moneda principal, es requerido que siempre se muestre el de Bolívares.

Solución:
-Se crea el método get_foreign_currency_is_vef en stock.picking, la cual evalúa si la moneda foránea es Bolívares.
-En el template de la guía de despacho, se agrega método get_foreign_currency_is_vef, se evalúa su contenido, si es verdadero, se setea una variable llamada foreign_symbol, la cual almacena el valor que trae el request,el cual es el símbolo de bolívares, y se procede a mostrar la variable. Si el retorno es falso, muestra el symbolo de la moneda principal.

Tarea []
Ticket [x]

Enlace:https://binaural.odoo.com/web#id=7987&cids=2&menu_id=293&action=389&model=helpdesk.ticket&view_type=form