### PR TITLE
FIX #55248: l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "18.0.0.0.1",
+    "version": "18.0.0.0.2",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -6,6 +6,7 @@ from ..utils.utils_retention import load_retention_lines, search_invoices_with_t
 from collections import defaultdict
 import json
 from odoo.tools.float_utils import float_round
+from decimal import Decimal, ROUND_HALF_UP
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -163,6 +164,22 @@ class AccountRetention(models.Model):
             " that the one that just has been deleted."
         )
     )
+
+    def round_2_decimals(self,value):
+        """
+        Rounds a numeric value to two decimal places using half-up rounding.
+
+        Args:
+            value (float or str or Decimal): The value to be rounded.
+
+        Returns:
+            float: The value rounded to two decimal places.
+
+        Example:
+            >>> round_2_decimals(2.345)
+            2.35
+        """
+        return float(Decimal(str(value)).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP))
 
     @api.depends("type", "partner_id")
     def _compute_allowed_lines_move_ids(self):
@@ -924,9 +941,7 @@ class AccountRetention(models.Model):
                 line_data["foreign_retention_amount"] = 0.0
             else:
                 line_data["retention_amount"] = retention_amount
-                line_data["foreign_retention_amount"] = line_data["foreign_iva_amount"] * (
-                    withholding_amount / 100
-                )
+                line_data["foreign_retention_amount"] = self.round_2_decimals(line_data["foreign_iva_amount"] * (withholding_amount / 100)) #Acá siempre que la tercera posición decimal sea 5 o mayor se redondea hacia arriba.
             lines_data.append(line_data)
         return lines_data
 


### PR DESCRIPTION
Problema:
-Se muestra cálculo erróneo en las líneas de retenciones. Al visualizar el foreign_retention_amount se logra percatar que al tener 3 decimales, no hace el redondeo respectivo, si es mayor de 5, debería redondear el segundo decimal.

Solución:
-Se crea el método round_2_decimals, el cual recibe un valor, dentro de se recibe el valor a redondear, se convierte en string para tener mayor presición a la hora de convertirlo a Decimal, se llama a quantize en el objeto decimal('0.01'), para redondear el objeto a 2 decimales, se usa rouding=ROUND_HALF_UP para indicarle que se redondee hacia arriba, y finalmente se convierte el objeto Decimal a Float para ser retornado.

Tarea (Link):
https://binaural.odoo.com/web#id=55248&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []