### PR TITLE
FEAT #51246: l10n_ve_base

### DIFF
--- a/l10n_ve_base/__manifest__.py
+++ b/l10n_ve_base/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.0.0.3",
+    "version": "17.0.0.0.4",
     "depends": ["base", "web"],
     "auto_install": False,
     "data": ["security/ir.model.access.csv", "views/res_config_settings_views.xml"],

--- a/l10n_ve_base/views/res_config_settings_views.xml
+++ b/l10n_ve_base/views/res_config_settings_views.xml
@@ -6,7 +6,8 @@
         <field name="arch" type="xml">
             <xpath expr="//form" position="inside">
                 <app data-string="Binaural Settings" string="Binaural Settings" name="l10n_ve_base">
-                    <block name="l10n_ve_base_block" invisible="1">
+                    <!-- invisible="1" -->
+                    <block name="l10n_ve_base_block">
                         <setting name="l10n_ve_base_setting"/>
                     </block>
                 </app>


### PR DESCRIPTION
.- Fue habilitada la vista l10n_ve_base_setting en el modulo l10n_ve_base con el fin de que se pueda visualizar y tener acceso a las configuraciones correspondientes a binaural_mobile.

Tarea (Link):
https://binaural.odoo.com/web\#id\=51246\&cids\=2\&menu_id\=975\&action\=341\&model\=project.task\&view_type\=form

Tarea de proyecto [x]
Ticket de soporte []