### PR TITLE
[FIX]Se añade el currency_id de la factura al compute del precio unit…

### DIFF
--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -76,7 +76,7 @@ class AccountMoveLine(models.Model):
 
     not_deductible_tax = fields.Boolean(default=False)
 
-    # overridee
+    # override
     @api.depends("product_id", "product_uom_id", "move_id.currency_id")
     def _compute_price_unit(self):
         for line in self:

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -75,7 +75,32 @@ class AccountMoveLine(models.Model):
     config_deductible_tax = fields.Boolean(related='company_id.config_deductible_tax')
 
     not_deductible_tax = fields.Boolean(default=False)
-    
+
+    # overridee
+    @api.depends("product_id", "product_uom_id", "move_id.currency_id")
+    def _compute_price_unit(self):
+        for line in self:
+            if (
+                not line.product_id
+                or line.display_type in ("line_section", "line_subsection", "line_note")
+                or line.is_imported
+            ):
+                continue
+            if line.move_id.is_sale_document(include_receipts=True):
+                document_type = "sale"
+            elif line.move_id.is_purchase_document(include_receipts=True):
+                document_type = "purchase"
+            else:
+                document_type = "other"
+            line.price_unit = line.product_id._get_tax_included_unit_price(
+                line.move_id.company_id,
+                line.move_id.currency_id,
+                line.move_id.date,
+                document_type,
+                fiscal_position=line.move_id.fiscal_position_id,
+                product_uom=line.product_uom_id,
+            )
+
     @api.onchange("amount_currency", "currency_id")
     def _inverse_amount_currency(self):
         for line in self:
@@ -261,7 +286,6 @@ class AccountMoveLine(models.Model):
             # line.foreign_credit = (
             #     abs(line.foreign_balance) if line.foreign_balance > 0 else 0.0
             # )
-
 
     @api.depends("foreign_credit", "foreign_debit")
     def _compute_foreign_balance(self):


### PR DESCRIPTION
…ario

Odoo no toma en consideracion si la factura cambia de moneda para recalcular sus precios a la nueva moneda,esto debido a que faltaba declarar el currency_id en el depends.