### PR TITLE
FIX_l10n_ve_stock#55243

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "18.0.0.0.4",
+    "version": "18.0.0.0.5",
     "depends": [
         "stock",
         "product",

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -2,7 +2,6 @@ import logging
 import re
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-import traceback
 from collections import defaultdict
 
 _logger = logging.getLogger(__name__)

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -2,6 +2,8 @@ import logging
 import re
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+import traceback
+from collections import defaultdict
 
 _logger = logging.getLogger(__name__)
 
@@ -59,8 +61,11 @@ class ProductTemplate(models.Model):
     @api.constrains("taxes_id")
     def _check_taxes_id(self):
         for product in self:
-            if len(product.taxes_id) != 1 and self.env.company.unique_tax:
-                raise ValidationError(_("This product must have only one tax."))
+            taxes_by_company = defaultdict(int)
+            for tax in product.taxes_id.sudo():
+                taxes_by_company[tax.company_id] += 1
+                if taxes_by_company[tax.company_id] > 1:
+                    raise ValidationError(_("This product must have only one tax."))                
 
     @api.depends("list_price")
     def _compute_prices_with_tax(self):

--- a/l10n_ve_stock/tests/test_stock.py
+++ b/l10n_ve_stock/tests/test_stock.py
@@ -48,3 +48,25 @@ class TestStockQuant(TransactionCase):
             {"product_id": product.id, "location_id": loc2.id, "quantity": 1}
         )
         self.assertFalse(quant2.is_physical_location)
+
+@tagged("post_install", "-at_install", "l10n_ve_stock_product")
+class TestProductTemplate(TransactionCase):
+    def test_check_taxes_id_multiple_taxes_same_company(self):
+        tax1 = self.env["account.tax"].create({
+            "name": "Tax 1",
+            "amount_type": "percent",
+            "amount": 10,
+            "company_id": self.env.company.id,
+        })
+        tax2 = self.env["account.tax"].create({
+            "name": "Tax 2",
+            "amount_type": "percent",
+            "amount": 20,
+            "company_id": self.env.company.id,
+        })
+        with self.assertRaises(ValidationError):
+            self.env["product.product"].create({
+                "name": "Product 1",
+                "barcode": "123456",
+                "taxes_id": [(6, 0, [tax1.id, tax2.id])],
+            })


### PR DESCRIPTION
Problema:
-Al intentar guardar un producto, si hay dos empresas en el entorno, el producto al no tener una compañía seleccionada, se guarda en ambas, al guardarse en otras compañías, odoo nativamente suma el tax de estas en en el taxes_id del producto.

Solución:

-Se crea una variable defaultdict para almacenar las ids. -Se recorren las ids del producto según la compañía para evaluar si existe más de un ID agregado en el mismo.

tarea[x]

enlace:
https://binaural.odoo.com/web#id=55243&cids=2&menu_id=975&action=341&model=project.task&view_type=form