### PR TITLE
l10nve_17.0_feat#53747_l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.12",
+    "version": "17.0.0.0.13",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -359,15 +359,7 @@ class AccountMove(models.Model):
                     and self.env.company.unique_tax
                 ):
                     raise ValidationError(_("This product must have only one tax."))
-
-    @api.constrains("currency_id")
-    def _check_currency_id(self):
-        for move in self.filtered(lambda m: m.is_invoice(include_receipts=True)):
-            if move.currency_id.id != self.env.company.currency_id.id:
-                raise ValidationError(
-                    _("You cannot place a currency other than the base of the system.")
-                )
-
+                
     def legacy_compute_line_ids_foreign_debit_and_credit(self):
         """
         This method is used to compute the foreign debit and foreign credit of the line_ids field


### PR DESCRIPTION
Problema: Quitar validación de integra que solo permita generar una factura en la moneda base del sistema

Solución: Se elimina la api contrains para verificaba el currency_id del account move

Tarea (Link): https://binaural.odoo.com/web#id=53747&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []