### PR TITLE
FEAT #59280: l10n_ve_account_move_line

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.0",
+    "version": "1.4",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -125,11 +125,28 @@ class AccountMoveLine(models.Model):
             line.name = line.move_id.name
         return res
 
-    @api.depends("price_unit", "foreign_inverse_rate")
+    @api.depends("price_unit", "foreign_inverse_rate", "currency_id")
     def _compute_foreign_price(self):
         for line in self:
-            line.foreign_price = line.price_unit * line.foreign_inverse_rate
-
+            company_currency = line.company_id.currency_id
+            foreign_currency = line.company_id.foreign_currency_id
+            # Si la línea está en moneda principal de la compañía
+            if line.currency_id.id == company_currency.id:
+                line.foreign_price = line.price_unit * line.foreign_inverse_rate
+            # Si la línea está en moneda foránea
+            elif line.currency_id.id == foreign_currency.id:
+                line.foreign_price = line.price_unit
+            # Si la línea está en otra moneda (ni principal ni foránea)
+            else:
+                # Convertir de la moneda de la línea a la moneda principal
+                price_in_company = line.currency_id._convert(
+                    line.price_unit,
+                    company_currency,
+                    line.company_id,
+                    line.move_id.invoice_date or fields.Date.today(),
+                )
+                # Luego convertir de la moneda principal a la foránea usando la tasa de la factura
+                line.foreign_price = price_in_company * line.foreign_inverse_rate 
     @api.depends("foreign_price", "quantity", "discount", "tax_ids", "price_unit")
     def _compute_foreign_subtotal(self):
         for line in self:


### PR DESCRIPTION
Problema:
-Al cambiar la moneda de la factura, los asientos se muestran desbalanceados en las líneas de cŕedito y débito alterno.

Solución:
-Se añaden validaciones para ajustar los casos según la moneda de la factura, si la moneda de la factura es la principal, sigue el flujo que estaba anteriormente. Si la moneda de la factura es la misma que la foranea, el precio foraneo es igual al precio standar. En el caso de tener una moneda diferente a la principal y secundaria, entonces se realiza una conversión a la moneda principal y a partir de esta, se convierte a la foranea.

Tarea (Link):
https://binaural.odoo.com/web#id=59280&cids=2&menu_id=309&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []