### PR TITLE
FEAT RESCATE IGTF: binaural_

### DIFF
--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.0.0.15",
+    "version": "17.0.0.0.17",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.0.0.16",
+    "version": "17.0.0.0.15",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -158,8 +158,8 @@ class AccountMove(models.Model):
                     # payment_id = line.move_id.payment_id
                     bi_igtf = payment_id.get_bi_igtf(move_id)
                     _logger.info(f'tiene payment_id igtf === {bi_igtf}')
-                    if initial_residual <= bi_igtf and bi_igtf >= record.amount_total:
-                        record.bi_igtf = min(record.bi_igtf + bi_igtf,record.amount_total)
+                    if initial_residual <= bi_igtf and bi_igtf >= amount_to_pay:
+                        record.bi_igtf = min(record.bi_igtf + bi_igtf,amount_to_pay)
                         _logger.warning(f'Hey 22222222222 {record.bi_igtf}')
                         bi_igtf = 0
                         continue
@@ -290,7 +290,6 @@ class AccountMove(models.Model):
 
     def js_assign_outstanding_line(self, line_id):
         _logger.info('entrando a l10 igtf')
-        # _logger.info(xd.xd)
         amount_residual = self.amount_residual
         self = self.with_context(from_widget=True)
         res = super().js_assign_outstanding_line(line_id)


### PR DESCRIPTION
Problema:
-No se calculaba bien el bi_igtf en los casos donde una factura tuviera un pago en bolivares ya asociado.

Solución:
-Se modifica la función para que esta utilice el monto a pagar de la factura en los casos que se requieran.

Tarea (Link):

Tarea de proyecto [x]
Ticket de soporte []