### PR TITLE
FIX #59698: l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "1.3",
+    "version": "1.6",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -872,15 +872,23 @@ class StockPicking(models.Model):
             raise_if_not_found=False,
         )
 
+        other_causes_reason =  self.env.ref(
+            "l10n_ve_stock_account.transfer_reason_other_causes",
+            raise_if_not_found=False,
+        )
+        
         for picking in self:
-            if (
+
+            picking.is_dispatch_guide = False if picking.is_dispatch_guide is None else picking.is_dispatch_guide
+            if picking.document == "invoice":
+                picking.is_dispatch_guide = False
+                continue
+
+            elif (
                 picking.transfer_reason_id
-                and picking.transfer_reason_id.id == consignment_reason.id
+                and picking.transfer_reason_id.id == consignment_reason.id or picking.transfer_reason_id.id == other_causes_reason.id
             ):
                 picking.is_dispatch_guide = True
-            else:
-                # This is necessary always should be return a value
-                picking.is_dispatch_guide = picking.is_dispatch_guide
 
     @api.depends(
         "is_donation", "is_dispatch_guide", "operation_code", "location_dest_id"
@@ -1002,12 +1010,13 @@ class StockPicking(models.Model):
             record.show_other_causes_transfer_reason = False
 
             if record.transfer_reason_id:
+
+                record.is_dispatch_guide = False if record.is_dispatch_guide is None else record.is_dispatch_guide
+
                 if record.transfer_reason_id.code == "other_causes":
                     record.show_other_causes_transfer_reason = True
                 if record.transfer_reason_id.code == "self_consumption":
                     record.is_dispatch_guide = False
-                else:
-                    record.is_dispatch_guide = True
 
     # === CONSTRAINT METHODS ===#
 

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -883,7 +883,9 @@ class StockPicking(models.Model):
             if picking.document == "invoice":
                 picking.is_dispatch_guide = False
                 continue
-
+            elif picking.document == "dispatch_guide":
+                picking.is_dispatch_guide = True
+                continue
             elif (
                 picking.transfer_reason_id
                 and picking.transfer_reason_id.id == consignment_reason.id or picking.transfer_reason_id.id == other_causes_reason.id


### PR DESCRIPTION
Problema:
-Al realizar una venta y confirmarla, el stock.picking que tiene esta marca que es una guía de despacho a pesar de que la orden de venta tiene como tipo de documento factura.

Solución:
-Se migran las funciones computadas _compute_is_dispatch_guide y _compute_show_other_causes_transfer_reason, las cuales en V17 ya tienen este bug solucionado.

Tarea (Link):
https://binaural.odoo.com/web#id=59698&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []