### PR TITLE
FEAT #59983: l10n_ve_accountant && l10n_ve_stock_account

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.0",
+    "version": "1.7",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -58,6 +58,13 @@ class AccountMove(models.Model):
         index=True,
     )
 
+    move_currency_to_company_currency_rate = fields.Float(
+        string="Move Currency to Company Currency Rate",
+        compute="_compute_move_currency_to_company_currency_rate",
+        copy=False,
+        help="The conversion rate between the move currency and the company currency at the move date.",
+    )
+
     manually_set_rate = fields.Boolean(default=False)
     last_foreign_rate = fields.Float(copy=False)
 
@@ -121,6 +128,26 @@ class AccountMove(models.Model):
     def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
         context = self.with_context(active_test=False)
         return super(AccountMove, context).search_read(domain, fields, offset, limit, order)
+    
+    @api.depends('currency_id', 'invoice_date')
+    def _compute_move_currency_to_company_currency_rate(self):
+        '''
+        Compute the move currency to company currency rate'''
+        for move in self:
+            if move.currency_id == move.company_currency_id:
+                move.move_currency_to_company_currency_rate = move.currency_id._get_conversion_rate(
+                    from_currency=move.foreign_currency_id,
+                    to_currency=move.company_currency_id,
+                    company=move.company_id,
+                    date=move._get_invoice_currency_rate_date(),
+                )
+            else:
+                move.move_currency_to_company_currency_rate = move.currency_id._get_conversion_rate(
+                    from_currency=move.currency_id,
+                    to_currency=move.company_currency_id,
+                    company=move.company_id,
+                    date=move._get_invoice_currency_rate_date(),
+                )
 
     @api.depends("line_ids.foreign_debit", "line_ids.foreign_credit")
     def _compute_total_debit_credit(self):
