### PR TITLE
FEAT #60919: l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.15",
+    "version": "1.14",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0+e-20250806\n"
+"Project-Id-Version: Odoo Server 19.0+e-20251118\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-29 18:36+0000\n"
-"PO-Revision-Date: 2025-08-29 18:36+0000\n"
+"POT-Creation-Date: 2025-12-01 14:10+0000\n"
+"PO-Revision-Date: 2025-12-01 14:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -40,6 +40,16 @@ msgstr ""
 "<span class=\"o_form_label\" style=\"font-size: 14px; white-space: nowrap;\">\n"
 "                        Una vez confirmado, el sistema generará las secuencias y el documento no podrá ser editado posteriormente. \n"
 "                    </span>"
+
+#. module: l10n_ve_accountant
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_account_move_form_l10n_ve_accountant
+msgid "<span>1</span>"
+msgstr ""
+
+#. module: l10n_ve_accountant
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_account_move_form_l10n_ve_accountant
+msgid "<span>=</span>"
+msgstr ""
 
 #. module: l10n_ve_accountant
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.account_report_document
@@ -143,12 +153,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.report_account_invoices_details
 msgid "Amount in Currency"
 msgstr "Importe en moneda"
-
-#. module: l10n_ve_accountant
-#: model:ir.model.constraint,message:l10n_ve_accountant.constraint_account_move_unique_name
-#: model:ir.model.constraint,message:l10n_ve_accountant.constraint_account_move_unique_name_ve
-msgid "Another entry with the same name already exists."
-msgstr "Ya existe un asiento con el mismo nombre."
 
 #. module: l10n_ve_accountant
 #: model:ir.actions.report,name:l10n_ve_accountant.action_account_report
@@ -258,22 +262,22 @@ msgid "Configuraciones fiscales usuario"
 msgstr ""
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Configuration Taxes:"
 msgstr "Configuraciones Impuestos:"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Configuration Taxes: Non-Deductible"
 msgstr "Configuración Impuestos: No Deducibles"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Configuration Taxes: Taxes Sales/Purchase"
 msgstr "Configuración Impuestos: Ventas/Compras"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Configuration: Accountant Books"
 msgstr "Configuración: Libros Contables"
 
@@ -283,7 +287,7 @@ msgid "Contact"
 msgstr "Contacto"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Core Settings"
 msgstr "Configuración Principal"
 
@@ -291,6 +295,11 @@ msgstr "Configuración Principal"
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_company__country_id
 msgid "Country"
 msgstr "País"
+
+#. module: l10n_ve_accountant
+#: model:ir.model,website_form_label:l10n_ve_accountant.model_res_partner
+msgid "Create a Customer"
+msgstr "Crear un cliente"
 
 #. module: l10n_ve_accountant
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_invoices_details__create_uid
@@ -339,7 +348,7 @@ msgid "Date of issue:"
 msgstr "Fecha de emisión:"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Deductibility"
 msgstr "Deducibilidad"
 
@@ -372,15 +381,34 @@ msgid "Discount"
 msgstr "Descuento"
 
 #. module: l10n_ve_accountant
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_invoice_report__display_name
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_invoices_details__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move_line__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_partial_reconcile__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_payment__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_payment_register__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_payment_term__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_tax__display_name
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_move_action_post_alert_wizard__display_name
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_payment_report__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_purchase_order_line__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_report_l10n_ve_accountant_account_related_report_call__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_report_l10n_ve_accountant_account_report_call__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_report_l10n_ve_accountant_financial_all_payments__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_report_l10n_ve_accountant_report_account_invoices_details__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_currency__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_partner__display_name
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_sale_order_line__display_name
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_tax_unit__display_name
 msgid "Display Name"
-msgstr "Nombre"
+msgstr "Nombre en pantalla"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Display Options"
 msgstr ""
 
@@ -400,12 +428,12 @@ msgid "Elaborado por:"
 msgstr ""
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Enable Non-Deductible Taxes"
 msgstr "Habilitar impuestos no deducibles"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Enable discount column visibility on invoice lines"
 msgstr "Habilitar visibilidad de la columna de descuento en líneas de factura"
 
