### PR TITLE
FEAT #8981: l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.15",
+    "version": "17.0.0.0.16",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_journal.py
+++ b/l10n_ve_payment_extension/models/account_journal.py
@@ -5,9 +5,5 @@ class AccountJournal(models.Model):
     _inherit = "account.journal"
 
     default_account_id = fields.Many2one(
-        domain=(
-            "[('deprecated', '=', False), ('company_id', '=', company_id),"
-            "'|',('account_type', '=', default_account_type),"
-            "('account_type', 'in', ('income', 'income_other') if type == 'sale' else ('expense', 'expense_depreciation', 'expense_direct_cost') if type == 'purchase' else ('asset_current', 'liability_current'))]"
-        )
+          domain="[('deprecated', '=', False), ('company_id', '=', company_id)]"
     )


### PR DESCRIPTION
Problema: No se visualizan por completo los tipos de cuentas al momento de crear un diario de tipo "Varios"

Solución: Se simplifica el filtro en el modulo payment_extension, modelo account_journal, el campo encargado de traer esas cuentas, su atributo domain se simplifica para traerlas todas

Tarea (Link):https://binaural.odoo.com/web#id=8981&cids=2&menu_id=303&action=387&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]