### PR TITLE
FIX #8079: l10n_ve_invoice_and_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.10",
+    "version": "17.0.0.0.11",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -64,7 +64,7 @@
             </xpath>
             <xpath expr="//page/field[@name='invoice_line_ids']/tree/field[@name='price_unit']"
                 position="after">
-                <field name="foreign_price" readonly="1" />
+                <field name="foreign_price" readonly="move_type != 'in_invoice'" />
             </xpath>
             <xpath expr="//page/field[@name='invoice_line_ids']/tree/field[@name='price_subtotal']"
                 position="after">

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.0.10",
+    "version": "17.0.0.0.11",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -61,12 +61,9 @@
 
             <button name="button_draft" position="attributes">
                 <!-- <attribute name="invisible">1</attribute> -->
-                <attribute name="invisible">move_type in ['out_invoice', 'out_refund']</attribute>
+                <attribute name="invisible">move_type in ['out_invoice', 'out_refund'] or state == 'draft'</attribute>
             </button>
 
-            <button name="button_cancel" position="attributes">
-                <attribute name="invisible">move_type in ['out_invoice', 'out_refund']</attribute>
-            </button>
 
         </field>
     </record>


### PR DESCRIPTION
.- Fue eliminada la modificacion de los atributos para el boton de cancelar que fue agregado en la vista de account_move del modulo de l10n_ve_invoice, ya que estaba ocasionando un funcionamiento errado del mismo, y no era necesario para que el boton cumpliera con su funcionamiento y flujo correcto.

.- el campo para el precio foraneo en el modulo de l10n_ve_accountant estaba bloqueado para todos los movimientos, se agrego a la codicion de la vista que siga bloqueado para los movimientos a excepcion de las facturas de proveedores.

Tarea (Link):
https://binaural.odoo.com/web\#id\=8079\&cids\=2\&menu_id\=302\&action\=386\&model\=helpdesk.ticket\&view_type\=form

Tarea de proyecto []
Ticket de soporte [x]