### PR TITLE
FIX #9413: l10n_ve_stock_accountant

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.1.11",
+    "version": "17.0.0.1.13",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.1.13",
+    "version": "17.0.0.1.14",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/sale_order.py
+++ b/l10n_ve_stock_account/models/sale_order.py
@@ -119,18 +119,7 @@ class SaleOrder(models.Model):
                             % line.product_id.name
                         )
 
-                    stock_available = self.env["stock.quant"].read_group(
-                        domain=[
-                            ("product_id", "=", line.product_id.id),
-                            ("location_id.partner_id", "=", order.partner_id.id),
-                            ("location_id.usage", "=", "internal"),
-                        ],
-                        fields=["quantity:sum"],
-                        groupby=[],
-                    )
-                    total_stock = stock_available[0]["quantity"] if stock_available else 0
-
-                    if line.product_uom_qty > total_stock:
+                    if line.product_uom_qty > line.free_qty_today:
                         raise ValidationError(
                             _(
                                 "Cannot sell more than the available consignation stock for product %s."

--- a/l10n_ve_stock_account/models/sale_order_line.py
+++ b/l10n_ve_stock_account/models/sale_order_line.py
@@ -31,18 +31,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             warehouse = line.order_id.warehouse_id
             if warehouse and warehouse.is_consignation_warehouse:
-                stock_available = self.env["stock.quant"].read_group(
-                    domain=[
-                        ("product_id", "=", line.product_id.id),
-                        ("location_id.partner_id", "=", line.order_id.partner_id.id),
-                        ("location_id.usage", "=", "internal"),
-                    ],
-                    fields=["quantity:sum"],
-                    groupby=[],
-                )
-                total_stock = stock_available[0]["quantity"] if stock_available else 0
-
-                if line.product_uom_qty > total_stock:
+                if line.product_uom_qty > line.free_qty_today:
                     raise ValidationError(
                         _("Cannot sell more than the available consignation stock.")
                     )

--- a/l10n_ve_stock_account/views/sale_order_views.xml
+++ b/l10n_ve_stock_account/views/sale_order_views.xml
@@ -15,7 +15,7 @@
             </field>
 
             <xpath expr="//button[@id='create_invoice']" position="attributes">
-                <attribute name="invisible">invoice_status != 'to invoice' or document == 'dispatch_guide' or is_consignation</attribute>
+                <attribute name="invisible">invoice_status != 'to invoice' or document == 'dispatch_guide'</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Problema: Las cantidades de UOM y cantidad disponible en almacen, estan haciendo mal las validaciones de cantidad en las cotizaciones Solución: Se agrega el campo ya computado free_qty_today para evitar que se tome el stock total traido del modulo stock.quant en donde se toman como base las unidades y no sus UOM correspondientes (ej 12 docenas, las tomaba como 12 unidades) Tarea (Link):https://binaural.odoo.com/web#id=56745&cids=2&model=project.task&view_type=form

Tarea de proyecto [x]