### PR TITLE
FEAT #8647:

### DIFF
--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -727,8 +727,9 @@ class StockPicking(models.Model):
     @api.depends("picking_type_id", "partner_id", "sale_id")
     def _compute_location_id(self):
         for picking in self:
+            location_dest_id = None
+            location_id = None
             picking = picking.with_company(picking.company_id)
-
             if not (picking.picking_type_id and picking.state in ["draft", "confirmed"]):
                 continue
 
@@ -759,10 +760,10 @@ class StockPicking(models.Model):
             if not picking.location_dest_id:
                 if picking.picking_type_id.default_location_dest_id:
                     location_dest_id = picking.picking_type_id.default_location_dest_id.id
+                else:
                     location_dest_id, _supplierloc = self.env[
                         "stock.warehouse"
                     ]._get_partner_locations()
-
                 picking.location_id = location_id
                 picking.location_dest_id = location_dest_id
 


### PR DESCRIPTION
l10nve_stock_account

Problema:
-Al realizar una orden de entrega, muestra un error por location_dest_id undefined.

Solución:
-Se declaran location_dest_id, location_id como None. -En la condición, si el picking no tiene location_dest_id, se agrega un else que se había eliminado anteriormente.

Tarea (Link):
https://binaural.odoo.com/web#id=8647&cids=2&menu_id=293&action=389&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]