@@ -415,7 +443,7 @@ msgid "End Date"
 msgstr "Fecha de fin"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Exempt Aliquot"
 msgstr "Alícuota exenta"
 
@@ -444,7 +472,7 @@ msgid "Extend Aliquot Sale"
 msgstr "Alícuota extendida ventas"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Extended Aliquot"
 msgstr "Alícuota extendida"
 
@@ -648,7 +676,7 @@ msgid "From"
 msgstr "Desde"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "General Aliquot"
 msgstr "Alícuota general"
 
@@ -675,19 +703,38 @@ msgid "Hasta:"
 msgstr ""
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Hide Extended Aliquot"
 msgstr "Ocultar alícuota extendida"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Hide Reduced Aliquot"
 msgstr "Ocultar alícuota reducida"
 
 #. module: l10n_ve_accountant
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_invoice_report__id
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_invoices_details__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move_line__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_partial_reconcile__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_payment__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_payment_register__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_payment_term__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_tax__id
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_move_action_post_alert_wizard__id
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_payment_report__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_purchase_order_line__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_report_l10n_ve_accountant_account_related_report_call__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_report_l10n_ve_accountant_account_report_call__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_report_l10n_ve_accountant_financial_all_payments__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_report_l10n_ve_accountant_report_account_invoices_details__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_currency__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_res_partner__id
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_sale_order_line__id
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_tax_unit__id
 msgid "ID"
 msgstr ""
@@ -785,6 +832,11 @@ msgid "Manually Set Rate"
 msgstr "Actualizar Tasa Manualmente"
 
 #. module: l10n_ve_accountant
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move_line__ves_currency_id
+msgid "Moneda VES"
+msgstr ""
+
+#. module: l10n_ve_accountant
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.financial_all_payments
 msgid "Monto"
 msgstr ""
@@ -798,6 +850,12 @@ msgstr "Movimiento"
 #: model:ir.model,name:l10n_ve_accountant.model_move_action_post_alert_wizard
 msgid "Move Action Post Alert"
 msgstr "Alerta al Postear Movimiento"
+
+#. module: l10n_ve_accountant
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__move_currency_to_company_currency_rate
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__move_currency_to_company_currency_rate
+msgid "Move Currency to Company Currency Rate"
+msgstr ""
 
 #. module: l10n_ve_accountant
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.report_account_invoices_details
@@ -829,12 +887,6 @@ msgstr "No Deducible Aliquota Reducida (Compra)"
 
 #. module: l10n_ve_accountant
 #. odoo-python
-#: code:addons/l10n_ve_accountant/models/account_tax.py:0
-msgid "No foreign currency configured in the company"
-msgstr "No hay moneda extranjera configurada en la empresa"
-
-#. module: l10n_ve_accountant
-#. odoo-python
 #: code:addons/l10n_ve_accountant/models/account_move.py:0
 msgid ""
 "No se ha confirmado la factura. Límite de crédito excedido. La cuenta por "
@@ -844,7 +896,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Non-Deductible Rates"
 msgstr "Tasas no deducibles"
 
@@ -955,7 +1007,7 @@ msgid "Proveedor"
 msgstr ""
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Purchase Book"
 msgstr "Libro de Compras"
 
@@ -965,7 +1017,7 @@ msgid "Purchase Order Line"
 msgstr "Línea de la orden de compra"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Purchase Tax Rates"
 msgstr "Tasas de Impuestos de Compras"
 
@@ -1009,7 +1061,7 @@ msgid "Recompute foreign debit and credit of journal entries"
 msgstr "Recalcular debito y credito alterno de apuntes contables"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Reduced Aliquot"
 msgstr "Alícuota Reducida"
 
@@ -1052,7 +1104,7 @@ msgid "Sale Details"
 msgstr "Detalle de ventas"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Sales Book"
 msgstr "Libro de Ventas"
 
@@ -1074,7 +1126,7 @@ msgid "Sales Report"
 msgstr "Informe de Ventas"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Sales Tax Rates"
 msgstr ""
 
