### PR TITLE
[FIX] l10n_ve_invoice: Secuencias de correlativos

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "1.3",
+    "version": "1.4.0",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -226,7 +226,7 @@ class AccountMove(models.Model):
 
             if not correlative:
                 raise UserError(_("The sale's series sequence must be in the selected journal."))
-            return correlative.next_by_id(correlative.id)
+            return correlative.next_by_id()
 
         correlative = sequence.search(
             [("code", "=", "invoice.correlative"), ("company_id", "=", self.env.company.id)]
@@ -239,7 +239,7 @@ class AccountMove(models.Model):
                     "padding": 5,
                 }
             )
-        return correlative.next_by_id(correlative.id)
+        return correlative.next_by_id()
 
 
     def action_debit_note_button(self):


### PR DESCRIPTION
Al momento de usar secuencias para los correlativos que tengan la opción "Use subsecuencias por date_range" ocurría un fallo, ya que se estaba llamando de forma incorrecta el método next_by_id del modelo ir.sequence en el método get_sequence del modelo account.move en el módulo l10n_ve_invoice.

El método next_by_id recibe como parámetro una fecha, sin embargo se está mandando a llamar con el id de la secuencia, lo cual ocasiona el fallo al momento de intentar acceder al id como si fuera una fecha.

(ref: https://github.com/odoo/odoo/blob/3557de4232ebc307c8861379f6573d7b36cd8db6/odoo/addons/base/models/ir_sequence.py#L267C9-L267C19)