### PR TITLE
FEAT #8659: l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.13",
+    "version": "17.0.0.0.14",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/tests/__init__.py
+++ b/l10n_ve_accountant/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_form_account_move

--- a/l10n_ve_accountant/tests/test_form_account_move.py
+++ b/l10n_ve_accountant/tests/test_form_account_move.py
@@ -1,0 +1,54 @@
+from odoo.tests import TransactionCase, tagged, Form
+from odoo import fields
+import logging
+_logger = logging.getLogger(__name__)
+
+
+@tagged('post_install', '-at_install', 'l10n_ve_accountant')
+class TestFormAccountMove(TransactionCase):
+    def setUp(self):
+        partner_model = self.env['res.partner']
+        self.invoice_model = self.env['account.move']
+
+        self.partner_a = self.env['res.partner'].create({
+            'name': 'Test Partner A',
+            'customer_rank': 1,
+        })
+        
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_vef = self.env.ref("base.VEF")
+        self.company = self.env.ref("base.main_company")
+        self.company.write(
+            {
+                "currency_id": self.currency_usd.id,
+                "currency_foreign_id": self.currency_vef.id,
+            }
+        )
+        self.invoice_model.create({
+            'move_type': 'in_invoice',
+            'foreign_rate': 1.23,
+            'partner_id': self.partner_a.id
+        })
+        self.date = fields.Date.today()
+
+    def test_foreign_rate_editable_only_on_in_invoice(self):
+        self.assertTrue(self.company.currency_foreign_id, 'Foreign currency should be set for the company.')
+        invoice_form = self.env['account.move'].with_context(default_move_type='in_invoice').new()
+        invoice_form.company_id = self.company.id
+        invoice_form.currency_id = self.currency_usd
+        invoice_form.foreign_currency_id = self.currency_vef
+        invoice_form.partner_id = self.partner_a
+        invoice_form.invoice_date = self.date
+        invoice_form.foreign_rate = 1.23
+
+        self.assertEqual(invoice_form.foreign_rate, 1.23, 'Foreign rate should be set to 1.23 for in_invoice move type.')
+    
+    def test_foreign_rate_editable_only_on_in_invoice_case_customer(self):
+        self.assertTrue(self.company.currency_foreign_id, 'Foreign currency should be set for the company.')
+        invoice_form = self.env['account.move'].with_context(default_move_type='out_invoice').new()
+        invoice_form.company_id = self.company.id
+        invoice_form.currency_id = self.currency_usd
+        invoice_form.foreign_currency_id = self.currency_vef
+        invoice_form.partner_id = self.partner_a
+        invoice_form.invoice_date = self.date
+        self.assertNotEqual(invoice_form.foreign_rate, 1.23, 'Foreign rate should be set to 1.23 for in_invoice move type.')

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -42,7 +42,7 @@
                         <t groups="base.group_no_one">
                             <field name="foreign_inverse_rate" invisible="1" />
                         </t>
-                        <field name="foreign_rate" readonly="1" />
+                        <field name="foreign_rate" readonly="move_type not in ['in_invoice']" />
                     </group>
                     <group colspan="4">
                         <group class="oe_subtotal_footer oe_right"


### PR DESCRIPTION
Problema:
-Se necesita editar la tasa de cambio cuando la factura es de proveedor.

Solución:
-Se agrega readonly si la factura no es move_type in_invoice -Se agregan las pruebas unitarias.
-Se agregan las pruebas unitarias.
Tarea (Link):
https://binaural.odoo.com/web#id=8659&cids=2&menu_id=293&action=389&model=helpdesk.ticket&view_type=form Tarea de proyecto []
Ticket de soporte [x]