### PR TITLE
FIX #8126: l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.4",
+    "version": "17.0.0.0.5",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -571,6 +571,10 @@ class AccountRetention(models.Model):
 
     def action_post(self):
         today = datetime.now()
+        
+        self.payment_ids.write({"date": self.date_accounting})
+        self._reconcile_all_payments()
+        
         for retention in self:
             if (
                 retention.type in ["out_invoice", "out_refund", "out_debit"]
@@ -593,8 +597,6 @@ class AccountRetention(models.Model):
                 retention._set_sequence()
                 self.set_voucher_number_in_invoice(move_ids, retention)
 
-        self.payment_ids.write({"date": self.date_accounting})
-        self._reconcile_all_payments()
         self.write({"state": "emitted"})
 
     def set_voucher_number_in_invoice(self, move, retention):


### PR DESCRIPTION
.- Error reportado:
Aumenta el numero de secuencia del IVA aun así cuando la factura no fue confirmada por mensaje de validación.

.- Solución:
Se estaban modificando las secuencias antes del proceso de la función _reconcile_all_payments(), por lo cual cuando en ese proceso entraba en la validación y no permitía confirmar la factura, ya la secuencia se había modificado previamente, es por ello que se movió el aumento de la secuencia para después de la ejecución de la función antes mencionada.

Tarea (Link):
https://binaural.odoo.com/web\#id\=8126\&cids\=2\&menu_id\=302\&action\=386\&model\=helpdesk.ticket\&view_type\=form

Tarea de proyecto []
Ticket de soporte [x]