@@ -317,21 +344,12 @@ class AccountMove(models.Model):
         computes the foreign debit and foreign credit of the line_ids fields (journal entries) when
         the move is edited.
         """
-        if "name" in vals and vals["name"] != "/" and vals["name"]:
-            for move in self:
-                partner_id = vals.get('partner_id', move.partner_id.id)
-                
-                domain = [
-                    ('name', '=', vals['name']),
-                    ('partner_id', '=', partner_id),
-                    ('id', '!=', move.id) 
-                ]
-                
-                existing_record = self.search(domain, limit=1)
-                
-                if existing_record:
-                    raise ValidationError(_("The operation cannot be completed: Another entry with the same name already exists."))
-                
+        # move_currency_to_company_currency_rate = vals.get('move_currency_to_company_currency_rate', False)
+        # if move_currency_to_company_currency_rate:
+        #     for move in self:
+        #         vals.update({"last_foreign_rate": move.foreign_rate})
+        #         vals.update({"foreign_rate": move_currency_to_company_currency_rate})
+        #A REALIZAR PARA INTEGRA FLEXIBLE
         if vals.get("foreign_rate", False):
             for move in self:
                 vals.update({"last_foreign_rate": move.foreign_rate})

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -73,39 +73,6 @@
                 <field name="vat"
                     invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')" />
             </xpath>
-            <xpath expr="//notebook" position="inside">
-                <page string="Foreign currency" name="foreign_currency">
-                    <group>
-                        <field name="foreign_currency_id" invisible='1' />
-                        <field name="manually_set_rate" invisible="1" />
-                        <field
-                            name="foreign_inverse_rate"
-                            invisible="1"
-                            string="Foreign inverse rate"
-                        />
-                        <t groups="base.group_no_one">
-                            <field name="foreign_inverse_rate" invisible="1" />
-                        </t>
-                        <field name="foreign_rate" readonly="1" />
-                    </group>
-                    <group colspan="4">
-                        <group class="oe_subtotal_footer oe_right"
-                            invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') or payment_state == 'invoicing_legacy'">
-                            <field name="tax_totals"
-                                widget="account-tax-foreign-totals-field"
-                                nolabel="1"
-                                colspan="2"
-                                readonly="state != 'draft' or (move_type not in ('in_invoice', 'in_refund') and not quick_edit_mode)" />
-                            <field name="invoice_payments_widget" colspan="2" nolabel="1"
-                                widget="payment" />
-                            <field name="invoice_outstanding_credits_debits_widget"
-                                class="oe_invoice_outstanding_credits_debits"
-                                colspan="2" nolabel="1" widget="payment"
-                                invisible="state != 'posted'" />
-                        </group>
-                    </group>
-                </page>
-            </xpath>
             <xpath expr="//page/field[@name='invoice_line_ids']/list/field[@name='price_unit']"
                 position="after">
                 <field name="foreign_price" readonly="move_type != 'in_invoice'" optional="hide"/>

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -10,6 +10,44 @@
                     Warning: This account move has a foreign balance of <field
                         name="foreign_balance" />. </div> -->
             </xpath>
+            <xpath expr="//div[@class='d-flex gap-1 text-muted'][1]" position="after">
+            <!-- TODO REGRESAR A REPLACE Y CAMBIAR EL XPR A //div[@class='w-100'][1] descomentar el codigo de abajo.
+            ESTO CUANDO CULMINEN LAS PRUEBAS DE LA GIRALDA
+             -->
+                <div name="currency_div"
+                 groups="base.group_multi_currency"
+                 class="w-100"
+                 invisible="move_type == 'entry'">
+                    <div class="d-flex gap-1">
+                        <!-- <field name="currency_id"
+                               readonly="state != 'draft'"
+                               class="oe_inline"
+                               options="{'no_create': True}"
+                               context="{'search_default_active': 1, 'search_default_inactive': 1}"/> -->
+                    </div>
+                    <div name="currency_conversion_div"
+                         class="d-flex gap-1 text-muted"
+                         invisible="currency_id == company_currency_id">
+                        <span>1</span>
+                        <field name="currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
+                        <span>=</span>
+                        <field name="move_currency_to_company_currency_rate" digits="[12,6]" readonly="True"/>
+                        <field name="company_currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
+                    </div>
+                    <div name="currency_conversion_div_foreign"
+                         class="d-flex gap-1 text-muted"
+                         invisible="currency_id != company_currency_id">
+                        <span>1</span>
+                        <field name="foreign_currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
+                        <span>=</span>
+                        <field name="move_currency_to_company_currency_rate" digits="[12,6]" readonly="True"/>
+                        <field name="company_currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
+                    </div>
+                </div>
+            </xpath>
+            <xpath expr="//span[@class='o_form_label'][1]/field[1]" position="attributes">
+                <attribute name='invisible'>True</attribute>     
+            </xpath>
             <xpath expr="//header/button[@name='button_cancel']" position="after">
                 <button name="action_update_account_id" string="Update account lines" type="object"
                     groups="base.group_no_one" />
@@ -70,12 +108,12 @@
             </xpath>
             <xpath expr="//page/field[@name='invoice_line_ids']/list/field[@name='price_unit']"
                 position="after">
-                <field name="foreign_price" readonly="move_type != 'in_invoice'" />
+                <field name="foreign_price" readonly="move_type != 'in_invoice'" optional="hide"/>
             </xpath>
             <xpath expr="//page/field[@name='invoice_line_ids']/list/field[@name='price_subtotal']"
                 position="after">
                 <field name="foreign_currency_id" column_invisible="True" />
-                <field name="foreign_subtotal"
+                <field name="foreign_subtotal" optional='hide'
                 />
                 <field name="foreign_price_total"
                     column_invisible="parent.tax_calculation_rounding_method == 'round_globally'" />

--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "1.0",
+    "version": "1.3",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/views/account_move_views.xml
+++ b/l10n_ve_stock_account/views/account_move_views.xml
@@ -29,7 +29,7 @@
             </xpath>
 
             <xpath expr="//page[@id='invoice_tab'][1]/field[1]/list[1]/field[1]" position="before">
-                <field name="from_picking_line" readonly="1" invisible="1"/>
+                <field name="from_picking_line" readonly="1" invisible="1" optional="hide"/>
             </xpath>
 
             <xpath expr="//page[@id='invoice_tab'][1]/field[1]/list[1]/field[@name='quantity']"


### PR DESCRIPTION
Problema:
-1. Ocultar la pestaña de moneda alterna para todos los usuarios

2. A nivel de tasa que se observe la información del campo: VEF por unidad y no la inversa

2.1. Cuando sea la moneda base VEF, la moneda seleccionada mostrar la tasa alterna según la confuguración de la moneda alterna

3. Oculto por defecto y opcional para mostrar el campo 'Desde el picking..'

3. Oculto por defecto y opcional para mostrar 'Precio alterno' y 'Subtotal alterno'

Solución:
-Se de la vista view_account_move_form_l10n_ve_accountant, el page "Foreign Currency". -Se crea el campo computado move_currency_to_company_currency_rate. -Se agrega la función computada, _compute_move_currency_to_company_currency_rate, la cual extrae la tasa de conversión a mostrar en la factura, dependiendo de la moneda de esta, si es igual a la de la compañía, va a mostrar la tasa de cambio de cuantos bs es una unidad de la moneda foranea, si es cualquier otra moneda, entonces muestra cuantos bs representa la unidad de la moneda seleccionada en la vista. -Se les agrega el atributo optional='hide' a los campos foreign_price, foreign_subtotal y from_picking_line. Para que estos no se muestren por defecto en la vista list. Tarea (Link):
http://localhost/odoo/customer-invoices/346?debug=1

Tarea de proyecto [x]
Ticket de soporte []