### PR TITLE
17.0 feat ta 59633 mandatory contact in asset receivable or liability payable accounts

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.0.14",
+    "version": "17.0.0.0.15",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -4,16 +4,29 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250821\n"
+"Project-Id-Version: Odoo Server 17.0+e-20251118\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-05 13:26+0000\n"
-"PO-Revision-Date: 2025-09-05 13:26+0000\n"
+"POT-Creation-Date: 2025-12-02 15:48+0000\n"
+"PO-Revision-Date: 2025-12-02 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+#, python-format
+msgid ""
+"\n"
+"                        <div>\n"
+"                            <ul>%s</ul>\n"
+"                        </div>\n"
+"                        "
+msgstr ""
 
 #. module: l10n_ve_invoice
 #: model:ir.actions.report,print_report_name:l10n_ve_invoice.action_invoice_free_form_l10n_ve_invoice
@@ -202,12 +215,14 @@ msgstr "Asistente para agregar nota de débito"
 #. module: l10n_ve_invoice
 #. odoo-python
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "An invoice already exists with the Control Number: %s"
 msgstr "Ya existe una factura con el Número de Control: %s"
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "An invoice cannot have a line with a price of zero"
@@ -232,6 +247,8 @@ msgstr "Libro de Compras"
 #. odoo-python
 #: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
 #: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
+#: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
+#: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
 #, python-format
 msgid "Check the move %s does not have an invoice date and its id is %s"
 msgstr "Verifique el asiento %s no tiene una fecha de factura"
@@ -239,7 +256,7 @@ msgstr "Verifique el asiento %s no tiene una fecha de factura"
 #. module: l10n_ve_invoice
 #: model:ir.model,name:l10n_ve_invoice.model_res_company
 msgid "Companies"
-msgstr "Compañías"
+msgstr "Empresas"
 
 #. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_wizard_accounting_reports__company_id
@@ -249,7 +266,7 @@ msgstr "Compañía"
 #. module: l10n_ve_invoice
 #: model:ir.model,name:l10n_ve_invoice.model_res_config_settings
 msgid "Config Settings"
-msgstr "Opciones de configuración"
+msgstr "Ajustes de configuración"
 
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_res_config_settings_l10n_ve_invoice
@@ -258,6 +275,7 @@ msgstr "Configuración de Facturación: General"
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid ""
@@ -425,6 +443,11 @@ msgid "Journal Entry"
 msgstr "Asiento contable"
 
 #. module: l10n_ve_invoice
+#: model:ir.model,name:l10n_ve_invoice.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
+
+#. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__last_payment_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__last_payment_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_payment__last_payment_date
@@ -449,6 +472,12 @@ msgid ""
 msgstr ""
 "Limitar la cantidad de líneas que se pueden imprimir en una factura\n"
 "forma libre"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_res_company__mandatory_contact_in_payable_or_receivable_accounting_accounts
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_res_config_settings__mandatory_contact_in_payable_or_receivable_accounting_accounts
+msgid "Mandatory Contact In Payable Or Receivable Accounting Accounts"
+msgstr "Contacto obligatorio en cuentas por pagar o por cobrar"
 
 #. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_res_company__max_product_invoice
@@ -482,6 +511,11 @@ msgstr "Advertencia: la fecha de la factura es anterior a la actual"
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_account_move_form_l10n_ve_invoice
 msgid "Nro de Pedido"
 msgstr ""
+
+#. module: l10n_ve_invoice
+#: model:ir.model,name:l10n_ve_invoice.model_account_payment
+msgid "Payments"
+msgstr "Pagos"
 
 #. module: l10n_ve_invoice
 #: model:ir.actions.act_window,name:l10n_ve_invoice.action_accounting_report_purchase
@@ -567,12 +601,14 @@ msgstr "Mostrar total en USD en forma libre"
 #. module: l10n_ve_invoice
 #. odoo-python
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "The accounting date cannot be earlier than the invoice date."
 msgstr "La fecha contable no puede ser anterior a la fecha de la factura."
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid ""
@@ -583,6 +619,38 @@ msgstr ""
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move_line.py:0
+#: code:addons/l10n_ve_invoice/models/account_move_line.py:0
+#, python-format
+msgid ""
+"The partner field is mandatory for accounting entries with payable or "
+"receivable accounts."
+msgstr ""
+"El campo de contacto es obligatorio para los asientos contables con cuentas "
+"por pagar o por cobrar."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_payment.py:0
+#, python-format
+msgid "The partner field is mandatory for advance payments"
+msgstr "El campo de contacto es obligatorio para los anticipos."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_payment.py:0
+#: code:addons/l10n_ve_invoice/models/account_payment.py:0
+#, python-format
+msgid ""
+"The partner field is mandatory for payments with payable or receivable "
+"accounts."
+msgstr ""
+"El campo de contacto es obligatorio para los pagos con cuentas por pagar o "
+"por cobrar."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "The sale's series sequence must be in the selected journal."
@@ -600,12 +668,22 @@ msgid "Total en USD"
 msgstr ""
 
 #. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_res_config_settings_l10n_ve_invoice
