### PR TITLE
Se corrije campo Code en lineas de retencion

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.23",
+    "version": "17.0.0.0.24",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention_line.py
+++ b/l10n_ve_payment_extension/models/account_retention_line.py
@@ -67,11 +67,17 @@ class AccountRetentionLine(models.Model):
     payment_concept_id = fields.Many2one(
         "payment.concept", "Payment concept", ondelete="cascade", index=True
     )
+    
     code = fields.Char(
-        related="payment_concept_id.line_payment_concept_ids.code"
+        string='Code',
+        compute='_compute_code',
+        store=True, 
+        readonly=False
     )
-    code_visible=fields.Boolean(
+
+    code_visible = fields.Boolean(
         related='company_id.code_visible')
+    
     economic_activity_id = fields.Many2one(
         "economic.activity",
         ondelete="cascade",
@@ -128,6 +134,18 @@ class AccountRetentionLine(models.Model):
     foreign_iva_amount = fields.Float(string="Foreign IVA")
     foreign_retention_amount = fields.Float()
     foreign_currency_rate = fields.Float(string="Rate")
+
+    @api.depends("payment_concept_id")
+    def _compute_code(self):
+        for rec in self:
+            if rec.retention_id.partner_id and rec.payment_concept_id:
+                codes = rec.payment_concept_id.line_payment_concept_ids.filtered(
+                    lambda l: l.type_person_id == rec.retention_id.partner_id.type_person_id
+                ).mapped('code')
+
+                rec.code = codes[0] if codes else ''
+            else:
+                rec.code = ''
 
 
     @api.onchange("move_id")
@@ -196,6 +214,8 @@ class AccountRetentionLine(models.Model):
                     
                 break
 
+
+   
 
     @api.depends("retention_id.type_retention", "move_id")
     def _compute_name(self):


### PR DESCRIPTION
FIX #9875: l10n_ve_payment_extension, account_retention_line.py

-Se corrio el campo 'code' en lineas de retencion el mismo siempre obtenia el mismo codigo para cada linea de retencion en base a los conceptos de pago, se cambio el campo depend a un campo computado almacenado.

Tarea (Link):https://binaural.odoo.com/web#cids=2&menu_id=293&action=393&active_id=58&model=helpdesk.ticket&view_type=form&id=9875

Tarea de proyecto []
Ticket de soporte [x]

