### PR TITLE
FIX #9251: l10nve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.25",
+    "version": "17.0.0.0.26",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -841,7 +841,7 @@ class AccountMove(models.Model):
         """
         Onchange the foreign rate and compute the foreign inverse rate
         """
-        if self.invoice_date:
+        if self.invoice_date or self.date:
             if self.foreign_rate < 0 or self.foreign_inverse_rate < 0:
                 raise ValidationError(_("The rate entered cannot be negative"))
             Rate = self.env["res.currency.rate"]


### PR DESCRIPTION
Problema: El calculo de los monto alternos depende fe la tasa inversa, cuando asignabas una tasa manual y modificabas la tasa, unicamente funcionaba cuando el asiento tipo "Entry" tenia invoice_date, ya que si calculaba el valor de foreign_rate y no el de inverse_foreign_rate

Solución:Se toma en cuando para cmabiar tanto invoice_date como date, asi recalcula la tasa si estamos tratando con un asiento que no tenga el campo invoice_date

Tarea (Link): Tickets relazionados, error vistro tras una actualizacion de ambiente https://binaural.odoo.com/web#id=9521&cids=2&menu_id=293&action=390&model=helpdesk.ticket&view_type=form https://binaural.odoo.com/web#id=9610&cids=2&menu_id=293&action=390&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]