### PR TITLE
FIX-#9366-sales-purchase-book

### DIFF
--- a/l10n_ve_iot_mf/__manifest__.py
+++ b/l10n_ve_iot_mf/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "license": "LGPL-3",
     "category": "Accounting",
-    "version": "17.0.0.0.8",
+    "version": "17.0.0.0.9",
     "author": "binaural-dev",
     "website": "https://binauraldev.com",
     "depends": [

--- a/l10n_ve_iot_mf/wizards/accounting_reports.py
+++ b/l10n_ve_iot_mf/wizards/accounting_reports.py
@@ -10,15 +10,39 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
 
     with_fiscal_machine = fields.Boolean(default=False)
 
+    #override
     def _get_domain(self):
-        res = super()._get_domain()
+        search_domain = []
+        is_purchase = self.report == "purchase"
+
+        search_domain += [("company_id", "=", self.company_id.id)]
+
+        move_type = (
+            ["out_invoice", "out_refund"]
+            if not is_purchase
+            else ["in_invoice", "in_refund", "in_debit"]
+        )
+
+        search_domain += [("date", ">=", self.date_from)]
+        search_domain += [("date", "<=", self.date_to)]
+        
         if not self.with_fiscal_machine:
-            return res
-        res = [d for d in res if d != ('correlative', 'not in', ['/', False])]
-        res.append(("mf_invoice_number", "!=", False))
-        res.append(("mf_reportz", "!=", False))
-        res.append(("mf_serial", "!=", False))
-        return res
+            search_domain += [
+                ("state", "in", ("posted", "cancel")),
+                ("move_type", "in", move_type),
+                "|",
+                ("correlative", "not in", ['/', False]),
+                "&",
+                ("mf_invoice_number", "!=", False),
+                ("mf_reportz", "!=", False),
+                ("mf_serial", "!=", False),
+            ]
+            return search_domain
+
+        search_domain.append(("mf_invoice_number", "!=", False))
+        search_domain.append(("mf_reportz", "!=", False))
+        search_domain.append(("mf_serial", "!=", False))
+        return search_domain
 
     def search_moves(self):
         if not self.with_fiscal_machine:


### PR DESCRIPTION
Problema:Al no seleccionar el check de con maquina fiscal el libro de ventas se esta imprimiendo vacio,esto debido a que no se cumple la condición de busqueda para las facutras

Solución:Se sobreescribe la función de dominio en l10n_ve_iot_mf para condicionar un or para la busqueda de las facturas por correlativo y numero de máquina fiscal.