### PR TITLE
FIX #8736: l10n_ve_stock

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "17.0.0.0.4",
+    "version": "17.0.0.0.5",
     "depends": [
         "stock",
         "l10n_ve_tax",

--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "17.0.0.0.5",
+    "version": "17.0.0.0.6",
     "depends": [
         "stock",
         "l10n_ve_tax",

--- a/l10n_ve_stock/i18n/es_VE.po
+++ b/l10n_ve_stock/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250311\n"
+"Project-Id-Version: Odoo Server 17.0+e-20250728\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-21 22:53+0000\n"
-"PO-Revision-Date: 2025-05-21 22:53+0000\n"
+"POT-Creation-Date: 2025-08-12 15:10+0000\n"
+"PO-Revision-Date: 2025-08-12 15:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -22,7 +22,6 @@ msgstr "'Etiqueta de Cajas- %s' % (object.name)"
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/product_product.py:0
 #: code:addons/l10n_ve_stock/models/product_product.py:0
 #, python-format
 msgid "- Barcode \"%s\" already assigned to product(s): %s"
@@ -46,7 +45,6 @@ msgstr ""
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/product_product.py:0
 #: code:addons/l10n_ve_stock/models/product_product.py:0
 #, python-format
 msgid "A packaging already uses the barcode"
@@ -126,17 +124,12 @@ msgid "Artículo"
 msgstr ""
 
 #. module: l10n_ve_stock
-#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__partner_id
-msgid "Assigned Customer"
-msgstr "Cliente"
-#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_attachment_count
 msgid "Attachment Count"
 msgstr "Nº de archivos adjuntos"
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/product_product.py:0
 #: code:addons/l10n_ve_stock/models/product_product.py:0
 #, python-format
 msgid ""
@@ -522,6 +515,11 @@ msgid "Packs Count"
 msgstr "Cantidad de Packs"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__partner_id
+msgid "Partner"
+msgstr "Cliente"
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_product_product__physical_location_id
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_product_template__physical_location_id
 msgid "Physical Location"
@@ -569,7 +567,6 @@ msgstr "Precio sin impuestos"
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/product_template.py:0
 #: code:addons/l10n_ve_stock/models/product_template.py:0
 #, python-format
 msgid "Price cannot be negative."
@@ -628,6 +625,11 @@ msgstr ""
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.report_inventory_valuation_template
 msgid "Rango:"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__rating_ids
+msgid "Ratings"
 msgstr ""
 
 #. module: l10n_ve_stock
@@ -696,11 +698,6 @@ msgid "Stock Move"
 msgstr "Movimiento de stock"
 
 #. module: l10n_ve_stock
-#: model:ir.model.fields,field_description:l10n_ve_stock.field_res_config_settings__limit_product_qty_out
-msgid "Stock Picking"
-msgstr "Guía de despacho"
-
-#. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_quantity_history
 msgid "Stock Quantity History"
 msgstr "Historial de cantidad de existencias "
@@ -718,31 +715,13 @@ msgstr "La Disponibilidad del Producto para la Venta."
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/product_template.py:0
-#: code:addons/l10n_ve_stock/models/product_template.py:0
-#, python-format
-msgid "The name contains a character that is not allowed for registration."
-msgstr ""
-"El nombre contiene al menos un carácter que no está permitido para el "
-"registro"
-
-#. module: l10n_ve_stock
-#. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_location.py:0
 #: code:addons/l10n_ve_stock/models/stock_location.py:0
 #, python-format
 msgid "The priority must be greater than 0."
 msgstr "La prioridad debe ser mayor que 0."
 
 #. module: l10n_ve_stock
-#: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__partner_id
-msgid "This location is assigned to a specific customer for consignation."
-msgstr ""
-"Esta ubicación está asignada a un cliente específico para consignación."
-
-#. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/product_template.py:0
 #: code:addons/l10n_ve_stock/models/product_template.py:0
 #, python-format
 msgid "This product must have only one tax."
@@ -816,6 +795,16 @@ msgid "VALOR DEL INVENTARIO A PARTIR DE UNA FECHA"
 msgstr ""
 
 #. module: l10n_ve_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.view_picking_form
+msgid "Validate"
+msgstr "Validar"
+
+#. module: l10n_ve_stock
+#: model:ir.model,name:l10n_ve_stock.model_stock_warehouse
+msgid "Warehouse"
+msgstr "Almacén"
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_quantity_history__warehouse_search_id
 msgid "Warehouse Search"
 msgstr "Buscar en Almacen"
@@ -833,15 +822,12 @@ msgstr "Historial de comunicación de la web"
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/product_product.py:0
-#: code:addons/l10n_ve_stock/models/product_product.py:0
 #, python-format
 msgid "You can't create products"
 msgstr "No puedes crear productos"
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #, python-format
@@ -851,7 +837,6 @@ msgstr "No puedes agregar productos a transferencias de tipo envío"
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #, python-format
 msgid "You cannot make transfers larger than the demand"
 msgstr "No puedes hacer transferencias mayores que la demanda"
@@ -859,14 +844,12 @@ msgstr "No puedes hacer transferencias mayores que la demanda"
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #, python-format
 msgid "You cannot make transfers larger than the reserved quantity"
 msgstr "No puedes hacer transferencias mayores que la cantidad reservada"
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #, python-format
 msgid "You do not have permission to make shipment-type transfers"
@@ -879,7 +862,6 @@ msgstr "plantilla de producto de cantidad de corrección"
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
 #, python-format
 msgid "does not have results from other pickings"

--- a/l10n_ve_stock/views/stock_picking_views.xml
+++ b/l10n_ve_stock/views/stock_picking_views.xml
@@ -45,24 +45,24 @@
             </xpath>
 
             <xpath expr="//form/header/button[@name='do_print_picking']" position="before">
-                <field name="purchase_id" invisible="1"/>
+                <field name="picking_type_code" invisible="1"/>
                 <button name="button_validate" type="object"
                         string="Validate"
                         class="oe_highlight"
                         groups="!l10n_ve_stock.group_hide_validate_inventory_transfers_button"
-                        invisible="state in ('draft', 'confirmed', 'done', 'cancel') or not purchase_id"
+                        invisible="state in ('confirmed', 'done', 'cancel') or picking_type_code != 'incoming'"
                         data-hotkey="v"/>
             </xpath>
 
             <xpath expr="//button[@name='button_validate'][2]" position="attributes">
                 <attribute name="groups">!l10n_ve_stock.group_hide_validate_inventory_transfers_button</attribute>
-                <attribute name="invisible">state in ('waiting', 'assigned', 'done', 'cancel') or purchase_id</attribute>
+                <attribute name="invisible">state in ('waiting', 'assigned', 'done', 'cancel') or picking_type_code == 'incoming'</attribute>
                 <attribute name='confirm'>Upon confirmation, the system will generate the number of sequences of shipping guides.</attribute>
             </xpath>
 
             <xpath expr="//button[@name='button_validate'][1]" position="attributes">
                 <attribute name="groups">!l10n_ve_stock.group_hide_validate_inventory_transfers_button</attribute>
-                <attribute name="invisible">state in ('draft', 'confirmed', 'done', 'cancel') or purchase_id</attribute>
+                <attribute name="invisible">state in ('draft', 'confirmed', 'done', 'cancel') or picking_type_code == 'incoming'</attribute>
                 <attribute name='confirm'>Upon confirmation, the system will generate the number of sequences of shipping guides.</attribute>
             </xpath>
 

--- a/l10n_ve_stock/views/stock_picking_views.xml
+++ b/l10n_ve_stock/views/stock_picking_views.xml
@@ -44,13 +44,25 @@
                 <attribute name="groups">!l10n_ve_stock.group_hide_print_button_for_inventory_transfers</attribute>
             </xpath>
 
+            <xpath expr="//form/header/button[@name='do_print_picking']" position="before">
+                <field name="purchase_id" invisible="1"/>
+                <button name="button_validate" type="object"
+                        string="Validate"
+                        class="oe_highlight"
+                        groups="!l10n_ve_stock.group_hide_validate_inventory_transfers_button"
+                        invisible="state in ('draft', 'confirmed', 'done', 'cancel') or not purchase_id"
+                        data-hotkey="v"/>
+            </xpath>
+
             <xpath expr="//button[@name='button_validate'][2]" position="attributes">
                 <attribute name="groups">!l10n_ve_stock.group_hide_validate_inventory_transfers_button</attribute>
+                <attribute name="invisible">state in ('waiting', 'assigned', 'done', 'cancel') or purchase_id</attribute>
                 <attribute name='confirm'>Upon confirmation, the system will generate the number of sequences of shipping guides.</attribute>
             </xpath>
 
             <xpath expr="//button[@name='button_validate'][1]" position="attributes">
                 <attribute name="groups">!l10n_ve_stock.group_hide_validate_inventory_transfers_button</attribute>
+                <attribute name="invisible">state in ('draft', 'confirmed', 'done', 'cancel') or purchase_id</attribute>
                 <attribute name='confirm'>Upon confirmation, the system will generate the number of sequences of shipping guides.</attribute>
             </xpath>
 

--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.1.4",
+    "version": "17.0.0.1.5",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -793,7 +793,7 @@ class StockPicking(models.Model):
             record.show_create_vendor_credit = False
             record.show_create_invoice_internal = False
 
-            if is_invoice_empty and is_done and is_to_invoice and not record.purchase_id:
+            if is_invoice_empty and is_done and is_to_invoice and record.picking_type_code != "incoming":
                 if record.operation_code == "incoming":
                     record.show_create_bill = not record.is_return
                     record.show_create_vendor_credit = record.is_return
@@ -835,7 +835,7 @@ class StockPicking(models.Model):
         for picking in self:
             picking.has_document = bool(picking.sale_id.document)
 
-    @api.depends("is_dispatch_guide", "state", "document", "sale_id", "write_uid", "purchase_id")
+    @api.depends("is_dispatch_guide", "state", "document", "sale_id", "write_uid", "picking_type_code")
     def _compute_dispatch_guide_controls(self):
         for picking in self:
             picking.dispatch_guide_controls = False
@@ -843,7 +843,7 @@ class StockPicking(models.Model):
             if picking.state != "done":
                 continue
 
-            if picking.purchase_id:
+            if picking.picking_type_code == "incoming":
                 continue
 
             # if not picking.sale_id and not picking.operation_code == "internal":


### PR DESCRIPTION
Problema: El mensaje de secuencia de guia de despacho se muestra aunque la guia sea de una orden de compra (No deberia)

Solución: Se modifica el invisible de los 2 botones de validacion que existian antes y se agrego un nuevo boton el cual no posee confirm y solo sera visible si la guia posee una orden de com>

Tarea (Link): https://binaural.odoo.com/web?db=binaural-dev-binaural-release-10413381&token=4P6sT2NxLGgos2OwxwuG#id=8736&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]