### PR TITLE
[FIX]l10n_ve_stock_account#8078

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.0.20",
+    "version": "17.0.0.0.21",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",
@@ -17,6 +17,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/res_groups.xml",
         "data/dispatch_guide_paperformat.xml",
         "data/ir_cron.xml",
         "data/ir_sequence.xml",

--- a/l10n_ve_stock_account/security/res_groups.xml
+++ b/l10n_ve_stock_account/security/res_groups.xml
@@ -1,7 +1,9 @@
 <odoo>
-  <record id="group_stock_account" model="res.groups"> 
-    <field name="name">Ver botón "Crear Factura"</field>
-    <field name="category_id" ref="base.module_category_accounting_accounting" />
-    <field name="users" eval="[(4, ref('base.user_root')),(4,ref('base.user_admin'))]" />
-  </record>
+  <data >
+      <record id="group_stock_account" model="res.groups"> 
+      <field name="name">Ver botón "Crear Factura"</field>
+      <field name="category_id" ref="base.module_category_accounting_accounting" />
+      <field name="users" eval="[(4, ref('base.user_root')),(4,ref('base.user_admin'))]" />
+      </record>
+  </data>
 </odoo>


### PR DESCRIPTION
Problema:
-No se ve el botón de crear factura cuando se va a facturar una guía de despacho.

Solución:
-Se agregó las etiqueta data a la declaración del grupo en res_groups. -Se agregó la referencia al archivo res_groups.xml en el manifest.

ticket[x]
tarea[]

enlace:
https://binaural.odoo.com/web#id=8078&cids=2&model=helpdesk.ticket&view_type=form