+msgid ""
+"When activated, the contact field will be mandatory in payments and "
+"accounting entries with accounts payable or receivable."
+msgstr ""
+"Una vez activado, el campo de contacto será obligatorio en los pagos y en "
+"los asientos contables con cuentas por pagar o por cobrar."
+
+#. module: l10n_ve_invoice
 #: model:ir.model,name:l10n_ve_invoice.model_wizard_accounting_reports
 msgid "Wizard para generar reportes de libro de compra y ventas"
 msgstr ""
 
 #. module: l10n_ve_invoice
 #. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "You can not add more than %s products to the invoice."

--- a/l10n_ve_invoice/models/__init__.py
+++ b/l10n_ve_invoice/models/__init__.py
@@ -1,5 +1,7 @@
 from . import account_move
+from . import account_move_line
 from . import account_journal
+from . import account_payment
 from . import res_company
 from . import res_config_settings
 from . import account_debit_note

--- a/l10n_ve_invoice/models/account_move_line.py
+++ b/l10n_ve_invoice/models/account_move_line.py
@@ -1,0 +1,76 @@
+import logging
+
+from odoo import api, fields, models,_
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Create account move line records and validate partner assignment for payable or receivable accounts.
+        This method first verifies whether the company configuration requires a partner to be assigned
+        on lines associated with payable or receivable accounts. If the configuration is disabled,
+        records are created normally. Otherwise, the method proceeds with the creation and then checks
+        the resulting lines. If any line violates the partner requirement, a validation error is raised.
+        :param vals_list: List of dictionaries containing values for new move line records.
+        :return: The created recordset of account.move.line.
+        :raises ValidationError: If one or more payable/receivable lines are missing a partner.
+        """
+
+        if not self.env.company.mandatory_contact_in_payable_or_receivable_accounting_accounts:
+            return super().create(vals_list)
+
+        move_lines = super().create(vals_list)
+
+        if not move_lines._check_mandatory_partner_in_payable_or_receivable_accounts():
+            raise ValidationError(_('The partner field is mandatory for accounting entries with payable or receivable accounts.'))
+
+        return move_lines
+
+    def write(self, vals):
+        """
+        Update account move line records and enforce partner assignment when applicable.
+        After performing the standard write operation, this method validates whether any updated line
+        associated with payable or receivable accounts is missing a partner, but only if the company
+        has the mandatory configuration enabled. If validation fails, the change is reverted via
+        a raised ValidationError.
+        :param vals: A dictionary of values being written into the move line.
+        :return: Boolean indicating success of the write operation.
+        :raises ValidationError: If the update results in payable/receivable lines without a partner.
+        """
+
+        if not self.env.company.mandatory_contact_in_payable_or_receivable_accounting_accounts:
+            return super().write(vals)
+
+        res = super().write(vals)
+
+        if not self._check_mandatory_partner_in_payable_or_receivable_accounts():
+            raise ValidationError(_('The partner field is mandatory for accounting entries with payable or receivable accounts.'))
+
+        return res
+
+    def _check_mandatory_partner_in_payable_or_receivable_accounts(self):
+        """
+        Validate that all move lines with payable or receivable accounts include a partner.
+        This method applies only if the company setting `mandatory_contact_in_payable_or_receivable_accounting_accounts`
+        is enabled. It searches for move lines of type 'entry' that use accounts marked as
+        receivable or payable and checks whether any of those lines lack a partner assignment.
+        :return: True if all conditions are satisfied or the feature is disabled; False otherwise.
+        """
+
+        if not self.env.company.mandatory_contact_in_payable_or_receivable_accounting_accounts:
+            return True
+
+        if any(
+            not line.partner_id for line in self.filtered(
+                lambda l: l.move_id.move_type == 'entry' and l.account_id 
+                and l.account_id.account_type in ['asset_receivable','liability_payable']
+            )
+        ):
+            return False
+
+        return True

--- a/l10n_ve_invoice/models/account_payment.py
+++ b/l10n_ve_invoice/models/account_payment.py
@@ -1,0 +1,90 @@
+import logging
+
+from odoo import api, fields, models,_
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Create payment records and validate mandatory partner assignment where applicable.
+        If the company configuration requires that payable or receivable related records must
+        have a partner assigned, this method ensures the rule is enforced. The payments are created
+        first, and then validation is applied. If any resulting payment references a payable or
+        receivable account without an assigned partner, a ValidationError is raised.
+        :param vals_list: List of dictionaries containing values for the new payment records.
+        :return: The created recordset of account.payment.
+        :raises ValidationError: If any payable/receivable related payment lacks a partner.
+        """
+
+        if not self.env.company.mandatory_contact_in_payable_or_receivable_accounting_accounts:
+            return super().create(vals_list)
+
+        payments = super().create(vals_list)
+
+        if not self._check_mandatory_partner_in_payable_or_receivable_accounts():
+            raise ValidationError(_('The partner field is mandatory for payments with payable or receivable accounts.'))
+
+        return payments
+
+    def write(self, vals):
+        """
+        Update payment records and enforce mandatory partner validation when required.
+        After applying the write operation, this method checks whether the updated payment records
+        reference payable or receivable accounts and ensures a partner is assigned, provided the
+        company configuration enforces this requirement. If validation fails, a ValidationError
+        is raised, preventing the inconsistent modification.
+        :param vals: A dictionary of values being written to the payment records.
+        :return: Boolean indicating success of the write operation.
+        :raises ValidationError: If the update results in a payable/receivable payment without a partner.
+        """
+
+        if not self.env.company.mandatory_contact_in_payable_or_receivable_accounting_accounts:
+            return super().write(vals)
+
+        res = super().write(vals)
+
+        if not self._check_mandatory_partner_in_payable_or_receivable_accounts():
+            raise ValidationError(_('The partner field is mandatory for payments with payable or receivable accounts.'))
+
+        return res
+
+    def _check_mandatory_partner_in_payable_or_receivable_accounts(self):
+        """
+        Verify that payments associated with payable or receivable accounts have a partner assigned.
+        The validation applies only when the company configuration 
+        `mandatory_contact_in_payable_or_receivable_accounting_accounts` is enabled. The method
+        evaluates payments whose destination accounts are marked as receivable or payable, and
+        checks that the partner field is present.
+        :return: True if validation passes or the configuration is disabled; False otherwise.
+        """
+
+        if not self.env.company.mandatory_contact_in_payable_or_receivable_accounting_accounts:
+            return True
+
+        if any(
+            not payment.partner_id for payment in self.filtered(
+                lambda p: p.destination_account_id 
+                and p.destination_account_id.account_type in ['asset_receivable','liability_payable']
+            )
+        ):
+            return False
+
+        module_name = 'binaural_advance_payment'
+
+        module = self.env['ir.module.module'].sudo().search([('name', '=', module_name)], limit=1)
+
+        if module and module.state == 'installed':
+
+            if any(
+                not payment.partner_id for payment in self.filtered(
+                    lambda p: p.is_advance_payment
+                )
+            ):
+                raise ValidationError(_('The partner field is mandatory for advance payments'))
+
+        return True

