### PR TITLE
Propagar sucursales desde Retenciones

### DIFF
--- a/l10n_ve_igtf/__init__.py
+++ b/l10n_ve_igtf/__init__.py
@@ -2,7 +2,7 @@ from . import models
 from . import wizard
 from . import tests
 
-from odoo.tools import column_exists, create_column
+from odoo.tools.sql import column_exists, create_column
 
 
 def pre_init_hook(env):

--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "1.0",
+    "version": "1.1",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "1.0",
+    "version": "1.1",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -802,6 +802,13 @@ class AccountRetention(models.Model):
                 }
             )
 
+            if 'subsidiary' in self.env.company._fields:
+                if self.env.company.subsidiary:
+                    payment_vals[-1]['account_analytic_id'] = line.move_id.account_analytic_id.id
+                else:
+                    payment_vals[-1]['account_analytic_id'] = False
+
+
         # payments = Payment.create(payment_vals)
         payments = self.env["account.payment"]
         for vals in payment_vals:
@@ -827,50 +834,48 @@ class AccountRetention(models.Model):
         """
         for payment in self.mapped("payment_ids"):
             payment.action_post()
-            if payment.partner_type == "supplier":
-                self._reconcile_supplier_payment(payment)
-            if payment.partner_type == "customer":
-                self._reconcile_customer_payment(payment)
+            self._reconcile_payment(payment)
 
-    def _reconcile_supplier_payment(self, payment):
+    def get_amount_field_and_account_type(self, payment, is_payment_credit=False):
+
+        if payment.partner_type == 'supplier':
+            account_type = "liability_payable"
+        else:
+            account_type = "asset_receivable"
+
+
+        is_base_currency = payment.currency_id == self.company_id.currency_id
 
         if payment.payment_type == "outbound":
-            lines = payment.move_id.line_ids.filtered(lambda l: l.account_id.account_type == "liability_payable" and l.debit > 0)
-            if not lines:
-                raise ValidationError(_("No registered lines found in the move to reconcile."))
-            line_to_reconcile = lines[0]
+            amount_field = 'debit' if is_base_currency else 'foreign_debit'
 
-            payment.retention_line_ids.move_id.js_assign_outstanding_line(line_to_reconcile.id)
-        
         elif payment.payment_type == "inbound":
-            
-            lines = payment.move_id.line_ids.filtered(lambda l: l.account_id.account_type == "liability_payable" and l.credit > 0)
-            if not lines:
-                raise ValidationError(_("No registered lines found in the move to reconcile."))
-            line_to_reconcile = lines[0]
-            
-            payment.retention_line_ids.move_id.js_assign_outstanding_line(line_to_reconcile.id)
+            amount_field = 'credit' if is_base_currency else 'foreign_credit'
 
-    def _reconcile_customer_payment(self, payment):
-        
-        if payment.payment_type == "outbound":
-            
-            lines = payment.move_id.line_ids.filtered(lambda l: l.account_id.account_type == "asset_receivable" and l.debit > 0)
-            
-            if not lines:
-                raise ValidationError(_("No registered lines found in the move to reconcile."))
-            line_to_reconcile = lines[0]
-            
-            payment.retention_line_ids.move_id.js_assign_outstanding_line(line_to_reconcile.id)
-        
-        elif payment.payment_type == "inbound":
-            lines = payment.move_id.line_ids.filtered(lambda l: l.account_id.account_type == "asset_receivable" and l.credit > 0)
-            
-            if not lines:
-                raise ValidationError(_("No registered lines found in the move to reconcile."))
-            line_to_reconcile = lines[0]
+        else:
+            return None, account_type 
 
-            payment.retention_line_ids.move_id.js_assign_outstanding_line(line_to_reconcile.id)
+        return amount_field, account_type
+
+    def _reconcile_payment(self, payment):
+        amount_field, account_type = self.get_amount_field_and_account_type(payment, is_payment_credit=False)
+
+        if not amount_field:
+            return 
+
+        line_to_reconcile = payment.move_id.line_ids.filtered(
+            lambda l: l.account_id.account_type == account_type
+            and getattr(l, amount_field) > 0
+        )
+
+        if line_to_reconcile:
+            line_to_reconcile = line_to_reconcile[0]
+
+            payment.action_draft()
+            
+            payment.retention_line_ids.move_id.js_assign_outstanding_line(
+                line_to_reconcile.id
+            )
 
     @api.model
     def compute_retention_lines_data(self, invoice_id, payment=None):


### PR DESCRIPTION
Se agregan la cuenta analitica a los pagos de retencion solamente si existe la configuracion de cuentas analitica activa, en caso contrario no se propaga.

Tambien se refactoriza metodo para conciliar el pago de la retencion contra las facturas retenidas, el mismo realizaba la misma funcion repetida tanto para cleintes como proveedores, se refactorizo en 1 sola funcion!!