### PR TITLE
FIX #8838: l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.1.5",
+    "version": "17.0.0.1.6",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_location.py
+++ b/l10n_ve_stock_account/models/stock_location.py
@@ -23,13 +23,12 @@ class StockLocation(models.Model):
     @api.constrains("usage", "location_id", "partner_id")
     def _check_internal_location_only(self):
         for record in self:
-            warehouse = record.get_warehouse()
-            if warehouse and warehouse.is_consignation_warehouse:
+            if record.warehouse_id and record.warehouse_id.is_consignation_warehouse:
                 if record.usage != "internal":
                     raise ValidationError(
                         _("Only 'Internal' locations can be created inside a consignation warehouse.")
                     )
-                if not record.partner_id:
+                if not record.warehouse_id.partner_id:
                     raise ValidationError(
                         _("A consignation warehouse must have an assigned customer.")
                     )


### PR DESCRIPTION
Problema: Al intentar instalar el modulo de "Binaural - Libro de inventario" salta una validacion de almacen de consignacion

Solución: Se modifico el constrains en donde salia el error (stock_location), ahora valida con su propio almacen en vez de obtenerlo por la funcion

Ticket (Link): https://binaural.odoo.com/web?db=binaural-dev-binaural-release-10413381&token=4P6sT2NxLGgos2OwxwuG#id=8838&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]