### PR TITLE
[FIX] Ticket#9511 Botón validar en recepción

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "17.0.0.0.8",
+    "version": "17.0.0.0.9",
     "depends": [
         "stock",
         "l10n_ve_tax",

--- a/l10n_ve_stock/views/stock_picking_views.xml
+++ b/l10n_ve_stock/views/stock_picking_views.xml
@@ -44,18 +44,6 @@
                 <attribute name="groups">!l10n_ve_stock.group_hide_print_button_for_inventory_transfers</attribute>
             </xpath>
 
-            <xpath expr="//button[@name='button_validate'][2]" position="attributes">
-                <attribute name="groups">!l10n_ve_stock.group_hide_validate_inventory_transfers_button</attribute>
-                <attribute name="invisible">state in ('waiting', 'assigned', 'done', 'cancel') or picking_type_code == 'incoming'</attribute>
-                <attribute name='confirm'>Upon confirmation, the system will generate the number of sequences of shipping guides.</attribute>
-            </xpath>
-
-            <xpath expr="//button[@name='button_validate'][1]" position="attributes">
-                <attribute name="groups">!l10n_ve_stock.group_hide_validate_inventory_transfers_button</attribute>
-                <attribute name="invisible">state in ('draft', 'confirmed', 'done', 'cancel') or picking_type_code == 'incoming'</attribute>
-                <attribute name='confirm'>Upon confirmation, the system will generate the number of sequences of shipping guides.</attribute>
-            </xpath>
-
             <xpath expr="//button[@name='action_cancel'][1]" position="attributes">
                 <attribute name="groups">!l10n_ve_stock.group_hide_cancel_button_from_inventory_transfers</attribute>
             </xpath>


### PR DESCRIPTION
En el modulo l10n_ve_stock había una herencia en la vista del modelo stock.picking que hacía que el botón de validar en las recepciones estuviera oculto.

Se quitó la parte que agrega dicha restricción, ya que la lógica que se intentaba hacer está implementada correctamente en l10n_ve_stock_account.