--- a/l10n_ve_invoice/models/res_company.py
+++ b/l10n_ve_invoice/models/res_company.py
@@ -14,3 +14,4 @@ class ResCompany(models.Model):
     show_tag_on_usd_invoice = fields.Boolean(default=True)
     show_column_default_code_free_form = fields.Boolean(default=True)
     auto_select_debit_note_journal = fields.Boolean(default=False) 
+    mandatory_contact_in_payable_or_receivable_accounting_accounts = fields.Boolean()

--- a/l10n_ve_invoice/models/res_config_settings.py
+++ b/l10n_ve_invoice/models/res_config_settings.py
@@ -30,6 +30,11 @@ class ResConfigSettings(models.TransientModel):
         readonly=False
     )
 
+    mandatory_contact_in_payable_or_receivable_accounting_accounts = fields.Boolean(
+        related="company_id.mandatory_contact_in_payable_or_receivable_accounting_accounts",
+        readonly=False
+    )
+
     @api.onchange("group_sales_invoicing_series")
     def onchange_group_sales_invoicing_series(self):
         ir_sequence = self.env["ir.sequence"].sudo()

--- a/l10n_ve_invoice/views/res_config_settings.xml
+++ b/l10n_ve_invoice/views/res_config_settings.xml
@@ -18,6 +18,19 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-4 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="mandatory_contact_in_payable_or_receivable_accounting_accounts" class="oe_inline" required="1"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <group colspan="2" col="4">
+                                    <label for="mandatory_contact_in_payable_or_receivable_accounting_accounts"/>
+                                </group>
+                                <div class="text-muted">
+                                    When activated, the contact field will be mandatory in payments and accounting entries with accounts payable or receivable.
+                                 </div>
+                            </div>
+                        </div>
                         <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_invoice_div_show_tag_on_usd_invoice">
                             <div class="o_setting_left_pane">
                                 <field name="show_tag_on_usd_invoice" />


### PR DESCRIPTION
FEAT #59633: l10n_ve_invoice
Escenario: Crear configuración para activar el campo de contacto obligatorio al usar una cuenta contable tipo por cobrar/pagar

Solución:

Se agrega configuración para exigir partner en cuentas por pagar o por cobrar:

Se añade campo booleano en res.company para habilitar la validación.
Se expone la configuración en res.config.settings.
Se implementa validaciones en las funciones de create y write de los modelos
account.payment y account.move.line para asegurar que se asigne partner cuando
se usen cuentas de tipo receivable o payable (por cobrar o pagar).
Se agregan docstrings

Tarea (Link): https://binaural.odoo.com/web#id=59633&cids=2&menu_id=975&action=341&model=project.task&view_type=form
Tarea de proyecto [x]
Ticket de soporte []

FEAT #59985: binaural_invoice
Problema: Agregar al desarrollo de contacto obligatorio cuando la cuenta es por cobrar o pagar, la condición de Anticipo

Solución:

Se agrega condicion adicional al modelo account payment para que tambien tome en cuenta los anticipos (is_advance_payment)
Se retiran loggers usados anteriormente para debuggear solucion en staging de proalca

Tarea (Link): https://binaural.odoo.com/web#id=59985&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []