### PR TITLE
18.0_fix_ti_9061-foreign_igtf_tax_total

### DIFF
--- a/l10n_ve_igtf/models/account_tax.py
+++ b/l10n_ve_igtf/models/account_tax.py
@@ -115,7 +115,7 @@ class AccountTax(models.Model):
             igtf_base_amount * igtf_percentage, precision_rounding=currency.rounding
         )
         foreign_igtf_amount = float_round(
-            foreign_igtf_base_amount * igtf_percentage,
+            igtf_amount * rate,
             precision_rounding=foreign_currency.rounding,
         )
 


### PR DESCRIPTION
problema: Cuando el pago en divisas es mayor a la factura , el asiento del pago se edita para agregar la cuenta contable de IGTF. Los valores en la factura esta correctos en Bs pero cuando se observa el asiento contable la Cuenta de IGTF tiene el monto incorrecto en los campos alternos.

solucion:
se nota que el problema en verdad era el calculo de los foraneos del tax totals, se corrige calculo para mantener veracidad con los apuntes contables

link ticket: https://binaural.odoo.com/web#cids=2&menu_id=293&action=393&active_id=58&model=helpdesk.ticket&view_type=form&id=9061