### PR TITLE
17.0_fix_ti_9089-igtf_calculation_from_payment_widget

### DIFF
--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -232,6 +232,23 @@ class AccountMoveLine(models.Model):
         new_foreign_credit = abs(line.foreign_balance) if line.foreign_balance < 0 else 0.0
         if line.foreign_credit != new_foreign_credit:
             line.foreign_credit = new_foreign_credit
+            
+    def _calculate_zero(self, line):
+        """Asigna cero para secciones o notas."""
+        if line.foreign_debit != 0.0:
+            line.foreign_debit = 0.0
+        if line.foreign_credit != 0.0:
+            line.foreign_credit = 0.0
+    
+    def _calculate_from_balance(self, line):
+        new_foreign_debit = abs(line.foreign_balance) if line.foreign_balance > 0 else 0.0
+        if line.foreign_debit != new_foreign_debit:
+            line.foreign_debit = new_foreign_debit
+
+        new_foreign_credit = abs(line.foreign_balance) if line.foreign_balance < 0 else 0.0
+        if line.foreign_credit != new_foreign_credit:
+            line.foreign_credit = new_foreign_credit
+
 
     def _calculate_from_amount_currency(self, line):
         new_foreign_debit = abs(line.amount_currency) if line.amount_currency > 0 else 0.0


### PR DESCRIPTION
problema: el monto foraneo sugerido en el wizard para cerrar la factura esta mal

solucion: se agrego condicion para pagos con igtf para hacer la consideracion exacta del pago y se resturan funciones de codigo eliminadas mediante conflictos