### PR TITLE
FIX #8606: l10n_ve_sale

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "18.0.1.1.16",
+    "version": "18.0.1.1.17",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -273,14 +273,16 @@ class SaleOrder(models.Model):
 
     def _get_invoiceable_lines(self, final=False):
         if self._context.get("ignore_limit", False):
-            return super()._get_invoiceable_lines(final)
+            res = super()._get_invoiceable_lines(final)
 
         res = super()._get_invoiceable_lines(final)
         limit = self.company_id.max_product_invoice
+        if len(res) > limit:
+            res = res[:limit]
 
-        if len(res) <= limit:
-            return res
-        return res[:limit]
+        if not any(not line.display_type for line in res):
+            return self.env['sale.order.line']
+        return res
 
     def _create_invoices(self, grouped=False, final=False, date=None):
         """

--- a/l10n_ve_sale/tests/__init__.py
+++ b/l10n_ve_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order

--- a/l10n_ve_sale/tests/test_sale_order.py
+++ b/l10n_ve_sale/tests/test_sale_order.py
@@ -1,0 +1,186 @@
+from odoo import _
+from odoo.tests import Form
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+import logging
+
+_logger = logging.getLogger(__name__)
+
+@tagged('post_install', '-at_install', 'l10n_ve_sale')
+class TestSaleOrderInvoice(TransactionCase):
+    """Tests for generating invoices from sale orders in Venezuelan localization."""
+
+    def setUp(self):
+        super(TestSaleOrderInvoice, self).setUp()
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_vef = self.env.ref("base.VEF")
+        self.company = self.env.ref("base.main_company")
+        self.company.write(
+            {
+                "currency_id": self.currency_vef.id,
+                "currency_foreign_id": self.currency_usd.id,
+            }
+        )
+
+        self.partner = self.env['res.partner'].create({
+            'name': 'Cliente Prueba',
+            'vat': 'J12345678',
+            'prefix_vat': 'J',
+            'country_id': self.env.ref('base.ve').id,
+            'phone': '04141234567',
+            'email': 'cliente@prueba.com',
+            'street': 'Calle Falsa 123',
+        })
+
+        self.tax_group = self.env['account.tax.group'].create({
+            'name': 'IVA',
+            'sequence': 10,
+        })
+
+        # Crear impuesto IVA 16%
+        self.tax_iva16 = self.env['account.tax'].create({
+            'name': 'IVA 16%',
+            'amount': 16,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+            'tax_group_id': self.tax_group.id,
+            'country_id': self.env.ref('base.ve').id,
+        })
+
+        # Crear el producto
+        self.product = self.env['product.product'].create({
+            'name': 'Producto Prueba',
+            'type': 'service',
+            'list_price': 100,
+            'barcode': '123456789',
+            'taxes_id': [(6, 0, [self.tax_iva16.id])],
+        })
+        
+        self.partner_a = self.env['res.partner'].create({
+            'name': 'Test Partner A',
+            'customer_rank': 1,
+        })
+        
+        sequence = self.env['ir.sequence'].create({
+            'name': 'Secuencia Factura',
+            'code': 'account.move',
+            'prefix': 'INV/',
+            'padding': 8,
+            "number_next_actual": 2,
+        })
+        refund_sequence = self.env['ir.sequence'].create({
+            'name': 'nota de credito',
+            'code': '',
+            'prefix': 'NC/',
+            'padding': 8,
+            "number_next_actual": 2,
+        })
+
+        self.journal = self.env['account.journal'].create({
+            'name': 'Diario de Ventas',
+            'code': 'VEN',
+            'type': 'sale',
+            'sequence_id': sequence.id,
+            "refund_sequence_id": refund_sequence.id,
+            'company_id': self.env.company.id,
+        })
+
+    def test_01_generate_invoice_from_sale_order(self):
+        rate = 5.0
+        order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'manually_set_rate': True,
+            'foreign_rate': rate,
+            'foreign_inverse_rate': 1 / rate,
+        })
+
+        order_line_01 = self.env['sale.order.line'].create({
+            'product_id': self.product.id,
+            'product_uom_qty': 2,
+            'price_unit': 100,
+            'tax_id': [(6, 0, [self.tax_iva16.id])],
+            'order_id': order.id,
+            'currency_id': self.currency_vef.id,
+            'foreign_currency_id': self.currency_usd.id,
+            'foreign_rate': rate,
+            'display_type': False,
+            'name': 'Test Product Line',
+        })
+
+        order_line_02 = self.env['sale.order.line'].create({
+            'product_id': False,
+            'product_uom_qty': 0,
+            'price_unit': 0,
+            'tax_id': [(6, 0, [self.tax_iva16.id])],
+            'order_id': order.id,
+            'currency_id': self.currency_vef.id,
+            'foreign_currency_id': self.currency_usd.id,
+            'foreign_rate': 0,
+            'display_type': 'line_section',
+            'name': 'Section Line',
+        })
+
+        order_line_03 = self.env['sale.order.line'].create({
+            'product_id': False,
+            'product_uom_qty': 0,
+            'price_unit': 0,
+            'tax_id': [(6, 0, [self.tax_iva16.id])],
+            'order_id': order.id,
+            'currency_id': self.currency_vef.id,
+            'foreign_currency_id': self.currency_usd.id,
+            'foreign_rate': 0,
+            'display_type': 'line_note',
+            'name': 'Section Line',
+        })
+
+        order.write({
+            'order_line': [order_line_01.id, order_line_02.id, order_line_03.id],
+        })
+        
+        order.action_confirm()
+        order._create_invoices()
+
+    def test_02_error_generate_invoice_from_sale_order(self):
+        rate = 5.0
+        order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'manually_set_rate': True,
+            'foreign_rate': rate,
+            'foreign_inverse_rate': 1 / rate,
+        })
+
+        order_line_02 = self.env['sale.order.line'].create({
+            'product_id': False,
+            'product_uom_qty': 0,
+            'price_unit': 0,
+            'tax_id': [(6, 0, [self.tax_iva16.id])],
+            'order_id': order.id,
+            'currency_id': self.currency_vef.id,
+            'foreign_currency_id': self.currency_usd.id,
+            'foreign_rate': 0,
+            'display_type': 'line_section',
+            'name': 'Section Line',
+        })
+
+        order_line_03 = self.env['sale.order.line'].create({
+            'product_id': False,
+            'product_uom_qty': 0,
+            'price_unit': 0,
+            'tax_id': [(6, 0, [self.tax_iva16.id])],
+            'order_id': order.id,
+            'currency_id': self.currency_vef.id,
+            'foreign_currency_id': self.currency_usd.id,
+            'foreign_rate': 0,
+            'display_type': 'line_note',
+            'name': 'Section Line',
+        })
+
+        order.write({
+            'order_line': [order_line_02.id, order_line_03.id],
+        })
+        
+        with self.assertRaises(UserError) as e:
+            order.action_confirm()
+            order._create_invoices()
+            _logger.info("Error generating invoice: %s", e.exception)

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -403,17 +403,28 @@ class StockPicking(models.Model):
     def _get_invoice_lines_for_invoice(self, from_picking_line=False):
         self.ensure_one()
         invoice_line_list = []
-        for move_id in self.move_ids_without_package:
-            price_unit = move_id.product_id.list_price
+        for order_line in self.sale_id.order_line:
             tax_ids = [(6, 0, [self.company_id.account_sale_tax_id.id])]
-            if move_id.sale_line_id:
+
+            if order_line.display_type:
+                move_id = order_line
+                vals_dict = {
+                    "name": move_id.name,
+                    "product_id": move_id.product_id.id,
+                    "price_unit": False,
+                    "tax_ids": tax_ids,
+                    "quantity": 0,
+                    "from_picking_line": from_picking_line,
+                    "display_type": move_id.display_type,
+                }
+            else:
+                move_id = self.move_ids_without_package.filtered(
+                    lambda m: m.sale_line_id and m.sale_line_id.id == order_line.id
+                )
+                move_id = move_id[0] if move_id else order_line
                 price_unit = move_id.sale_line_id.price_unit
                 tax_ids = [(6, 0, move_id.sale_line_id.tax_id.ids)]
-
-            vals = (
-                0,
-                0,
-                {
+                vals_dict = {
                     "name": move_id.description_picking,
                     "product_id": move_id.product_id.id,
                     "price_unit": price_unit,
@@ -425,8 +436,8 @@ class StockPicking(models.Model):
                     "tax_ids": tax_ids,
                     "quantity": move_id.quantity,
                     "from_picking_line": from_picking_line,
-                },
-            )
+                }
+            vals = (0, 0, vals_dict)
             invoice_line_list.append(vals)
         return invoice_line_list
     
@@ -1166,4 +1177,4 @@ class StockPicking(models.Model):
                 'is_consignment', 'is_dispatch_guide', 'partner_required']):
                 self._assign_partner_from_location()
         return res
-            
+

--- a/l10n_ve_stock_account/tests/__init__.py
+++ b/l10n_ve_stock_account/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_picking

--- a/l10n_ve_stock_account/tests/test_stock_picking.py
+++ b/l10n_ve_stock_account/tests/test_stock_picking.py
@@ -1,0 +1,162 @@
+from odoo import _
+from odoo.tests import Form
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+import logging
+
+_logger = logging.getLogger(__name__)
+
+@tagged('post_install', '-at_install', 'l10n_ve_stock_account')
+class TestStockPickingInvoice(TransactionCase):
+    """Tests for generating invoices from sale orders in Venezuelan localization."""
+
+    def setUp(self):
+        super(TestStockPickingInvoice, self).setUp()
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_vef = self.env.ref("base.VEF")
+        self.company = self.env.ref("base.main_company")
+        self.company.write(
+            {
+                "currency_id": self.currency_vef.id,
+                "currency_foreign_id": self.currency_usd.id,
+            }
+        )
+
+        self.partner = self.env['res.partner'].create({
+            'name': 'Cliente Prueba',
+            'vat': 'J12345678',
+            'prefix_vat': 'J',
+            'country_id': self.env.ref('base.ve').id,
+            'phone': '04141234567',
+            'email': 'cliente@prueba.com',
+            'street': 'Calle Falsa 123',
+        })
+
+        self.tax_group = self.env['account.tax.group'].create({
+            'name': 'IVA',
+            'sequence': 10,
+        })
+
+        # Crear impuesto IVA 16%
+        self.tax_iva16 = self.env['account.tax'].create({
+            'name': 'IVA 16%',
+            'amount': 16,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+            'tax_group_id': self.tax_group.id,
+            'country_id': self.env.ref('base.ve').id,
+        })
+
+        # Crear el producto
+        self.product = self.env['product.product'].create({
+            'name': 'Producto Prueba',
+            'type': 'product',
+            'list_price': 100,
+            'barcode': '123456789',
+            'taxes_id': [(6, 0, [self.tax_iva16.id])],
+            'detailed_type': 'product',
+        })
+        
+        self.partner_a = self.env['res.partner'].create({
+            'name': 'Test Partner A',
+            'customer_rank': 1,
+        })
+        
+        sequence = self.env['ir.sequence'].create({
+            'name': 'Secuencia Factura',
+            'code': 'account.move',
+            'prefix': 'INV/',
+            'padding': 8,
+            "number_next_actual": 2,
+        })
+        refund_sequence = self.env['ir.sequence'].create({
+            'name': 'nota de credito',
+            'code': '',
+            'prefix': 'NC/',
+            'padding': 8,
+            "number_next_actual": 2,
+        })
+
+        self.journal = self.env['account.journal'].create({
+            'name': 'Diario de Ventas',
+            'code': 'VEN',
+            'type': 'sale',
+            'sequence_id': sequence.id,
+            "refund_sequence_id": refund_sequence.id,
+            'company_id': self.env.company.id,
+            'is_contingency': False,
+            })
+        self.company.write(
+            {
+                "customer_journal_id": self.journal.id,
+            }
+        )
+
+    def create_sale_order(self):
+        rate = 5.0
+        order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'manually_set_rate': True,
+            'foreign_rate': rate,
+            'foreign_inverse_rate': 1 / rate,
+            'document': 'dispatch_guide',
+        })
+
+        order_line_01 = self.env['sale.order.line'].create({
+            'product_id': self.product.id,
+            'product_uom_qty': 2,
+            'price_unit': 100,
+            'tax_id': [(6, 0, [self.tax_iva16.id])],
+            'order_id': order.id,
+            'currency_id': self.currency_vef.id,
+            'foreign_currency_id': self.currency_usd.id,
+            'foreign_rate': rate,
+            'display_type': False,
+            'name': 'Test Product Line',
+        })
+
+        order_line_02 = self.env['sale.order.line'].create({
+            'product_id': False,
+            'product_uom_qty': 0,
+            'price_unit': 0,
+            'tax_id': [(6, 0, [self.tax_iva16.id])],
+            'order_id': order.id,
+            'currency_id': self.currency_vef.id,
+            'foreign_currency_id': self.currency_usd.id,
+            'foreign_rate': 0,
+            'display_type': 'line_section',
+            'name': 'Section Line',
+        })
+
+        order_line_03 = self.env['sale.order.line'].create({
+            'product_id': False,
+            'product_uom_qty': 0,
+            'price_unit': 0,
+            'tax_id': [(6, 0, [self.tax_iva16.id])],
+            'order_id': order.id,
+            'currency_id': self.currency_vef.id,
+            'foreign_currency_id': self.currency_usd.id,
+            'foreign_rate': 0,
+            'display_type': 'line_note',
+            'name': 'Section Line',
+        })
+
+        order.write({
+            'order_line': [order_line_01.id, order_line_02.id, order_line_03.id],
+        })
+        return order
+
+    def test_01_generate_invoice_from_dispatch_guide(self):
+        order = self.create_sale_order()
+        order.action_confirm()
+        dispatch_guide = order.picking_ids
+
+        for move in dispatch_guide.move_ids_without_package:
+            move.quantity = move.product_uom_qty
+
+        dispatch_guide.button_validate()
+        
+        invoice = dispatch_guide.create_invoice()
+        _logger.info(f"Dispatch guide invoice created: {invoice.invoice_line_ids}")
+        _logger.info("Dispatch guide invoice created successfully.")


### PR DESCRIPTION
Problema: Al generar una factura desde una orden de venta y que en sus lineas contengan una seccion o una nota salta un error

Solución: Para evitar el error y el ciclo que ocacionaba la funcion "_get_invoiceable_lines" al solo quedar lineas de notas o secciones se agrego un condicional: si el conjunto de líneas facturables contiene solo secciones y notas, el método devolverá vacío y evitarás el ciclo infinito.

Tarea (Link): https://binaural.odoo.com/web?db=binaural-dev-binaural-release-10413381&token=4P6sT2NxLGgos2OwxwuG&debug=1#id=8606&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]