### PR TITLE
FIX#59584 l10_ve_invoice

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "1.0",
+    "version": "1.1",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -108,7 +108,7 @@
     <record id="account.action_move_out_refund_type" model="ir.actions.act_window">
         <field name="name">Credit Notes</field>
         <field name="res_model">account.move</field>
-        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_mode">list,kanban,form</field>
         <field name="view_id" ref="account.view_out_credit_note_tree" />
         <field name="search_view_id" ref="account.view_account_invoice_filter" />
         <field name="domain">[('move_type', '=', 'out_refund')]</field>
@@ -128,7 +128,7 @@
     <record id="account.action_move_in_invoice_type" model="ir.actions.act_window">
         <field name="name">Bills</field>
         <field name="res_model">account.move</field>
-        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_mode">list,kanban,form</field>
         <field name="view_id" ref="account.view_in_invoice_tree" />
         <field name="search_view_id" ref="account.view_account_invoice_filter" />
         <field name="domain">[('move_type', '=', 'in_invoice')]</field>
@@ -148,7 +148,7 @@
     <record id="account.action_move_in_refund_type" model="ir.actions.act_window">
         <field name="name">Credit Notes</field>
         <field name="res_model">account.move</field>
-        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_mode">list,kanban,form</field>
         <field name="view_id" ref="account.view_in_invoice_tree" />
         <field name="search_view_id" ref="account.view_account_invoice_filter" />
         <field name="domain">[('move_type', '=', 'in_refund')]</field>

--- a/l10n_ve_invoice/views/menu.xml
+++ b/l10n_ve_invoice/views/menu.xml
@@ -5,7 +5,7 @@
             <field name="name">control number</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">ir.sequence</field>
-            <field name="view_mode">tree,form</field>
+            <field name="view_mode">list,form</field>
             <field name="domain">[('code', '=','invoice.correlative')]</field>
         </record>
         


### PR DESCRIPTION
 Corrijiendo error al vizualizar notas de credito para proveedores

Se migran las vistas al contexto de la 19

Link:https://www.binauraldev.com/web#id=59584&cids=2&model=project.task&view_type=form