### PR TITLE
FIX #59698: l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -882,7 +882,9 @@ class StockPicking(models.Model):
             if picking.document == "invoice":
                 picking.is_dispatch_guide = False
                 continue
-
+            elif picking.document == "dispatch_guide":
+                picking.is_dispatch_guide = True
+                continue
             elif (
                 picking.transfer_reason_id
                 and picking.transfer_reason_id.id == consignment_reason.id or picking.transfer_reason_id.id == other_causes_reason.id

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -8,7 +8,6 @@ from datetime import date, datetime, timedelta
 
 _logger = logging.getLogger(__name__)
 
-
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -887,7 +887,10 @@ class StockPicking(models.Model):
                 continue
             elif (
                 picking.transfer_reason_id
-                and picking.transfer_reason_id.id == consignment_reason.id or picking.transfer_reason_id.id == other_causes_reason.id
+                and (
+                    picking.transfer_reason_id.id == consignment_reason.id
+                    or picking.transfer_reason_id.id == other_causes_reason.id
+                )
             ):
                 picking.is_dispatch_guide = True
 


### PR DESCRIPTION
Problema:
-El check de is_dispatch_guide no se marca como True cuando el tipo de documento es 'dispatch_guide'

Solución:
-Se agrega condicional para asignar true cuando el tipo de documento de la orden de venta se a "dispatch_guide"

Tarea (Link):
https://binaural.odoo.com/web#id=c&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []