### PR TITLE
[IMP]Comentado invisible,y onchange que cambia el valor del pago actu…

### DIFF
--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -54,8 +54,6 @@ class AccountPaymentRegister(models.TransientModel):
             payment.foreign_inverse_rate = Rate.compute_inverse_rate(
                 payment.foreign_rate
             )
-            total_amount_residual_in_wizard_currency = 0
-            payment.amount = total_amount_residual_in_wizard_currency
 
     @api.onchange("payment_date")
     def _onchange_invoice_date(self):

--- a/l10n_ve_payment_extension/wizard/account_payment_register.xml
+++ b/l10n_ve_payment_extension/wizard/account_payment_register.xml
@@ -60,6 +60,9 @@
                         </page>
                     </notebook>
                 </group>
+                <!-- <group name="group2" position="attributes"> -->
+                <!--     <attribute name="invisible">not edit_retention_fields or payment_difference == 0.0 or not can_edit_wizard or can_group_payments and not group_payment</attribute> -->
+                <!-- </group> -->
             </field>
         </record>
     </data>


### PR DESCRIPTION
…al a 0

La vista de account_payment_register hacia que se volvieran invisible por lo tanto se comenta por ahora.
Se elimina en el onchange la asignacion al amount.