### PR TITLE
FIX #53528: l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.10",
+    "version": "17.0.0.0.11",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -96,6 +96,7 @@ class AccountRetention(models.Model):
     date_accounting = fields.Date(
         "Accounting Date",
         states={"draft": [("readonly", False)]},
+        default=fields.Date.context_today,
         help=(
             "Date of arrival of the document and date to be used to make the accounting record."
             " Keep blank to use current date."
@@ -430,7 +431,6 @@ class AccountRetention(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
-        res._set_sequence()
         res._create_payments_from_retention_lines()
         return res
 


### PR DESCRIPTION
.-Fecha automática: Al ingresar al formulario de registro de retenciones, el campo de fecha se completa automáticamente con la fecha actual del sistema.
.-Generación de número de retención: El correlativo único para la retención de proveedores se genera automáticamente al aplicar la retención, garantizando su secuencialidad.

Tarea (Link):
https://binaural.odoo.com/web\#id\=53528\&cids\=2\&menu_id\=975\&action\=341\&model\=project.task\&view_type\=form

Tarea de proyecto [x]
Ticket de soporte []