### PR TITLE
 FEAT#51060_binaural_pos_17.0

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.2",
+    "version": "17.0.0.0.3",
     # any module necessary for this one to work correctly
     "depends": [
         "base",
@@ -28,6 +28,7 @@
         "views/res_config_settings.xml",
         "views/pos_payment_views.xml",
         "views/report_saledetails.xml",
+        "views/product_views.xml",
         "security/res_group.xml",
         "wizard/payment_report.xml",
         "report/payment_report.xml",

--- a/l10n_ve_pos/i18n/es_VE.po
+++ b/l10n_ve_pos/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250321\n"
+"Project-Id-Version: Odoo Server 17.0+e-20250313\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-27 17:00+0000\n"
-"PO-Revision-Date: 2025-03-27 17:00+0000\n"
+"POT-Creation-Date: 2025-07-04 16:05+0000\n"
+"PO-Revision-Date: 2025-07-04 16:05+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -89,18 +89,39 @@ msgid "Activate Barcode Strict Mode"
 msgstr "Activar Modo Estricto Barcode"
 
 #. module: l10n_ve_pos
+#: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
+msgid ""
+"Activate product entry with barcode in\n"
+"                                                            strict mode"
+msgstr ""
+
+#. module: l10n_ve_pos
 #: model:ir.model.fields,help:l10n_ve_pos.field_pos_config__activate_barcode_strict_mode
 #: model:ir.model.fields,help:l10n_ve_pos.field_res_config_settings__activate_barcode_strict_mode
-#: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
 msgid "Activate product entry with barcode in strict mode"
 msgstr "Activar entrada de producto con código de barras en modo estricto"
 
 #. module: l10n_ve_pos
+#: model:ir.model.fields,field_description:l10n_ve_pos.field_pos_config__allow_sales_on_order
+#: model:ir.model.fields,field_description:l10n_ve_pos.field_res_config_settings__allow_sales_on_order
+#: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
+msgid "Allow sales on order"
+msgstr "Permitir ventas bajo pedido"
+
+#. module: l10n_ve_pos
+#: model:ir.model.fields,help:l10n_ve_pos.field_product_product__pos_sale_on_order
+#: model:ir.model.fields,help:l10n_ve_pos.field_product_template__pos_sale_on_order
+msgid ""
+"Allow selling this product in POS even if it is not available in stock."
+msgstr ""
+
+#. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
 msgid ""
-"Allows you to sell kits whose products are not in the main warehouse of the "
-"box."
-msgstr "Permite vender kits cuyos productos no están en el almacén principal de la caja."
+"Allows you to sell kits whose products are\n"
+"                                                        not in the main\n"
+"                                                        warehouse of the box."
+msgstr ""
 
 #. module: l10n_ve_pos
 #: model:ir.model.fields,field_description:l10n_ve_pos.field_pos_config__amount_to_zero
@@ -252,8 +273,10 @@ msgstr "Moneda alterna para la compañía"
 
 #. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
-msgid "Deletes automatically products without free qty on POS"
-msgstr "Elimina automáticamente productos sin cantidad disponible en el POS"
+msgid ""
+"Deletes automatically products without free qty on\n"
+"                                                POS"
+msgstr ""
 
 #. module: l10n_ve_pos
 #. odoo-javascript
@@ -436,11 +459,10 @@ msgstr "Es moneda alterna"
 #. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
 msgid ""
-"It is allowed to break reconciliation of payments associated with the POS\n"
+"It is allowed to break reconciliation of payments associated\n"
+"                                    with the POS\n"
 "                                    if the session it corresponds to is open"
 msgstr ""
-"Se permite romper la conciliación de pagos asociados con el POS\n"
-"                                    si la sesión correspondiente está abierta"
 
 #. module: l10n_ve_pos
 #: model:ir.model,name:l10n_ve_pos.model_account_move
@@ -492,8 +514,11 @@ msgstr "Nombre"
 
 #. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
-msgid "No Point of Sale selected"
-msgstr "No se ha seleccionado un Punto de Venta"
+msgid ""
+"No Point of\n"
+"                                                Sale\n"
+"                                                selected"
+msgstr ""
 
 #. module: l10n_ve_pos
 #. odoo-python
@@ -531,7 +556,7 @@ msgstr "Configuración del POS"
 #. module: l10n_ve_pos
 #: model:ir.model,name:l10n_ve_pos.model_account_partial_reconcile
 msgid "Partial Reconcile"
-msgstr "Conciliación Parcial"
+msgstr "Conciliación parcial"
 
 #. module: l10n_ve_pos
 #. odoo-javascript
@@ -570,9 +595,10 @@ msgstr "Pagos en"
 #. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
 msgid ""
-"Please create/select a Point of Sale above to show the configuration "
-"options."
-msgstr "Por favor cree/seleccione un Punto de Venta arriba para mostrar las opciones de configuración."
+"Please create/select a Point of Sale above to show\n"
+"                                                the\n"
+"                                                configuration options."
+msgstr ""
 
 #. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
@@ -597,7 +623,7 @@ msgstr "Punto de Venta Reporte de Detalles"
 #. module: l10n_ve_pos
 #: model:ir.model,name:l10n_ve_pos.model_pos_order_line
 msgid "Point of Sale Order Lines"
-msgstr "Líneas de orden del Punto de venta"
+msgstr "Líneas de orden del punto de venta"
 
 #. module: l10n_ve_pos
 #: model:ir.model,name:l10n_ve_pos.model_pos_order
@@ -617,7 +643,7 @@ msgstr "Pagos en punto de venta"
 #. module: l10n_ve_pos
 #: model:ir.model,name:l10n_ve_pos.model_pos_session
 msgid "Point of Sale Session"
-msgstr "Sesión de punto de venta"
+msgstr "Sesión del punto de venta"
 
 #. module: l10n_ve_pos
 #: model:ir.model.fields,field_description:l10n_ve_pos.field_pos_payment_report__pos_config_ids
@@ -679,9 +705,15 @@ msgid "Print"
 msgstr "Imprimir"
 
 #. module: l10n_ve_pos
+#: model:ir.model,name:l10n_ve_pos.model_product_template
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.report_saledetails
 msgid "Product"
 msgstr "Producto"
+
+#. module: l10n_ve_pos
+#: model:ir.model,name:l10n_ve_pos.model_product_product
+msgid "Product Variant"
+msgstr "Variante del producto"
 
 #. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.report_saledetails
@@ -703,6 +735,12 @@ msgstr ""
 " movimientos."
 
 #. module: l10n_ve_pos
+#: model:ir.model.fields,field_description:l10n_ve_pos.field_product_product__pos_sale_on_order
+#: model:ir.model.fields,field_description:l10n_ve_pos.field_product_template__pos_sale_on_order
+msgid "Sale on Order in POS"
+msgstr "Venta bajo pedido en POS"
+
+#. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.report_saledetails
 msgid "Sales Details"
 msgstr "Detalle de ventas"
@@ -710,7 +748,8 @@ msgstr "Detalle de ventas"
 #. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
 msgid "Search clients by vat number in CNE database"
-msgstr "Buscar clientes por número de identificación en la base de datos del CNE"
+msgstr ""
+"Buscar clientes por número de identificación en la base de datos del CNE"
 
 #. module: l10n_ve_pos
 #: model:ir.model.fields,field_description:l10n_ve_pos.field_pos_config__sell_kit_from_another_store
@@ -735,8 +774,10 @@ msgstr "Mostrar cantidad disponible en el POS"
 
 #. module: l10n_ve_pos
 #: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
-msgid "Show quantites from warehouse of TPV"
-msgstr "Mostrar cantidades del almacén del TPV"
+msgid ""
+"Show quantites from warehouse of\n"
+"                                                                    TPV"
+msgstr ""
 
 #. module: l10n_ve_pos
 #: model:ir.model.fields,field_description:l10n_ve_pos.field_pos_payment_report__start_date
@@ -825,7 +866,7 @@ msgstr ""
 #: code:addons/l10n_ve_pos/static/src/overrides/components/order_widget/order_widget.xml:0
 #, python-format
 msgid "Total de productos:"
-msgstr "Total de productos:"
+msgstr ""
 
 #. module: l10n_ve_pos
 #. odoo-javascript
@@ -897,6 +938,10 @@ msgid ""
 msgstr ""
 "No puede romper conciliación de un pago vinculado a una sesión de POS que "
 "aún está abierta"
+#. module: l10n_ve_pos
+#: model_terms:ir.ui.view,arch_db:l10n_ve_pos.res_config_settings_l10n_ve_pos
+msgid "allows sales on order without having the product available"
+msgstr "Permite la venta bajo pedido sin tener el producto disponible"
 
 #. module: l10n_ve_pos
 #: model:ir.model,name:l10n_ve_pos.model_report_l10n_ve_pos_payment_report_pos

--- a/l10n_ve_pos/models/__init__.py
+++ b/l10n_ve_pos/models/__init__.py
@@ -9,3 +9,5 @@ from . import pos_payment
 from . import account_move
 from . import stock_picking
 from . import account_partial_reconcile
+from . import product_product
+from . import product_template

--- a/l10n_ve_pos/models/pos_config.py
+++ b/l10n_ve_pos/models/pos_config.py
@@ -31,6 +31,9 @@ class PosConfig(models.Model):
     )
     pos_search_cne = fields.Boolean(related="company_id.pos_search_cne")
     amount_to_zero = fields.Boolean("Amount to zero")
+    allow_sales_on_order = fields.Boolean(
+        "Allow sales on order",
+    )
     activate_barcode_strict_mode = fields.Boolean(
         help="Activate product entry with barcode in strict mode"
     )

--- a/l10n_ve_pos/models/pos_session.py
+++ b/l10n_ve_pos/models/pos_session.py
@@ -59,6 +59,7 @@ class PosSession(models.Model):
         params["search_params"]["fields"].append("free_qty")
         params["search_params"]["fields"].append("qty_available")
         params["search_params"]["fields"].append("detailed_type")
+        params["search_params"]["fields"].append("pos_sale_on_order")
         params["context"] = {
             **params["context"],
             "warehouse": self.config_id.picking_type_id.warehouse_id.id,

--- a/l10n_ve_pos/models/product_product.py
+++ b/l10n_ve_pos/models/product_product.py
@@ -1,0 +1,10 @@
+from odoo import _, api, models, fields
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    pos_sale_on_order = fields.Boolean(
+        string="Sale on Order in POS",
+        related='product_tmpl_id.pos_sale_on_order',
+        store=False,
+    )

--- a/l10n_ve_pos/models/product_template.py
+++ b/l10n_ve_pos/models/product_template.py
@@ -1,0 +1,12 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    pos_sale_on_order = fields.Boolean(
+            string="Sale on Order in POS",
+            help="Allow selling this product in POS even if it is not available in stock.",
+            default=False,
+            tracking=True,
+        )

--- a/l10n_ve_pos/models/res_config_settings.py
+++ b/l10n_ve_pos/models/res_config_settings.py
@@ -17,6 +17,12 @@ class ResConfigSettings(models.TransientModel):
     amount_to_zero = fields.Boolean(
         related="pos_config_id.amount_to_zero", readonly=False
     )
+
+    allow_sales_on_order = fields.Boolean(
+        related="pos_config_id.allow_sales_on_order",
+        readonly=False
+    )
+
     pos_show_just_products_with_available_qty = fields.Boolean(
         related="company_id.pos_show_just_products_with_available_qty", readonly=False
     )

--- a/l10n_ve_pos/static/src/overrides/components/product_list/product_list.js
+++ b/l10n_ve_pos/static/src/overrides/components/product_list/product_list.js
@@ -12,9 +12,9 @@ patch(ProductsWidget.prototype, {
     if (!this.pos.config.pos_show_just_products_with_available_qty) {
       return list;
     }
-
+    
     list = list.filter(product => {
-      if (product.type === 'service' || product.type === 'consu') {
+      if (product.type === 'service' || product.type === 'consu' || (this.pos.config.allow_sales_on_order && product.pos_sale_on_order)) {
         return true;
       }
       return product.qty_available > 0;

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -306,11 +306,17 @@ patch(Order.prototype, {
     if (this.pos.config.amount_to_zero) {
       let product_quantity_by_product = {};
       let products = [];
+      let allow_sales_on_order = false
       for (let line of lines) {
         let prd = this.pos.db.get_product_by_id(line.get_product().id);
 
         if (prd.type != "product") {
           continue;
+        }
+        
+        console.log("AKDASD PRODUCT", this.pos.config.allow_sales_on_order );
+        if (this.pos.config.allow_sales_on_order && prd.pos_sale_on_order){
+          allow_sales_on_order = true
         }
 
         if (product_quantity_by_product[prd.id] == undefined) {
@@ -324,6 +330,10 @@ patch(Order.prototype, {
         ) {
           products.push(prd.display_name);
         }
+      }
+
+      if (allow_sales_on_order){
+        return await super.pay(...arguments)
       }
 
       if (products.length > 0)

--- a/l10n_ve_pos/views/product_views.xml
+++ b/l10n_ve_pos/views/product_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_form_pos_view" model="ir.ui.view">
+        <field name="name">product.template.form.view.l10nve.pos</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="arch" type="xml">
+            <field name="pos_categ_ids" position="after">
+                <field name="pos_sale_on_order"
+                    invisible="not available_in_pos" 
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_ve_pos/views/res_config_settings.xml
+++ b/l10n_ve_pos/views/res_config_settings.xml
@@ -123,6 +123,17 @@
                                                             Do not allow sales less than
                                                         </div>
                                                     </div>
+                                                    <div class="col-12 col-lg-6 o_setting_box" invisible="not amount_to_zero">
+                                                        <div class="o_setting_left_pane">
+                                                            <field name="allow_sales_on_order"/>
+                                                        </div>
+                                                        <div class="o_setting_right_pane">
+                                                            <label for="allow_sales_on_order" string="Allow sales on order"/>
+                                                            <div class="text-muted">
+                                                                allows sales on order without having the product available 
+                                                            </div>
+                                                        </div>
+                                                    </div>
                                                     <div class="col-12 col-lg-6 o_setting_box"
                                                         id="l10n_ve_pos_div_pos_show_free_qty">
                                                         <div class="o_setting_left_pane">


### PR DESCRIPTION
Problema:  hay empresas que venden productos almacenables con stock pero también algunos productos que no mantienen inventario físico disponible. Estos productos se consideran almacenables en Odoo, pero no se tiene stock disponible de manera constante, ya que están en inventario del proveedor. Teniendo en cuenta que ya se tiene restricción (por configuración Binaural) para no vender más de lo disponible en almacén.

Solución: Se agrega un check de configuracion de pos que permite vender productos bajo pedido. Este check sirve para poder validar los productos que no tienen disponiblidad en inventario, pero si pueden ser vendidos bajo pedido, esto tiene la finalidad de saltarse la condicion de stock en inventario si solo si la configuracion esta activa en el post y en la fiucha del producto. Ademas se modifica la condicional de carga de productos en el Pos para que cuando tenga activa la configuracion de "pos_show_just_products_with_available_qty" me retorne solo los productos que tengan disponibilidad en inventario y los que tengan este check de "pos_sale_on_order" en la fucha del producto activo.

Tarea (Link):https://binaural.odoo.com/web#id=51060&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []