### PR TITLE
FEAT #52956: l10n_ve_sale

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "17.0.1.1.13",
+    "version": "17.0.1.1.14",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -88,7 +88,9 @@ class SaleOrder(models.Model):
     mobile = fields.Char(related="partner_id.mobile")
 
     @api.model
-    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
+    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None, **kwargs):
+        if 'load' in kwargs:
+            del kwargs['load']
         context = self.with_context(active_test=False)
         return super(SaleOrder, context).search_read(
             domain, fields, offset, limit, order

--- a/l10n_ve_sale/views/sale_order.xml
+++ b/l10n_ve_sale/views/sale_order.xml
@@ -83,7 +83,8 @@
                     groups="!l10n_ve_sale.create_invoice_sale_order_group" />
             </xpath>
 
-            <xpath expr="//sheet//group[1]//div[3]" position="replace">
+            <xpath expr="//field[@name='show_update_pricelist']" position="after">
+				<label for="pricelist_id" groups="product.group_product_pricelist" invisible="not has_active_pricelist"/>
                 <field name="pricelist_id" invisible="1" />
                 <div groups="l10n_ve_sale.pricelist_sale_order_group" class="o_row">
                     <field name="pricelist_id" readonly="1"
@@ -95,6 +96,7 @@
                         confirm="This will update all unit prices based on the currently set pricelist."
                         invisible="not show_update_pricelist or state in ['sale', 'done', 'cancel']" />
                 </div>
+                            
                 <div groups="!l10n_ve_sale.pricelist_sale_order_group" class="o_row">
                     <field name="pricelist_id" options="{'no_open':True,'no_create': True}" />
                     <button name="action_update_prices" type="object"
@@ -106,6 +108,13 @@
                 </div>
             </xpath>
 
+			<xpath expr="//group[@name='order_details']/div[@groups='product.group_product_pricelist']" position="attributes">
+				<attribute name="invisible">1</attribute>
+			</xpath>
+			<xpath expr="//sheet//group[@name='order_details']/label[@for='pricelist_id'][2]" position="attributes">
+				<attribute name="invisible">1</attribute>
+			</xpath>
+            
             <field name="payment_term_id" position="replace">
                 <field name="payment_term_id" options="{'no_open':True,'no_create': True}"
                     groups="!l10n_ve_sale.payment_terms_sale_order_group" />


### PR DESCRIPTION
.- Se eliminó el replace y se agregó en su lugar una referencia diferente usando after. Además, se ocultaron algunos campos mediante un atributo hidden en lugar de reemplazarlos, para garantizar que sigan existiendo y sus referencias permanezcan válidas..

Tarea (Link):
https://binaural.odoo.com/web\#id\=52956\&cids\=2\&menu_id\=975\&action\=341\&model\=project.task\&view_type\=form

Tarea de proyecto [x]
Ticket de soporte []