### PR TITLE
17.0_fix#9148_l10nve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/views/account_retention_islr.xml
+++ b/l10n_ve_payment_extension/views/account_retention_islr.xml
@@ -8,7 +8,7 @@
             <field name="model">account.retention</field>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                <form string="Retention">
+                <form string="Retention" duplicate="false">
                     <header>
                         <button name="action_draft" type="object"
                             string="Convert to draft"

--- a/l10n_ve_payment_extension/views/account_retention_iva.xml
+++ b/l10n_ve_payment_extension/views/account_retention_iva.xml
@@ -5,7 +5,7 @@
             <field name="model">account.retention</field>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                <form string="Retention">
+                <form string="Retention" duplicate="false">
                     <header>
                         <field name="state" invisible="1" />
                         <button name="action_draft" type="object"

--- a/l10n_ve_payment_extension/views/account_retention_municipal.xml
+++ b/l10n_ve_payment_extension/views/account_retention_municipal.xml
@@ -5,7 +5,7 @@
             <field name="model">account.retention</field>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                <form string="Retention">
+                <form string="Retention" duplicate="false">
                     <header>
                         <button name="action_print_municipal_retention_xlsx" type="object"
                             string="Print municipal retention XLSX" />


### PR DESCRIPTION
Problema: Se requier eliminar la opción de duplicar desde el módelo de retenciones (IVA-ISLR-MUNICIPAL) para cliente/proveedores

Solución: Se agrega el atribute "duplicate='false'" en los forms de retenciones correspondientes.

Tarea (Link): https://binaural.odoo.com/web#id=9148&cids=2&menu_id=293&action=389&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]