### PR TITLE
FIX #8251: l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.5",
+    "version": "17.0.0.0.6",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_journal.py
+++ b/l10n_ve_payment_extension/models/account_journal.py
@@ -8,6 +8,6 @@ class AccountJournal(models.Model):
         domain=(
             "[('deprecated', '=', False), ('company_id', '=', company_id),"
             "'|',('account_type', '=', default_account_type),"
-            "('account_type', 'in', ('asset_current', 'liability_current'))]"
+            "('account_type', 'in', ('income', 'income_other') if type == 'sale' else ('expense', 'expense_depreciation', 'expense_direct_cost') if type == 'purchase' else ('asset_current', 'liability_current'))]"
         )
     )


### PR DESCRIPTION
Problema:
-Cuando se va a crear un diario de tipo ventas o compras, no muestra los tipos de cuentas correspondientes al seleccionar la predeterminada de los diarios.

Solución:
-En el domain del campo default_account_id del modelo account.journal, no tenìa previsto los casos correspondientes a mostrar cuando el diario sea de tipo venta o compra.

Ticket (Link):
https://binaural.odoo.com/web#id=8251&cids=2&menu_id=293&action=389&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]