### PR TITLE
17.0 fix ti 8665 error on invoice when theres not rate in the invoice date

### DIFF
--- a/l10n_ve_rate/__manifest__.py
+++ b/l10n_ve_rate/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.0.0.2",
+    "version": "17.0.0.0.3",
     # any module necessary for this one to work correctly
     "depends": ["base", "l10n_ve_base"],
     "data": [

--- a/l10n_ve_rate/models/res_currency_rate.py
+++ b/l10n_ve_rate/models/res_currency_rate.py
@@ -42,12 +42,16 @@ class ResCurrencyRate(models.Model):
                 ("currency_id", "=", foreign_currency_id),
                 ("company_id", "=", self.env.company.id),
                 ("name", "<=", rate_date),
-            ]
+            ], order='name desc', limit=1
         )
         if not rates:
+            rates = self.env['res.currency.rate'].search([
+                ("currency_id", "=", foreign_currency_id),
+                ("company_id", "=", self.env.company.id),
+            ], order='name asc', limit=1)
+        if not rates:
             return {}
-
-        rate = rates.filtered(lambda r: r.name == rate_date) or rates[0]
+        rate = rates[0]
         base_usd_id = self.env["ir.model.data"]._xmlid_to_res_id(
             "base.USD", raise_if_not_found=False
         )

--- a/l10n_ve_rate/tests/__init__.py
+++ b/l10n_ve_rate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_rate

--- a/l10n_ve_rate/tests/test_rate.py
+++ b/l10n_ve_rate/tests/test_rate.py
@@ -1,0 +1,70 @@
+from odoo.tests import TransactionCase, tagged
+from odoo import fields
+import logging
+_logger = logging.getLogger(__name__)
+@tagged('post_install', '-at_install', 'l10n_ve_rate')
+class TestResCurrencyRate(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_vef = self.env.ref("base.VEF")
+        self.company = self.env.ref("base.main_company")
+        self.company.write(
+            {
+                "currency_id": self.currency_vef.id,
+                "currency_foreign_id": self.currency_usd.id, 
+            }
+        )
+
+        self.env['res.currency.rate'].create({
+            'name': fields.Date.from_string('2025-07-28'),
+            'currency_id': self.currency_usd.id,
+            'inverse_company_rate': 120.439,
+            'company_id': self.company.id,
+        })
+
+        self.env['res.currency.rate'].create({
+            'name': fields.Date.from_string('2025-07-21'),
+            'currency_id': self.currency_usd.id,
+            'inverse_company_rate': 119.439,
+            'company_id': self.company.id,
+        })
+        self.env['res.currency.rate'].create({
+            'name': fields.Date.from_string('2025-07-18'),
+            'currency_id': self.currency_usd.id,
+            'inverse_company_rate': 118.439,
+            'company_id': self.company.id,
+        })
+
+    def test_date_up_to_last_rate(self):
+        """
+        Test that the method returns the last rate before or on the given date.
+        """
+        rate = self.env['res.currency.rate'].compute_rate(
+            foreign_currency_id= self.currency_usd.id,
+            rate_date=fields.Date.from_string('2025-07-29')
+        )
+        
+        self.assertEqual(rate['foreign_rate'], 120.439, 'Rate should be 120.439 for 2025-07-29')
+
+    def test_date_before_to_first_rate(self):
+        """
+        Test that the method returns the first rate that is after the given date if theres not rate in that date or before.
+        """
+        rate = self.env['res.currency.rate'].compute_rate(
+            foreign_currency_id= self.currency_usd.id,
+            rate_date=fields.Date.from_string('2025-07-17')
+        )
+        self.assertEqual(rate['foreign_rate'], 118.439, 'Rate should be 118.439 for 2025-07-17')
+
+
+    def test_date_equal_to_a_rate_date(self):
+        """
+        Test that the method returns the rate that is in the given date.
+        """
+        rate = self.env['res.currency.rate'].compute_rate(
+            foreign_currency_id= self.currency_usd.id,
+            rate_date=fields.Date.from_string('2025-07-21')
+        )
+        self.assertEqual(rate['foreign_rate'], 119.439, 'Rate should be 119.439 for 2025-07-21')
+        


### PR DESCRIPTION
FEAT #8665: l10n_ve_rate
Problema:
-Al setear en una factura una fecha en la cuál debajo o en esa no hay una tasa de cambio, regresa error de campo foreing_rate en cero.
Solución:

-En la función compute_rate de res.currency.rate, en el search de búsqueda de en esa fecha o debajo, se agrega que ordene por nombre en desc, y que se limite a 1. En caso de que la anterior condición no regrese nada, se agrega una búsqueda por nombre en orden asc y se limita a 1 para conseguir la más cercana a esa fecha.
-Se cambia rate a que apunte a la primera posición de la lista.

Tarea (Link):
https://binaural.odoo.com/web#id=8665&cids=2&menu_id=293&action=389&model=helpdesk.ticket&view_type=form
Tarea de proyecto []
Ticket de soporte [x]
