### PR TITLE
stg_ti_fix_9820_l10n_ve_pos_mf

### DIFF
--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
-    "version": "17.0.1.0.3",
+    "version": "17.0.1.0.4",
     "category": "Accounting",
     "summary": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
     "description": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",

--- a/l10n_ve_pos_mf/static/src/js/Navbar.js
+++ b/l10n_ve_pos_mf/static/src/js/Navbar.js
@@ -2,6 +2,7 @@
 
 import { Navbar } from "@point_of_sale/app/navbar/navbar";
 import { patch } from "@web/core/utils/patch";
+import { Gui } from "point_of_sale.Gui";
 
 patch(Navbar.prototype, {
   async _on_click_mf_test() {
@@ -16,7 +17,7 @@ patch(Navbar.prototype, {
 
       }
     } catch (e) {
-      this.showPopup("ErrorPopup", {
+      Gui.showPopup("ErrorPopup", {
         title: "No se ha podido conectar a la Maquina fiscal",
       });
     }
@@ -28,6 +29,6 @@ patch(Navbar.prototype, {
     return this.pos.config.access_button_mf
   },
   async showFiscalMachinePopup() {
-    await this.showPopup('FiscalMachinePopup');
+    await Gui.showPopup('FiscalMachinePopup');
   }
 })


### PR DESCRIPTION
FIx9820 l10n_ve_pos_mf
Error al reiniciar la computadora de la caja 1 se desconecta la maquina fiscal y se debe siempre reiniciar la IOT Problema:Siempre que se reinicia la computadora donde esta la caja 1  se desconecta la impresora fiscal y tienen que reiniciar el IOT , aparece un error de Showup en _on_click_mf_test Solucion:Usar Gui e importar
Link:https://binaural.odoo.com/web#id=9820&cids=2&menu_id=293&action=393&active_id=3&model=helpdesk.ticket&view_type=form