### PR TITLE
Show dual currency totals on invoices

### DIFF
--- a/l10n_ve_accountant/static/src/components/tax_totals/tax_totals.xml
+++ b/l10n_ve_accountant/static/src/components/tax_totals/tax_totals.xml
@@ -56,7 +56,20 @@
     </t>
 
     <t t-name="l10n_ve_tax.TaxForeignTotalsField" owl="1">
-        <table t-if="totals" class="oe_right">
+        <t t-set="documentCurrencyLabel" t-value="(props.record.data.currency_id and props.record.data.currency_id[1]) or ''"/>
+        <t t-set="foreignCurrencyLabel" t-value="(props.record.data.foreign_currency_id and props.record.data.foreign_currency_id[1]) or ''"/>
+        <table t-if="totals" class="o_tax_totals_table oe_right">
+            <thead>
+                <tr>
+                    <th/>
+                    <th class="o_list_monetary">
+                        <span t-out="documentCurrencyLabel"/>
+                    </th>
+                    <th class="o_list_monetary">
+                        <span t-out="foreignCurrencyLabel"/>
+                    </th>
+                </tr>
+            </thead>
             <tbody>
                 <t t-foreach="totals.subtotals" t-as="subtotal" t-key="subtotal.name">
                     <tr>
@@ -64,8 +77,12 @@
                             <label class="o_form_label o_tax_total_label" t-esc="subtotal.name"/>
                         </td>
                         <td class="o_list_monetary">
-                            <span style="white-space: nowrap; font-weight: bold;"
-                                  t-out="subtotal.formatted_base_amount_foreign_currency"/>
+                            <span class="o_tax_group_amount_value" style="white-space: nowrap;"
+                                  t-out="subtotal.formatted_base_amount_currency or ''"/>
+                        </td>
+                        <td class="o_list_monetary">
+                            <span class="o_tax_group_amount_value" style="white-space: nowrap;"
+                                  t-out="subtotal.formatted_base_amount_foreign_currency or ''"/>
                         </td>
                     </tr>
                     <t t-foreach="subtotal.tax_groups" t-as="taxGroup" t-key="taxGroup.id">
@@ -73,10 +90,13 @@
                             <td class="o_td_label">
                                 <label class="o_form_label o_tax_total_label" t-esc="'Total G ' + taxGroup.group_name"/>
                             </td>
-                            <td>
-                                <span class="o_tax_group_amount_value o_list_monetary"
-                                      t-out="taxGroup.formatted_base_amount_foreign_currency"
-                                      style="white-space: nowrap;"/>
+                            <td class="o_list_monetary">
+                                <span class="o_tax_group_amount_value" style="white-space: nowrap;"
+                                      t-out="taxGroup.formatted_display_base_amount_currency or taxGroup.formatted_base_amount_currency"/>
+                            </td>
+                            <td class="o_list_monetary">
+                                <span class="o_tax_group_amount_value" style="white-space: nowrap;"
+                                      t-out="taxGroup.formatted_display_base_amount_foreign_currency or taxGroup.formatted_base_amount_foreign_currency"/>
                             </td>
                         </tr>
                         <tr>
@@ -84,19 +104,40 @@
                                 <label class="o_form_label o_tax_total_label" t-esc="taxGroup.group_name"/>
                             </td>
                             <td class="o_list_monetary">
-                                <span style="white-space: nowrap;"
+                                <span class="o_tax_group_amount_value" style="white-space: nowrap;"
+                                      t-out="taxGroup.formatted_tax_amount_currency"/>
+                            </td>
+                            <td class="o_list_monetary">
+                                <span class="o_tax_group_amount_value" style="white-space: nowrap;"
                                       t-out="taxGroup.formatted_tax_amount_foreign_currency"/>
                             </td>
                         </tr>
                     </t>
                 </t>
-                <tr>
+                <tr t-if="totals.formatted_tax_amount_currency or totals.formatted_tax_amount_foreign_currency">
                     <td class="o_td_label">
-                        <label class="o_form_label o_tax_total_label">Total</label>
+                        <label class="o_form_label o_tax_total_label" t-esc="_('Taxes')"/>
                     </td>
                     <td class="o_list_monetary">
-                        <span style="font-size: 1.3em; font-weight: bold; white-space: nowrap;"
-                              t-out="totals.formatted_total_amount_foreign_currency"/>
+                        <span class="o_tax_group_amount_value" style="white-space: nowrap;"
+                              t-out="totals.formatted_tax_amount_currency or ''"/>
+                    </td>
+                    <td class="o_list_monetary">
+                        <span class="o_tax_group_amount_value" style="white-space: nowrap;"
+                              t-out="totals.formatted_tax_amount_foreign_currency or ''"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="o_td_label">
+                        <label class="o_form_label o_tax_total_label" t-esc="_('Total')"/>
+                    </td>
+                    <td class="o_list_monetary">
+                        <span class="o_tax_group_amount_value" style="font-size: 1.3em; font-weight: bold; white-space: nowrap;"
+                              t-out="totals.formatted_total_amount_currency or ''"/>
+                    </td>
+                    <td class="o_list_monetary">
+                        <span class="o_tax_group_amount_value" style="font-size: 1.3em; font-weight: bold; white-space: nowrap;"
+                              t-out="totals.formatted_total_amount_foreign_currency or ''"/>
                     </td>
                 </tr>
             </tbody>

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -68,6 +68,9 @@
                     </group>
                 </page>
             </xpath>
+            <xpath expr="//field[@name='tax_totals'][@widget='account-tax-totals-field']" position="attributes">
+                <attribute name="widget">account-tax-foreign-totals-field</attribute>
+            </xpath>
             <xpath expr="//page/field[@name='invoice_line_ids']/list/field[@name='price_unit']"
                 position="after">
                 <field name="foreign_price" readonly="move_type != 'in_invoice'" />


### PR DESCRIPTION
## Summary
- reuse the foreign tax totals widget in the main invoice totals block so both currencies are visible
- redesign the widget template to render subtotals, taxes, and totals in document and company currencies side by side

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ffbef3d608832fa2d235ec055592f5