### PR TITLE
[FIX]Se cambia la validación para el monto de las retenciones contra …

### DIFF
--- a/l10n_ve_payment_extension/i18n/es_VE.po
+++ b/l10n_ve_payment_extension/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250522\n"
+"Project-Id-Version: Odoo Server 17.0+e-20251004\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-25 16:00+0000\n"
-"PO-Revision-Date: 2025-07-25 16:00+0000\n"
+"POT-Creation-Date: 2025-11-05 13:27+0000\n"
+"PO-Revision-Date: 2025-11-05 13:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -25,6 +25,16 @@ msgid ""
 "                        Funciones Publicas o por Razón de sus Actividades Privadas intervengan en operaciones\n"
 "                        Gravadas con el Impuesto Establecido en este Decreto con Rango,\n"
 "                        Valor y Fuerza de Ley."
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "% Alic"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "% Ret"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -55,6 +65,26 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "/ Mes:"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "01-REG"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "02-REG"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "03-ANU"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "03-REG"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -91,12 +121,6 @@ msgid "<span class=\"tal\">Nombre o Razón Social:</span><br/>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span style=\"visibility:hidden\">--</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
 msgid ""
 "<span text-align=\"center\" style=\"font-weight: bold;\">Agente de "
@@ -114,50 +138,13 @@ msgid "<span text-align=\"center\">Firma y sello</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>% Alic</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>% Ret</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
-msgid "<span>%</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
 msgid "<span>---</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
 msgid "<span>--</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>01-REG</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>02-REG</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>03-ANU</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>03-REG</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -175,16 +162,6 @@ msgstr ""
 msgid ""
 "<span>Art. 24 del Drecreto 1808 Según G.O Nro 36.203 de fecha de mayo de "
 "1997</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Base Imponible</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Compras sin derecho a Crédito IVA</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -218,21 +195,6 @@ msgid "<span>Dirección:</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
-msgid "<span>FA</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Factura afectada</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Fecha Factura</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "<span>Fecha de emision:</span>"
 msgstr ""
@@ -240,26 +202,6 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "<span>Fecha:</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>IVA Retenido</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Impuesto IVA</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
-msgid "<span>NC</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
-msgid "<span>ND</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -278,34 +220,14 @@ msgid "<span>Nombre o Razón Social del Sujeto Retenido</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Nota de Crédito</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Nota de Débito</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "<span>Nro Comprobante:</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Nro de Control Factura</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "<span>Nro. R.I.F.:</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Número de Factura</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -332,16 +254,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid ""
 "<span>Registro de Información Fiscal del Sujeto Retenido (R.I.F)</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Tipo de Transacción</span>"
-msgstr ""
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
-msgid "<span>Total Compras Incluyendo el IVA</span>"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -375,6 +287,11 @@ msgstr "Comprobante ARCV"
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.arcv_report_form_view
 msgid "ARCV Voucher"
 msgstr "Comprobante ARCV"
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.res_config_settings_l10n_ve_payment_extension
+msgid "Account reports"
+msgstr "Reportes contables"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__date_accounting
@@ -433,6 +350,11 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__activity_type_icon
 msgid "Activity Type Icon"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__actual_invoice_ids
+msgid "Actual Invoices"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -505,6 +427,13 @@ msgid "Associated Payment Concept"
 msgstr "Concepto de pago asociado"
 
 #. module: l10n_ve_payment_extension
+#. odoo-python
+#: code:addons/l10n_ve_payment_extension/models/account_retention_line.py:0
+#, python-format
+msgid "Atención"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__message_attachment_count
 msgid "Attachment Count"
 msgstr ""
@@ -515,6 +444,11 @@ msgstr ""
 #, python-format
 msgid "August"
 msgstr "Agosto"
+
+#. module: l10n_ve_payment_extension
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__available_invoice_ids
+msgid "Available Invoices"
+msgstr ""
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
@@ -528,6 +462,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__base_currency_is_vef
 msgid "Base Currency Is Vef"
 msgstr "La moneda base es Bs"
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Base Imponible"
+msgstr ""
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
@@ -608,7 +547,7 @@ msgstr "Referencia del Comprobante"
 #. module: l10n_ve_payment_extension
 #: model:ir.model,name:l10n_ve_payment_extension.model_res_company
 msgid "Companies"
-msgstr "Compañías"
+msgstr "Empresas"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__company_id
@@ -625,6 +564,11 @@ msgstr "Compañía"
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention_line__company_currency_id
 msgid "Company Currency"
 msgstr "Moneda de la Compañía"
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Compras sin derecho a Crédito IVA"
+msgstr ""
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
@@ -650,7 +594,7 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model:ir.model,name:l10n_ve_payment_extension.model_res_config_settings
 msgid "Config Settings"
