### PR TITLE
FIX #59950: l10n_ve_stock

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "1.0",
+    "version": "1.2",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -83,7 +83,6 @@ class StockPicking(models.Model):
 
     is_dispatch_guide = fields.Boolean(
         string="Is Dispatch Guide",
-        default=True,
         tracking=True,
         store=True,
         compute="_compute_is_dispatch_guide",


### PR DESCRIPTION
Problema:
-Al realizar una orden de venta la cuál tiene como tipo de documento "factura", en el stock.picking se colocaba como true el campo es guía de despacho (is_dispatch_guide).

Solución:
-Se elimina el default=True en los paramétros del campo. Tarea (Link):
https://binaural.odoo.com/web#id=59950&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []