### PR TITLE
FEAT #8701: l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/report/report_invoice_free_form.xml
+++ b/l10n_ve_stock_account/report/report_invoice_free_form.xml
@@ -2,7 +2,7 @@
     <template id="template_free_form_l10_ve_stock_account" name="free_form_l10_ve_stock_account" inherit_id="l10n_ve_invoice.report_freeform_document">
         <xpath expr="//div[@name='header_right']" position="inside">
             <br/>
-            <t t-if="o.picking_id">
+            <t t-if="o.picking_ids">
                 <strong>Número de Guía: </strong>
                 <t t-out="o.guide_number or 'N/A'"/>
             </t>


### PR DESCRIPTION
Problema:
-Al intentar imprimir el forma libre de factura de cliente, lanza error al no encontrar el campo picking_id.

Solución:
-Se reempleza picking_id por picking_ids.

Tarea (Link):
https://binaural.odoo.com/web#id=8701&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]