### PR TITLE
FIX l10n_ve_payment_extension # 9932

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.23",
+    "version": "17.0.0.0.24",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/i18n/es_VE.po
+++ b/l10n_ve_payment_extension/i18n/es_VE.po
@@ -58,11 +58,6 @@ msgid "'Comprobante_ARCV'"
 msgstr "'Comprobante ARCV'"
 
 #. module: l10n_ve_payment_extension
-#: model:ir.actions.report,print_report_name:l10n_ve_payment_extension.retention_voucher_action
-msgid "(object.number)"
-msgstr "(número del objeto)"
-
-#. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid "/ Mes:"
 msgstr "/ Mes:"


### PR DESCRIPTION
Problema: el nombre del archivo se modifica por la traduccion e impide el funcionamiento correcto del mismo

Solucion: corregir traduccion

tarea: https://binaural.odoo.com/web#cids=2&menu_id=293&action=393&active_id=58&model=helpdesk.ticket&view_type=form&id=9932