### PR TITLE
FEAT #61158: l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.15",
+    "version": "1.18",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/data/account_data.xml
+++ b/l10n_ve_accountant/data/account_data.xml
@@ -8,17 +8,22 @@
             <field name="digits">2</field>
         </record>
 
-         <record forcecreate="True" id="alternative_rate" model="decimal.precision">
+        <record forcecreate="True" id="alternative_rate" model="decimal.precision">
             <field name="name">Tasa</field>
-            <field name="digits">2</field>
+            <field name="digits">6</field>
         </record>
 
-         <record forcecreate="True" id="alternative_price_product" model="decimal.precision">
+        <record forcecreate="True" id="alternative_price_product" model="decimal.precision">
             <field name="name">Foreign Product Price</field>
-            <field name="digits">2</field>
+            <field name="digits">6</field>
         </record>
-        
+
     </data>
     
-
+    <data noupdate="0">
+        <record id="product.decimal_price" model="decimal.precision">
+            <field name="name">Product Price</field>
+            <field name="digits">6</field>
+        </record>
+    </data>
 </odoo>


### PR DESCRIPTION
Problema:
-Se requiere cambiar la precisión decimal predefinida para Tasa, precio, y precio fóraneo.

Solución:

-Se modifica el digits de Tasa y Foreign Product Price.

-Se hereda de product, decimal_price para así realizar la modificación a los digits de este, se coloca el noupdate en 0 para que este reescriba el que odoo agrega al instalar el módulo de product.

Tarea (Link):
https://binaural.odoo.com/web#id=61158&cids=2&menu_id=975&action=341&model=project.task&view_type=form Tarea de proyecto [x]
Ticket de soporte []