### PR TITLE
FIX: l10n_ve_invoice_digital

### DIFF
--- a/l10n_ve_invoice_digital/models/account_move.py
+++ b/l10n_ve_invoice_digital/models/account_move.py
@@ -613,7 +613,7 @@ class AccountMove(models.Model):
 
     def build_payment_info(self, item, payment, currency, payment_method, foreign_rate):
         payment_info = {
-            "descripcion": payment.concept,
+            "descripcion": payment.concept if payment.concept else "N/A",
             "fecha": item.get("date").strftime("%d/%m/%Y") if item.get("date") else "",
             "forma": payment_method,
             "monto": str(item.get("amount")),

--- a/l10n_ve_invoice_digital/models/account_move.py
+++ b/l10n_ve_invoice_digital/models/account_move.py
@@ -616,7 +616,7 @@ class AccountMove(models.Model):
             "descripcion": payment.concept if payment.concept else "N/A",
             "fecha": item.get("date").strftime("%d/%m/%Y") if item.get("date") else "",
             "forma": payment_method,
-            "monto": str(item.get("amount")),
+            "monto": str(round(item.get("amount"), 2)),
             "moneda": currency,
         }
 

--- a/l10n_ve_invoice_digital/models/account_retention.py
+++ b/l10n_ve_invoice_digital/models/account_retention.py
@@ -304,7 +304,7 @@ class AccountRetention(models.Model):
                     type_person = line.payment_concept_id.line_payment_concept_ids.filtered(lambda x: x.type_person_id.id == record.partner_id.type_person_id.id)
                     code = type_person.code if type_person else ""
                     if code:
-                        retention_data["CodigoConcepto"] = code
+                        retention_data["CodigoConcepto"] = code.zfill(3)
 
                     retention_data["porcentaje"] = str(round(line.related_percentage_fees, 2))
 


### PR DESCRIPTION
Problema: Al digitalizar una factura con un pago registrado y sin un concepto la API devuelve un error de validacion porque se le esta un valor false

Solución: Se agrego una validacion, si el concepto del pago esta vacio se le pondra el valor de "N/A" (No aplica)

Tarea (Link): https://binaural.odoo.com/web?db=binaural-dev-binaural-release-10413381&token=4P6sT2NxLGgos2OwxwuG#id=53041&cids=2&menu_id=975&action=341&model=project.task&view_type=form