@@ -1122,7 +1174,7 @@ msgstr "Calle"
 #. module: l10n_ve_accountant
 #. odoo-javascript
 #: code:addons/l10n_ve_accountant/static/src/components/tax_totals/tax_totals.xml:0
-msgid "Subtotal pinga"
+msgid "Subtotal"
 msgstr ""
 
 #. module: l10n_ve_accountant
@@ -1134,6 +1186,20 @@ msgstr "Usuario de Soporte (Diarios)"
 #: model:ir.ui.menu,name:l10n_ve_accountant.l10n_ve_account_support_views
 msgid "Support views"
 msgstr "Soporte"
+
+#. module: l10n_ve_accountant
+#: model:ir.model.fields,help:l10n_ve_accountant.field_account_bank_statement_line__company_currency_rate
+#: model:ir.model.fields,help:l10n_ve_accountant.field_account_move__company_currency_rate
+msgid ""
+"Tasa de la moneda seleccionada en la compañía (campo inverse_rate_company de"
+" res.currency)"
+msgstr ""
+
+#. module: l10n_ve_accountant
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__company_currency_rate
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__company_currency_rate
+msgid "Tasa de moneda de la compañía"
+msgstr ""
 
 #. module: l10n_ve_accountant
 #: model:ir.model,name:l10n_ve_accountant.model_account_tax
@@ -1152,7 +1218,7 @@ msgid "Tax Unit Description"
 msgstr "Descripción de Unidad Tributaria"
 
 #. module: l10n_ve_accountant
-#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_taxes
+#: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant
 msgid "Tax is mandatory on order and invoice lines, only one tax allowed"
 msgstr ""
 
@@ -1181,6 +1247,11 @@ msgid "Taxpayer Type"
 msgstr "Tipo de contribuyente"
 
 #. module: l10n_ve_accountant
+#: model:res.groups.privilege,name:l10n_ve_accountant.res_groups_privilege_category_hidden
+msgid "Technically"
+msgstr "Técnicamente"
+
+#. module: l10n_ve_accountant
 #: model:ir.model.fields,help:l10n_ve_accountant.field_res_company__vat
 #: model:ir.model.fields,help:l10n_ve_accountant.field_res_partner__vat
 #: model:ir.model.fields,help:l10n_ve_accountant.field_res_users__vat
@@ -1203,14 +1274,13 @@ msgstr ""
 "multimoneda."
 
 #. module: l10n_ve_accountant
-#. odoo-python
-#: code:addons/l10n_ve_accountant/models/account_move.py:0
+#: model:ir.model.fields,help:l10n_ve_accountant.field_account_bank_statement_line__move_currency_to_company_currency_rate
+#: model:ir.model.fields,help:l10n_ve_accountant.field_account_move__move_currency_to_company_currency_rate
 msgid ""
-"The operation cannot be completed: Another entry with the same name already "
-"exists."
+"The conversion rate between the move currency and the company currency at "
+"the move date."
 msgstr ""
-"La operación no se puede completar: Ya existe otro asiento con el mismo "
-"nombre."
+"La tasa de conversión entre la moneda del asiento y la moneda de la compañía en la fecha del asiento."
 
 #. module: l10n_ve_accountant
 #. odoo-python
@@ -1315,6 +1385,16 @@ msgid "Unique Tax"
 msgstr "Impuesto único"
 
 #. module: l10n_ve_accountant
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move_line__price_unit_ves
+msgid "Unit Price VES"
+msgstr "Precio unitario VES"
+
+#. module: l10n_ve_accountant
+#: model:ir.model.fields,help:l10n_ve_accountant.field_account_move_line__price_unit_ves
+msgid "Unit Price in VES currency"
+msgstr "Precio unitario en moneda VES"
+
+#. module: l10n_ve_accountant
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_account_move_form_l10n_ve_accountant
 msgid "Update account lines"
 msgstr "Actualizar Apuntes"
@@ -1365,12 +1445,6 @@ msgstr ""
 #: code:addons/l10n_ve_accountant/models/account_move.py:0
 msgid "You can only register payments for one foreign rate at a time."
 msgstr "Solo puedes registrar pagos para una tasa alterna a la vez."
