### PR TITLE
FIX #8699: l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.1.3",
+    "version": "17.0.0.1.4",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/data/dispatch_guide_paperformat.xml
+++ b/l10n_ve_stock_account/data/dispatch_guide_paperformat.xml
@@ -10,8 +10,8 @@
             <field name="margin_left">7</field>
             <field name="margin_right">7</field>
             <field name="header_line" eval="False" />
-            <field name="header_spacing">110</field>
-            <field name="dpi">90</field>
+            <field name="header_spacing">120</field>
+            <field name="dpi">100</field>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
Problema: El header de las guias de despacho al tener mucho contenido como en la direccion de entrega o en la direccion fiscal se esta sobreponiendo en el body

Solución: Se modifico el paperformat para reducir el tamaño de las letras y el espacio del header

Tarea (Link): https://binaural.odoo.com/web?db=binaural-dev-binaural-release-10413381&token=4P6sT2NxLGgos2OwxwuG#id=8699&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]