### PR TITLE
17.0_l10n_ve_account_payment_extension_fix_9286_generate_iva_retentio…

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.15",
+    "version": "17.0.0.0.17",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_move.py
+++ b/l10n_ve_payment_extension/models/account_move.py
@@ -75,8 +75,9 @@ class AccountMoveRetention(models.Model):
             if move.retention_islr_line_ids and not move.islr_voucher_number:
                 move._validate_islr_retention()
                 retention = move._create_supplier_retention("islr")
-                retention.action_post()
+                
                 move.islr_voucher_number = retention.number
+                retention.action_post()
 
             if move.retention_municipal_line_ids:
                 move._validate_municipal_retention()
@@ -91,8 +92,8 @@ class AccountMoveRetention(models.Model):
             ):
                 move._validate_iva_retention()
                 retention = move._create_supplier_retention("iva")
-                retention.action_post()
                 move.iva_voucher_number = retention.number
+                retention.action_post()
         return res
 
     def _validate_islr_retention(self):


### PR DESCRIPTION
…n_check

problema: cuando se le da al check de generar retenciones de IVA estas crean la retencion en el asiento antes de que se pueda confirmar la factura y eso genera error de duplicidad solucion:se cambia el orden del action_post en el modelo para evitar la duplicidad de los registros link ticket: https://binaural.odoo.com/web#id=9286&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form