### PR TITLE
FEAT #60501: l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "1.4",
+    "version": "1.5",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -919,7 +919,46 @@ class AccountRetention(models.Model):
         """
         for payment in self.mapped("payment_ids"):
             payment.action_post()
-            self._reconcile_payment(payment)
+            if payment.partner_type == "supplier":
+                self._reconcile_supplier_payment(payment)
+            if payment.partner_type == "customer":
+                self._reconcile_customer_payment(payment)
+
+
+    def _reconcile_supplier_payment(self, payment):
+
+        if payment.payment_type == "outbound":
+
+            lines = payment.move_id.line_ids.filtered(
+                lambda l: l.account_id.account_type == "liability_payable"
+                and l.debit > 0
+            )
+            if not lines:
+                raise ValidationError(
+                    _("No registered lines found in the move to reconcile.")
+                )
+            line_to_reconcile = lines[0]
+
+            payment.retention_line_ids.move_id.js_assign_outstanding_line(
+                line_to_reconcile.id
+            )
+
+        elif payment.payment_type == "inbound":
+
+            lines = payment.move_id.line_ids.filtered(
+                lambda l: l.account_id.account_type == "liability_payable"
+                and l.credit > 0
+            )
+            if not lines:
+                raise ValidationError(
+                    _("No registered lines found in the move to reconcile.")
+                )
+            line_to_reconcile = lines[0]
+
+            payment.retention_line_ids.move_id.js_assign_outstanding_line(
+                line_to_reconcile.id
+            )
+
 
     def get_amount_field_and_account_type(self, payment, is_payment_credit=False):
 

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -921,7 +921,7 @@ class AccountRetention(models.Model):
             payment.action_post()
             if payment.partner_type == "supplier":
                 self._reconcile_supplier_payment(payment)
-            if payment.partner_type == "customer":
+            elif payment.partner_type == "customer":
                 self._reconcile_customer_payment(payment)
 
 


### PR DESCRIPTION
Problema:
-Al intentar crear una retención, se generaba un error al intentar acceder a una función llamada _reconcile_payment.

Solución:
-Se traen las funciones estabilizadas en 17.0 para así resolver errores en el flujo.

Tarea (Link):
https://binaural.odoo.com/web#id=60501&cids=2&menu_id=975&action=341&model=project.task&view_type=form Tarea de proyecto [x]
Ticket de soporte []