### PR TITLE
FIX #53528: l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.12",
+    "version": "17.0.0.0.13",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/i18n/es_VE.po
+++ b/l10n_ve_payment_extension/i18n/es_VE.po
@@ -2942,3 +2942,14 @@ msgstr "El porcentaje no puede exceder el 100% en la linea de pago."
 #, python-format
 msgid "No registered lines found in the move to reconcile."
 msgstr "No existen líneas registradas en el movimiento"
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.res_config_settings_l10n_ve_payment_extension
+msgid "Account reports"
+msgstr "Reportes contables"
+
+#. module: l10n_ve_payment_extension
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_res_company__hide_patent_columns_extra
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_res_config_settings__hide_patent_columns_extra
+msgid "Hide extra columns in Patent Municipal Report related to advances"
+msgstr "Ocultar columnas adicionales en el reporte de Patente Municipal relacionadas con anticipos"

--- a/l10n_ve_payment_extension/models/res_company.py
+++ b/l10n_ve_payment_extension/models/res_company.py
@@ -39,4 +39,10 @@ class ResCompany(models.Model):
         "account.withholding.type",
         string="The condition of this taxpayer requires the withholding of",
     )
+    
     code_visible=fields.Boolean(string="See payment concept code")
+
+    hide_patent_columns_extra = fields.Boolean(
+        string="Hide extra columns in Patent Municipal Report related to advances",
+        default=False,
+    )

--- a/l10n_ve_payment_extension/models/res_config_settings.py
+++ b/l10n_ve_payment_extension/models/res_config_settings.py
@@ -29,3 +29,8 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.condition_withholding_id', readonly=False
     )
     code_visible=fields.Boolean(related='company_id.code_visible',readonly=False)
+    
+    hide_patent_columns_extra = fields.Boolean(
+        related='company_id.hide_patent_columns_extra',
+        readonly=False
+    )

--- a/l10n_ve_payment_extension/views/res_config_settings.xml
+++ b/l10n_ve_payment_extension/views/res_config_settings.xml
@@ -61,7 +61,15 @@
                                     <field name="municipal_customer_retention_journal_id" class="col-lg-6"/>
                                 </div>
                             </div>
-                        </setting>
+                        </setting>                    
+                        <h2>Account reports</h2>
+                        <div class="row mt16 o_settings_container" name="binaural_accounting_reports_settings">
+                            <div class="o_setting_right_pane">
+                                <group colspan="4" col="4">
+                                    <field name="hide_patent_columns_extra"/>
+                                </group>
+                            </div>
+                        </div>                    
                     </block>
                 </xpath>
             </field>


### PR DESCRIPTION
.- Se agregó el campo booleano show_patent_columns_extra en res.company y res.config.settings, que permite a la empresa ocultar columnas opcionales en el reporte.

Tarea (Link):
https://binaural.odoo.com/web\#id\=53528\&cids\=2\&menu_id\=975\&action\=341\&model\=project.task\&view_type\=form

Tarea de proyecto [x]
Ticket de soporte []