### PR TITLE
FIX #59177: l10n_ve_accoutant

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "1.0",
+    "version": "1.1",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -50,14 +50,6 @@
                 <attribute name="invisible">1</attribute>
                 <!-- <attribute name="invisible">state in ['posted', 'cancel'] and move_type in ['out_invoice', 'out_refund'] and is_debit_journal and not show_reset_to_draft_button</attribute> -->
             </button>
-            
-            <xpath expr="//form//header" position="inside">
-                <button
-                    name="action_debit_note_button" string="Debit note"
-                    type="object" class="o_btn_validate"
-                    invisible="is_debit_journal"
-                />
-            </xpath>
 
              <xpath expr="//header" position="after">
                 <field name="display_date_warning" invisible="1"/>


### PR DESCRIPTION
Problema:
-Se muestra un boton de agregar nota de debito adicional

Solución:
 Se remueve el boton de ve_invoice, al ya estar definido de forma nativa

Tarea (Link): https://binaural.odoo.com/web/#id=59177&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]

Ticket de soporte []