-
-#. module: l10n_ve_accountant
-#. odoo-python
-#: code:addons/l10n_ve_accountant/models/account_move.py:0
-msgid "You cannot place a currency other than the base of the system."
-msgstr "No puede colocar una moneda que no sea la base del sistema."
 
 #. module: l10n_ve_accountant
 #. odoo-python
@@ -1425,6 +1499,12 @@ msgid "fecha"
 msgstr ""
 
 #. module: l10n_ve_accountant
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__foreign_untaxed_total
+#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__foreign_untaxed_total
+msgid "foreign untaxed total"
+msgstr "Total alterno sin impuestos"
+
+#. module: l10n_ve_accountant
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.account_report_document
 msgid "nombre"
 msgstr ""
@@ -1433,6 +1513,12 @@ msgstr ""
 #: model:ir.model,name:l10n_ve_accountant.model_payment_report
 msgid "payment.report"
 msgstr "Reporte de pagos"
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/account_move.py:0
+msgid "rate"
+msgstr "Tasa"
 
 #. module: l10n_ve_accountant
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.account_report_document
@@ -1463,8 +1549,3 @@ msgstr "Informe de Detalles de Facturas de Cuentas"
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.report_account_invoices_details
 msgid "to"
 msgstr "Hasta"
-
-#. module: l10n_ve_accountant
-#: model:ir.rule,name:l10n_ve_accountant.account_move_unlink_draft_only
-msgid "delete invoice if draft"
-msgstr "Eliminar factura si está en borrador"

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -204,6 +204,8 @@ class AccountMove(models.Model):
     foreign_balance = fields.Monetary(
         compute="_compute_total_debit_credit", currency_field="foreign_currency_id"
     )
+    foreign_untaxed_total = fields.Monetary(string="foreign untaxed total", currency_field="foreign_currency_id", store=True, 
+                                            compute='_compute_foreign_untaxed_total' )
     amount = fields.Float(tracking=True)
     @api.model
     def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
@@ -217,6 +219,23 @@ class AccountMove(models.Model):
         context = self.with_context(active_test=False)
         return super(AccountMove, context).search_read(domain, fields, offset, limit, order)
     
+    @api.depends('tax_totals')
+    def _compute_foreign_untaxed_total(self):
+        """
+        Compute the foreign total untaxed of the invoice using the tax_totals
+        """
+        for move in self:
+            move.foreign_untaxed_total = 0
+            if not (
+                move.invoice_line_ids
+                and move.is_invoice(include_receipts=True)
+                and move.tax_totals
+            ):
+                continue
+            move.foreign_untaxed_total = move.tax_totals.get(
+                "base_amount_foreign_currency", 0
+            )
+         
     @api.depends('currency_id', 'invoice_date')
     def _compute_move_currency_to_company_currency_rate(self):
         '''

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -200,6 +200,20 @@
             </xpath>
         </field>
     </record>
+    <record id="l10n_ve_accountant_view_invoice_tree_inherit" model="ir.ui.view">
+        <field name="name">account.move.list.inherit.l10n_ve_accountant</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_invoice_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list/field[@name='amount_total_in_currency_signed']" position="before">
+                <field name="foreign_currency_id" column_invisible="True"/>
+                <field name="amount_total_signed" optional="hide"/>
+                <field name="amount_untaxed_signed" optional="hide"/>
+                <field name="foreign_total_billed" widget="monetary" optional="hide"/>
+                <field name="foreign_untaxed_total" widget="monetary" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
     <!-- <record id="view_invoice_tree" model="ir.ui.view">
         <field name="name">account.move.list</field>
         <field name="model">account.move</field>


### PR DESCRIPTION
Problema:
-Se requiere mostrar campos para total con y sin impuestos en BS y en USD.

Solución:
-Se agregan en la vista los campos amount_total_signed, amount_untaxed_signed que muestran los Bs en la vista. -Se agregan foreign_total_billed y foreign_untaxed_total que muestran los totales en USD. Tarea (Link):
https://binaural.odoo.com/web#id=60919&cids=2&menu_id=975&action=341&model=project.task&view_type=form Tarea de proyecto [x]
Ticket de soporte []