### PR TITLE
[FIX] Se elimina el atributo default en el campo foreign_rate

### DIFF
--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -27,7 +27,6 @@ class AccountPayment(models.Model):
     foreign_rate = fields.Float(
         compute="_compute_rate",
         digits="Tasa",
-        default=0.0,
         store=True,
         readonly=False,
     )
@@ -35,7 +34,6 @@ class AccountPayment(models.Model):
         help="Rate that will be used as factor to multiply of the foreign currency for this move.",
         compute="_compute_rate",
         digits=(16, 15),
-        default=0.0,
         store=True,
         readonly=False,
     )


### PR DESCRIPTION
[FIX] Se elimina el atributo default en el campo foreign_rate, esto debido a que al ser un campo computado no necesita de un default y fue la manera que se consiguio para dar solucion a una incidencia presente en la seccion de pagos al entrar por el tablero de contabilidad