### PR TITLE
FEAT #60501: l10n_ve_igtf && l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "1.1",
+    "version": "1.3",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -187,14 +187,17 @@ class AccountMove(models.Model):
         return res
 
     def js_assign_outstanding_line(self, line_id):
+        _logger.info('entrando a l10 igtf')
         amount_residual = self.amount_residual
         res = super().js_assign_outstanding_line(line_id)
-        self.recalculate_bi_igtf(
-            line_id,
-            initial_residual=amount_residual
-            if not self.currency_id.is_zero(amount_residual)
-            else self.amount_residual,
-        )
+        lines = self.env["account.move.line"].browse(line_id)
+        if lines['move_id'].currency_id.id == self.env.ref('base.USD').id or lines['move_id'].payment_id.currency_id.id == self.env.ref('base.USD').id:
+            self.recalculate_bi_igtf(
+                line_id,
+                initial_residual=amount_residual
+                if not self.currency_id.is_zero(amount_residual)
+                else self.amount_residual,
+            )
         return res
 
     @api.depends("tax_totals")

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "1.2",
+    "version": "1.4",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_move.py
+++ b/l10n_ve_payment_extension/models/account_move.py
@@ -184,6 +184,11 @@ class AccountMoveRetention(models.Model):
             "foreign_inverse_rate": self.foreign_inverse_rate,
             "currency_id": self.env.user.company_id.currency_id.id,
         }
+        if 'subsidiary' in self.env.company._fields:
+                if self.env.company.subsidiary:
+                    payment_vals['account_analytic_id'] = self.account_analytic_id.id
+                else:
+                    payment_vals['account_analytic_id'] = False
         if type_retention == "islr":
             payment_vals["retention_line_ids"] = self.retention_islr_line_ids.filtered(
                 lambda rl: rl.state != "cancel"

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -552,6 +552,12 @@ class AccountRetention(models.Model):
             )
             payment_vals["payment_method_line_id"] = method_line.id
             payment_vals["payment_type"] = "outbound"
+            if 'subsidiary' in self.env.company._fields:
+                if self.env.company.subsidiary:
+                    payment_vals['account_analytic_id'] = line.move_id.account_analytic_id.id
+                else:
+                    payment_vals['account_analytic_id'] = False
+            
             payment_vals["foreign_rate"] = lines[0].foreign_currency_rate
             payment = Payment.create(payment_vals)
             payment.update(
@@ -604,6 +610,11 @@ class AccountRetention(models.Model):
             payment_vals["payment_method_line_id"] = method_line.id
             payment_vals["payment_type"] = "inbound"
             payment_vals["foreign_rate"] = lines[0].foreign_currency_rate
+            if 'subsidiary' in self.env.company._fields:
+                if self.env.company.subsidiary:
+                    payment_vals['account_analytic_id'] = line.move_id.account_analytic_id.id
+                else:
+                    payment_vals['account_analytic_id'] = False
             payment = Payment.create(payment_vals)
             payment.update(
                 {"foreign_inverse_rate": Rate.compute_inverse_rate(payment.foreign_rate)}

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -554,7 +554,7 @@ class AccountRetention(models.Model):
             payment_vals["payment_type"] = "outbound"
             if 'subsidiary' in self.env.company._fields:
                 if self.env.company.subsidiary:
-                    payment_vals['account_analytic_id'] = line.move_id.account_analytic_id.id
+                    payment_vals['account_analytic_id'] = lines[0].move_id.account_analytic_id.id
                 else:
                     payment_vals['account_analytic_id'] = False
             

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -612,7 +612,7 @@ class AccountRetention(models.Model):
             payment_vals["foreign_rate"] = lines[0].foreign_currency_rate
             if 'subsidiary' in self.env.company._fields:
                 if self.env.company.subsidiary:
-                    payment_vals['account_analytic_id'] = line.move_id.account_analytic_id.id
+                    payment_vals['account_analytic_id'] = lines[0].move_id.account_analytic_id.id
                 else:
                     payment_vals['account_analytic_id'] = False
             payment = Payment.create(payment_vals)


### PR DESCRIPTION
Problema:
-Al intentar crear una retención a través del check "genera retención de IVA?" en una factura de proveedor, para una sucursal, mostraba error de no poder reconciliar el pago de la retención con la factura. -Al generar una retención a través del check genera retención de IVA?, al asociar el pago de la retención, hacía que recomputara el bi_igtf de la factura.

Solución:
-En las funciones donde se generan los pagos de las retenciones, se agrega validación para evaluar si tienen sucursales activa en la compañía, en caso de ser afirmativo, se agrega en el campo account_analytic_id la misma que la factura en el pago.

-Se agrega validación en la función js_assign_outstanding_line, para evaluar antes de recalcular en bi_igtf, la moneda que tienen la línea que se va a reconciliar, en caso de ser diferente a dolar, no recalcular el bi_igtf de la factura.

Tarea (Link):
https://binaural.odoo.com/web#id=60501&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []