### PR TITLE
Odoove 17.0 feat ta 47125 new validations internal transfers

### DIFF
--- a/l10n_ve_stock/models/stock_location.py
+++ b/l10n_ve_stock/models/stock_location.py
@@ -7,6 +7,7 @@ class StockLocation(models.Model):
     _inherit = ["stock.location", "mail.thread", "mail.activity.mixin"]
 
     priority = fields.Integer(string="Priority", default=10, tracking=True)
+    partner_id = fields.Many2one(tracking=True)
 
     @api.constrains("priority")
     def _check_priority(self):

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -81,7 +81,7 @@ class StockPicking(models.Model):
         store=True,
         compute="_compute_is_dispatch_guide",
     )
-    partner_required = fields.Boolean(store=True)
+    partner_required = fields.Boolean(compute='_compute_partner_required', store=True)
     
     is_consignment = fields.Boolean(compute="_compute_is_consignment", store=True)
     is_consignment_readonly = fields.Boolean(default=False)
@@ -1017,19 +1017,24 @@ class StockPicking(models.Model):
 
         return f"Tienes {len(pickings_combined)} guías de despacho sin facturar al {result.strftime('%d-%m-%Y')}. De facturarse en el siguiente periodo el Seniat será Notificado."
     
-    def get_foreign_currency_is_vef(self):
-        return self.env.company.currency_foreign_id == self.env.ref("base.VEF")
-    @api.onchange('location_dest_id', 'is_dispatch_guide', 'is_consignment', 'transfer_reason_id.id')
-    def _compute_required_partner_id(self):
+    @api.depends('is_consignment', 'is_dispatch_guide', 'transfer_reason_id')
+    def _compute_partner_required(self):
         for picking in self:
             if picking.transfer_reason_id.id == self.env.ref('l10n_ve_stock_account.transfer_reason_consignment').id and picking.is_dispatch_guide and picking.is_consignment: 
+                picking.partner_required = True
+            else:
+                picking.partner_required = False
+                
+    @api.onchange('location_dest_id', 'partner_required')
+    def _change_required_partner_id(self):
+        for picking in self:
+            if picking.partner_required: 
                 contact = self.env['res.partner'].search([('id', '=', picking.location_dest_id.partner_id.id)], limit=1)
                 if contact:
                     picking.partner_required = True
                     picking.partner_id = contact.id
                 else:
                     picking.partner_id = None
-                    picking.partner_required = False
             else:
                 picking.partner_id = None
                 picking.partner_required = False

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -1017,6 +1017,9 @@ class StockPicking(models.Model):
 
         return f"Tienes {len(pickings_combined)} guías de despacho sin facturar al {result.strftime('%d-%m-%Y')}. De facturarse en el siguiente periodo el Seniat será Notificado."
     
+    def get_foreign_currency_is_vef(self):
+        return self.env.company.currency_foreign_id == self.env.ref("base.VEF")
+    
     @api.depends('is_consignment', 'is_dispatch_guide', 'transfer_reason_id')
     def _compute_partner_required(self):
         for picking in self:

--- a/l10n_ve_stock_account/views/stock_picking_views.xml
+++ b/l10n_ve_stock_account/views/stock_picking_views.xml
@@ -22,8 +22,12 @@
             <xpath expr="//form//group//group//field[@name='location_id'][2]" position="attributes">
                 <attribute name="readonly">order_is_consignment</attribute>
             </xpath>
+            <xpath expr="//field[@name='partner_id']" position="before">
+                <field name="partner_required" invisible='1'/>
+            </xpath>
             <xpath expr="//form//group//group//field[@name='partner_id']" position="attributes">
-                <attribute name="readonly">order_is_consignment</attribute>
+                <attribute name="required">partner_required</attribute> 
+                <attribute name="readonly">order_is_consignment or partner_required</attribute>
             </xpath>
             <xpath expr="//form//header" position="inside">
                 <field name="dispatch_guide_controls" invisible="1" />


### PR DESCRIPTION
Problema:

Escenario 1: Cuando las condiciones sean

Es guia de despacho: ACTIVO

Motivo de traslado: CONSIGNACIÓN

Es consignación: ACTIVO

Tipo de operación: Traslados Internos

Validaciones: Crear las siguientes validaciones

Contacto no puede estar vacio

Se debe asignar de forma automatica el CONTACTO (CLIENTE). Ubicar la información desde la ubicación destino. Es decir:

No se debe colocar manual

No se puede editar

Escenario 2: Dejar trazabilidad cuando se cambie de cliente en las ubicaciones de almacenes

Ruta: Inventario/ configuración / Ubicaciones / Campo cliente

Ejemplo: Se cambia de Mariuska Parra a Farmatodo (Dejar trazabilidad)

Solución:

-Se crea un field booleano llamado partner_required, el cual será usado para ver si las condiciones del primer escenario se cumplen o no.

-Se crea un método onchange llamado _compute_required_partner_id, el cual modifica el partner_required en base a los requerimientos del primer escenario, si se cumplen, asigna el cliente de la ubicación de destino como el contacto del traslado, y asigna el valor de True al partner_required.

-En la vista correspondiente al formulario de los traslados internos, se crea un xpath para inicializar el field partner_required y poder acceder a él desde al xml.

-Usando el valor del field partner_required, se cambian los atributos de readonly y required del field partner_id en el formulario, si es true, estos se activan.

Tarea (Link):
https://binaural.odoo.com/web#id=47125&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [X]
Ticket de soporte []

