### PR TITLE
FEAT #61123: l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "1.4",
+    "version": "1.5",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_move.py
+++ b/l10n_ve_stock_account/models/stock_move.py
@@ -38,7 +38,7 @@ class StockMove(models.Model):
 
         quantity = self.quantity or 0.0
         discount = self.sale_line_id.discount or 0.0
-        tax = self.sale_line_id.tax_id.amount or 0.0
+        tax = self.sale_line_id.tax_ids.amount or 0.0
 
         subtotal = price_unit * quantity
 

--- a/l10n_ve_stock_account/report/dispatch_guide_template.xml
+++ b/l10n_ve_stock_account/report/dispatch_guide_template.xml
@@ -177,7 +177,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <t t-foreach="o.move_ids_without_package" t-as="line">
+                            <t t-foreach="o.move_ids" t-as="line">
                                 <t t-set="line_values"
                                     t-value="line._get_line_values(use_foreign_currency=o.get_foreign_currency_is_vef())" />
 


### PR DESCRIPTION
Problema:
-Se requiere migrar el formato de guía de despacho.

Solución:
-Se cambia la referencia de move_ids_without_package a move_ids en el template, ya que este campo no existe más. -En la función _get_line_values, se cambia la referencia al field tax_id del sale.order.line a tax_ids.

Tarea (Link):
https://binaural.odoo.com/web#id=61123&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []