### PR TITLE
[IMP]Se añade al compute_price_unit la dependencia de currency_id

### DIFF
--- a/l10n_ve_sale/models/sale_order_line.py
+++ b/l10n_ve_sale/models/sale_order_line.py
@@ -30,6 +30,40 @@ class SaleOrderLine(models.Model):
 
     invoiced = fields.Boolean(compute="_compute_invoiced", store=True, copy=False)
 
+    # override
+    @api.depends("product_id", "product_uom_id", "product_uom_qty","order_id.currency_id")
+    def _compute_price_unit(self):
+        def has_manual_price(line):
+            # `line.currency_id` can be False for NewId records
+            currency = (
+                line.currency_id or
+                line.order_id.currency_id
+                or line.company_id.currency_id
+                or line.env.company.currency_id
+            )
+            return currency.compare_amounts(line.technical_price_unit, line.price_unit)
+
+        force_recompute = self.env.context.get('force_price_recomputation')
+        for line in self:
+            # Don't compute the price for deleted lines or lines for which the
+            # price unit doesn't come from the product.
+            if not line.order_id or line.is_downpayment or line._is_global_discount():
+                continue
+
+            # check if the price has been manually set or there is already invoiced amount.
+            # if so, the price shouldn't change as it might have been manually edited.
+            if (
+                (not force_recompute and has_manual_price(line))
+                or line.qty_invoiced > 0
+                or (line.product_id.expense_policy == 'cost' and line.is_expense)
+            ):
+                continue
+            line = line.with_context(sale_write_from_compute=True)
+            if not line.product_uom_id or not line.product_id:
+                line.price_unit = 0.0
+                line.technical_price_unit = 0.0
+            else:
+                line._reset_price_unit()
     @api.depends("invoice_lines.move_id.state", "invoice_lines.quantity")
     def _compute_invoiced(self):
         for line in self:


### PR DESCRIPTION
Se añade al depends el currency_id para lograr hacer que cuando cambia la moneda de la orden este recalcule automaticamente los precios de las lineas.