### PR TITLE
Problema:

### DIFF
--- a/l10n_ve_tax/__manifest__.py
+++ b/l10n_ve_tax/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.7",
+    "version": "17.0.0.0.8",
     # any module necessary for this one to work correctly
     "depends": ["base", "account", "l10n_ve_base", "l10n_ve_rate"],
     "data": [

--- a/l10n_ve_tax/models/account_tax.py
+++ b/l10n_ve_tax/models/account_tax.py
@@ -1,4 +1,4 @@
-from odoo.tools.float_utils import float_round
+from odoo.tools.float_utils import float_round, float_compare
 from odoo import api, models, _
 from odoo.exceptions import ValidationError
 from odoo.tools.misc import formatLang
@@ -123,7 +123,7 @@ class AccountTax(models.Model):
         )
         
         move = self._get_move_from_base_lines(base_lines)
-        
+
         amounts = self._get_total_paid_foreign(move, foreign_currency) if move else []
 
         res["foreign_total_amount_paid"] = float_round(
@@ -133,17 +133,17 @@ class AccountTax(models.Model):
 
         foreign_amount_total = res.get('foreign_amount_total', 0.0)
 
-
         res["foreign_total_residual"] = float_round(
             foreign_amount_total - res["foreign_total_amount_paid"],
             precision_digits=foreign_currency.decimal_places
         )
 
+        formatted_result = 0 if float_compare(res['foreign_total_residual'], 0, precision_digits=foreign_currency.decimal_places) < 0 else res['foreign_total_residual']
         res["foreign_formatted_total_residual"] = formatLang(
             self.env,
-            res["foreign_total_residual"],
+            formatted_result,
             currency_obj=foreign_currency
-        )      
+        )            
         
         return res
     


### PR DESCRIPTION
En la vista de facturación, el campo "total a pagar" muestra el importe negativo si el cliente realiza un pago mayor al monto requerido en la factura.

Solución:
Se crea la variable formated_result, encargada de decidir qué valor se va a mostrar. Esta obtiene su resultado dependiendo del float_compare: si el resultado es menor a 0, asigna 0 como valor a ser mostrado; si es mayor o igual a 0, formated_result tendrá el valor de foreign_total_residual. Además, se cambia la traducción de "Total a pagar" a "Importe adeudado".

Tarea (Link):
https://binaural.odoo.com/web#id=9367&cids=2&menu_id=293&action=389&model=helpdesk.ticket&view_type=form

Tarea de proyecto: []
Ticket de soporte: [x]