### PR TITLE
17.0 fix ti #10014 stock picking does not send the payment term to invoice

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.1.14",
+    "version": "17.0.0.1.15",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -929,7 +929,10 @@ class StockPicking(models.Model):
                 continue
             elif (
                 picking.transfer_reason_id
-                and picking.transfer_reason_id.id == consignment_reason.id or picking.transfer_reason_id.id == other_causes_reason.id
+                and (
+                    picking.transfer_reason_id.id == consignment_reason.id
+                    or picking.transfer_reason_id.id == other_causes_reason.id
+                )
             ):
                 picking.is_dispatch_guide = True
 

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -217,6 +217,7 @@ class StockPicking(models.Model):
                             "transfer_ids": self,
                             "from_picking": True,
                             "fiscal_position_id": picking_id.sale_id.fiscal_position_id.id if picking_id.sale_id.fiscal_position_id else False,
+                            "invoice_payment_term_id": picking_id.sale_id.payment_term_id.id if picking_id.sale_id.payment_term_id else False,
                         }
                     )
                 else:

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -924,7 +924,9 @@ class StockPicking(models.Model):
             if picking.document == "invoice":
                 picking.is_dispatch_guide = False
                 continue
-
+            elif picking.document == "dispatch_guide":
+                picking.is_dispatch_guide = True
+                continue
             elif (
                 picking.transfer_reason_id
                 and picking.transfer_reason_id.id == consignment_reason.id or picking.transfer_reason_id.id == other_causes_reason.id


### PR DESCRIPTION
Problema:
-Al hacer una orden de venta que tenga como tipo de documento "dispatch_guide", cuando se le realiza la factura al stock_picking, no se envía el término de pago.

Solución:
-Se agrega invoice_payment_term_id en el diccionario del write al invoice que se crea en la función create_invoice.

Tarea (Link):
https://binaural.odoo.com/web#id=10014&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form

Tarea de proyecto [x]
Ticket de soporte []