-msgstr "Opciones de configuración"
+msgstr "Ajustes de configuración"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model,name:l10n_ve_payment_extension.model_res_partner
@@ -718,11 +662,6 @@ msgstr "Diario del Cliente"
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.view_retention_line_report_search
 msgid "Customer Retention"
 msgstr "Retenciones de Cliente"
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
-msgid "Código"
-msgstr ""
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention_line__payment_date
@@ -891,6 +830,20 @@ msgid "Economy Branch"
 msgstr "Rama Económica"
 
 #. module: l10n_ve_payment_extension
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_bank_statement_line__not_edit_islr_retention_lines
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_move__not_edit_islr_retention_lines
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_payment__not_edit_islr_retention_lines
+msgid "Edit ISLR Retention Lines?"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_bank_statement_line__not_edit_municipal_retention_lines
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_move__not_edit_municipal_retention_lines
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_payment__not_edit_municipal_retention_lines
+msgid "Edit Municipal Retention Lines?"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_payment_register__edit_retention_fields
 msgid "Edit Retention Fields"
 msgstr "Editar campos de retención"
@@ -929,7 +882,17 @@ msgstr "Error en el campo de porcentaje de tarifas"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
+msgid "FA"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "Fact Nro"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Factura afectada"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -953,6 +916,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.view_retention_iva_search_l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.view_retention_municipal_search_l10n_ve_payment_extension
 msgid "Fecha Contable"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Fecha Factura"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -1112,6 +1080,14 @@ msgid "Has Message"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_res_company__hide_patent_columns_extra
+#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_res_config_settings__hide_patent_columns_extra
+msgid "Hide extra columns in Patent Municipal Report related to advances"
+msgstr ""
+"Ocultar columnas adicionales en el reporte de Patente Municipal relacionadas"
+" con anticipos"
+
+#. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__id
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention_line__id
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_withholding_type__id
@@ -1186,13 +1162,6 @@ msgid "ISLR Retentions"
 msgstr "Retenciones de ISLR"
 
 #. module: l10n_ve_payment_extension
-#. odoo-python
-#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
-#, python-format
-msgid "ISLR retention: Number must be exactly 11 numeric digits."
-msgstr "Retención ISLR: El número debe tener exactamente 11 dígitos numéricos."
-
-#. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention_line__iva_amount
 #: model:ir.model.fields.selection,name:l10n_ve_payment_extension.selection__account_payment__payment_type_retention__iva
 #: model:ir.model.fields.selection,name:l10n_ve_payment_extension.selection__account_retention__type_retention__iva
@@ -1204,6 +1173,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_res_users__iva_account
 msgid "IVA Account"
 msgstr "Cuenta de Retención IVA"
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "IVA Retenido"
+msgstr ""
 
 #. module: l10n_ve_payment_extension
 #. odoo-python
@@ -1299,6 +1273,11 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
 msgid "Impuesto <br/>retenido"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Impuesto IVA"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -1425,6 +1404,7 @@ msgstr "IVA"
 #. module: l10n_ve_payment_extension
 #. odoo-python
 #: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
+#: code:addons/l10n_ve_payment_extension/models/account_retention_line.py:0
 #, python-format
 msgid "Iva Retention"
 msgstr "Retención de IVA"
@@ -1710,6 +1690,16 @@ msgid "My Activity Deadline"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
+msgid "NC"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
+msgid "ND"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
 msgid "NO HAY DATOS"
 msgstr ""
@@ -1742,10 +1732,27 @@ msgstr ""
 
 #. module: l10n_ve_payment_extension
 #. odoo-python
+#: code:addons/l10n_ve_payment_extension/wizard/wizard_retention_iva.py:0
+#, python-format
+msgid "No VAT number for company %s"
+msgstr "La compañia %s no tiene RIF"
+
+#. module: l10n_ve_payment_extension
+#. odoo-python
 #: code:addons/l10n_ve_payment_extension/wizard/wizard_retention_islr.py:0
 #, python-format
 msgid "No data to export"
 msgstr "No hay datos para exportar"
+
+#. module: l10n_ve_payment_extension
+#. odoo-python
+#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
+#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
+#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
+#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
+#, python-format
+msgid "No registered lines found in the move to reconcile."
+msgstr "No existen líneas registradas en el movimiento"
 
 #. module: l10n_ve_payment_extension
 #. odoo-python
@@ -1762,6 +1769,16 @@ msgid "No withholdings have been found in the selected period"
 msgstr "No se han encontrado retenciones en el periodo seleccionado"
 
 #. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Nota de Crédito"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Nota de Débito"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
 #. odoo-python
 #: code:addons/l10n_ve_payment_extension/utils/utils_retention.py:0
 #, python-format
@@ -1771,6 +1788,11 @@ msgstr "Noviembre"
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "Nro de Control"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Nro de Control Factura"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -1802,6 +1824,11 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,help:l10n_ve_payment_extension.field_account_retention__message_has_error_counter
 msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Número de Factura"
 msgstr ""
 
 #. module: l10n_ve_payment_extension
@@ -1973,11 +2000,6 @@ msgstr "Tasa"
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_fees_retention__accumulated_rate
 msgid "Rate accumulated?"
 msgstr "¿Tarifa Acumulada?"
-
-#. module: l10n_ve_payment_extension
-#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__rating_ids
-msgid "Ratings"
-msgstr ""
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_retention_line_report__raw_aliquot
@@ -2405,7 +2427,8 @@ msgstr "La alícuota debe ser mayor a cero "
 #: code:addons/l10n_ve_payment_extension/models/account_move.py:0
 #, python-format
 msgid ""
-"The amount of the retention is greater than the total amount of the invoice %s."
+"The amount of the retention is greater than the total amount of the invoice "
+"%s."
 msgstr ""
 "La base imponible de la retención es mayor que la base imponible de la "
 "factura %s."
@@ -2450,6 +2473,7 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #. odoo-python
 #: code:addons/l10n_ve_payment_extension/models/account_move.py:0
+#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
 #, python-format
 msgid "The company must have a journal for ISLR supplier retention."
 msgstr ""
@@ -2524,6 +2548,7 @@ msgstr "La factura %s no tiene impuesto"
 #. module: l10n_ve_payment_extension
 #. odoo-python
 #: code:addons/l10n_ve_payment_extension/models/account_move.py:0
+#: code:addons/l10n_ve_payment_extension/models/account_retention_line.py:0
 #, python-format
 msgid "The invoice has no tax."
 msgstr "La factura no tiene impuesto"
@@ -2562,6 +2587,15 @@ msgstr "El porcentaje de las tarifas no puede ser mayor que 100%"
 #, python-format
 msgid "The rate percentage cannot be negative.\n"
 msgstr "El porcentaje de retención no puede ser negativo."
+
+#. module: l10n_ve_payment_extension
+#. odoo-python
+#: code:addons/l10n_ve_payment_extension/models/account_move.py:0
+#, python-format
+msgid ""
+"The taxable base of one of the withholding lines is greater than the taxable"
+" base of the invoice"
+msgstr "La base imponible de una de las lineas de retencion es mayor a la base imponible de la factura"
 
 #. module: l10n_ve_payment_extension
 #. odoo-python
@@ -2619,9 +2653,19 @@ msgid "There is no data to show."
 msgstr "No hay datos que mostrar."
 
 #. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Tipo de Transacción"
+msgstr ""
+
+#. module: l10n_ve_payment_extension
 #: model:ir.model.fields,help:l10n_ve_payment_extension.field_account_retention__type
 msgid "Tipo del Comprobante"
 msgstr "TIpo del Comprobante"
+
+#. module: l10n_ve_payment_extension
+#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
+msgid "Total Compras Incluyendo el IVA"
+msgstr ""
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
@@ -2932,31 +2976,3 @@ msgstr "Impuesto retenido"
 #, python-format
 msgid "the percentage may not exceed 100% on the payment concept line"
 msgstr "El porcentaje no puede exceder el 100% en la linea de pago."
-
-#. module: l10n_ve_payment_extension
-#. odoo-python
-#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
-#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
-#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
-#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
-#, python-format
-msgid "No registered lines found in the move to reconcile."
-msgstr "No existen líneas registradas en el movimiento"
-
-#. module: l10n_ve_payment_extension
-#: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.res_config_settings_l10n_ve_payment_extension
-msgid "Account reports"
-msgstr "Reportes contables"
-
-#. module: l10n_ve_payment_extension
-#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_res_company__hide_patent_columns_extra
-#: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_res_config_settings__hide_patent_columns_extra
-msgid "Hide extra columns in Patent Municipal Report related to advances"
-msgstr "Ocultar columnas adicionales en el reporte de Patente Municipal relacionadas con anticipos"
-
-#. module: l10n_ve_payment_extension
-#. odoo-python
-#: code:addons/l10n_ve_payment_extension/wizard/wizard_retention_iva.py:0
-#, python-format
-msgid "No VAT number for company %s"
-msgstr "La compañia %s no tiene RIF"

--- a/l10n_ve_payment_extension/i18n/es_VE.po
+++ b/l10n_ve_payment_extension/i18n/es_VE.po
@@ -30,17 +30,17 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "% Alic"
-msgstr ""
+msgstr "% Alic"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "% Ret"
-msgstr ""
+msgstr "% Ret"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
 msgid "% o <br/>tarifa"
-msgstr ""
+msgstr "% o tarifa"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention_line__related_percentage_fees
@@ -60,32 +60,32 @@ msgstr "'Comprobante ARCV'"
 #. module: l10n_ve_payment_extension
 #: model:ir.actions.report,print_report_name:l10n_ve_payment_extension.retention_voucher_action
 msgid "(object.number)"
-msgstr ""
+msgstr "(número del objeto)"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "/ Mes:"
-msgstr ""
+msgstr "/ Mes:"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "01-REG"
-msgstr ""
+msgstr "01-REG"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "02-REG"
-msgstr ""
+msgstr "02-REG"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "03-ANU"
-msgstr ""
+msgstr "03-ANU"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "03-REG"
-msgstr ""
+msgstr "03-REG"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
@@ -182,42 +182,42 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "<span>Direccion Fiscal del Agente de Retención</span>"
-msgstr ""
+msgstr "Dirección Fiscal del Agente de Retención"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "<span>Direccion Fiscal del Sujeto Retenido</span>"
-msgstr ""
+msgstr "Dirección Fiscal del Sujeto Retenido"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "<span>Dirección:</span>"
-msgstr ""
+msgstr "Dirección:"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "<span>Fecha de emision:</span>"
-msgstr ""
+msgstr "Fecha de emisión:"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "<span>Fecha:</span>"
-msgstr ""
+msgstr "Fecha:"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "<span>No. R.I.F.:</span>"
-msgstr ""
+msgstr "No. R.I.F.:"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "<span>Nombre o Razón Social del Agente de Retención</span>"
-msgstr ""
+msgstr "Nombre o Razón Social del Agente de Retención"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "<span>Nombre o Razón Social del Sujeto Retenido</span>"
-msgstr ""
+msgstr "Nombre o Razón Social del Sujeto Retenido"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
@@ -350,12 +350,12 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__activity_type_icon
 msgid "Activity Type Icon"
-msgstr ""
+msgstr "Ícono del tipo de actividad"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__actual_invoice_ids
 msgid "Actual Invoices"
-msgstr ""
+msgstr "Facturas actuales"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
@@ -431,12 +431,12 @@ msgstr "Concepto de pago asociado"
 #: code:addons/l10n_ve_payment_extension/models/account_retention_line.py:0
 #, python-format
 msgid "Atención"
-msgstr ""
+msgstr "Atención"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__message_attachment_count
 msgid "Attachment Count"
-msgstr ""
+msgstr "Cantidad de adjuntos"
 
 #. module: l10n_ve_payment_extension
 #. odoo-python
@@ -448,7 +448,7 @@ msgstr "Agosto"
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__available_invoice_ids
 msgid "Available Invoices"
-msgstr ""
+msgstr "Facturas disponibles"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
@@ -568,7 +568,7 @@ msgstr "Moneda de la Compañía"
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "Compras sin derecho a Crédito IVA"
-msgstr ""
+msgstr "Compras sin derecho a Crédito IVA"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_template_arcv
@@ -834,14 +834,14 @@ msgstr "Rama Económica"
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_move__not_edit_islr_retention_lines
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_payment__not_edit_islr_retention_lines
 msgid "Edit ISLR Retention Lines?"
-msgstr ""
+msgstr "¿Editar líneas de retención ISLR?"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_bank_statement_line__not_edit_municipal_retention_lines
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_move__not_edit_municipal_retention_lines
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_payment__not_edit_municipal_retention_lines
 msgid "Edit Municipal Retention Lines?"
-msgstr ""
+msgstr "¿Editar líneas de retención municipal?"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_payment_register__edit_retention_fields
@@ -893,7 +893,7 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "Factura afectada"
-msgstr ""
+msgstr "Factura afectada"
 
 #. module: l10n_ve_payment_extension
 #. odoo-python
@@ -921,7 +921,7 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "Fecha Factura"
-msgstr ""
+msgstr "Fecha Factura"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_municipal_retention_xlsx_report__date_start
@@ -1077,7 +1077,7 @@ msgstr "Agrupar por"
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__has_message
 msgid "Has Message"
-msgstr ""
+msgstr "Tiene mensaje"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_res_company__hide_patent_columns_extra
@@ -2014,7 +2014,7 @@ msgstr "Porcentaje de Retención Bruto"
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "Recibido por:"
-msgstr ""
+msgstr "Recibido por:"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model,name:l10n_ve_payment_extension.model_account_payment_register
@@ -2333,7 +2333,7 @@ msgstr "Retenciones de Proveedor"
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "Sustraendo"
-msgstr ""
+msgstr "Sustraendo"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
@@ -2343,7 +2343,7 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "Tarifa Ret"
-msgstr ""
+msgstr "Tarifa Ret"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_accumulated_fees__fees_id
@@ -2655,7 +2655,7 @@ msgstr "No hay datos que mostrar."
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "Tipo de Transacción"
-msgstr ""
+msgstr "Tipo de Transacción"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,help:l10n_ve_payment_extension.field_account_retention__type
@@ -2665,18 +2665,18 @@ msgstr "TIpo del Comprobante"
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "Total Compras Incluyendo el IVA"
-msgstr ""
+msgstr "Total Compras Incluyendo el IVA"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_islr_customer
 msgid "Total Factura"
-msgstr ""
+msgstr "Total Factura"
 
 #. module: l10n_ve_payment_extension
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__foreign_total_iva_amount
 #: model:ir.model.fields,field_description:l10n_ve_payment_extension.field_account_retention__total_iva_amount
 msgid "Total IVA"
-msgstr ""
+msgstr "Total IVA"
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.view_retention_line_report_tree

--- a/l10n_ve_payment_extension/models/account_move.py
+++ b/l10n_ve_payment_extension/models/account_move.py
@@ -182,21 +182,24 @@ class AccountMoveRetention(models.Model):
                 lambda rl: rl.state != "cancel"
             ).mapped("invoice_amount")
         )
-        self._check_retention_vs_move(sum_invoice_amount)
+        self._check_retention_vs_move(islr_retention)
 
         if not self.partner_id.type_person_id:
             raise UserError(_("The partner must have a type of person"))
         if sum_invoice_amount <= 0:
             raise UserError(_("The amount of the retention must be greater than zero."))
 
-    def _check_retention_vs_move(self, sum_invoice_amount):
-        if sum_invoice_amount > self.tax_totals.get("amount_untaxed", 0.0):
-            raise UserError(
-                _(
-                    "The amount of the retention is greater than the total amount of the invoice %s."
+    @api.model
+    def _check_retention_vs_move(self, islr_retention_lines):
+        for line in islr_retention_lines:
+            move = line.move_id
+            invoice_base = move.tax_totals.get("amount_untaxed", 0.0)
+            if line.invoice_amount > invoice_base:
+                raise UserError(
+                    _(
+                        "The taxable base of one of the withholding lines is greater than the taxable base of the invoice"
+                    )
                 )
-                % self.name
-            )
 
     def _validate_iva_retention(self):
         """

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -706,8 +706,8 @@ class AccountRetention(models.Model):
         for line in islr_retention.filtered(lambda rl: rl.state != "cancel"):
             invoice_amounts_by_move[line.move_id] += line.invoice_amount
 
-        for move, sum_invoice_amount in invoice_amounts_by_move.items():
-            move._check_retention_vs_move(sum_invoice_amount)
+        move = self.env["account.move"]
+        move._check_retention_vs_move(islr_retention)
 
     def set_voucher_number_in_invoice(self, move, retention):
         if retention.type_retention == "iva":

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -706,8 +706,7 @@ class AccountRetention(models.Model):
         for line in islr_retention.filtered(lambda rl: rl.state != "cancel"):
             invoice_amounts_by_move[line.move_id] += line.invoice_amount
 
-        move = self.env["account.move"]
-        move._check_retention_vs_move(islr_retention)
+        self.env['account.move']._check_retention_vs_move(islr_retention)
 
     def set_voucher_number_in_invoice(self, move, retention):
         if retention.type_retention == "iva":


### PR DESCRIPTION
…la factura.

Anteriormente se validadaba la sumatoria de las lineas de una misma factura contra su base imponible. Esto no funcionaba ya que si dos lineas de retención con conceptos distintos tenian la base imponible igual a la de la factura esto hacia saltar la validación.
Ahora se valida la base imponible de cada linea contra la base imponible de la factura de la misma linea. Link:https://binaural.odoo.com/web#id=9719&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form