### PR TITLE
FEAT #61865: l10n_ve_accountant & l10n_ve_payment_extension

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.18",
+    "version": "1.23",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -226,6 +226,7 @@ class AccountMoveLine(models.Model):
         "not_foreign_recalculate",
         "foreign_debit_adjustment",
         "foreign_credit_adjustment",
+        "foreign_inverse_rate",
     )
     def _compute_foreign_debit_credit(self):
         for line in self:
@@ -307,8 +308,22 @@ class AccountMoveLine(models.Model):
                     line.foreign_credit = abs(balance) if balance > 0 else 0.0
                     continue
 
-                line.foreign_debit = line.debit * line.foreign_inverse_rate
-                line.foreign_credit = line.credit * line.foreign_inverse_rate
+                if line.currency_id and line.currency_id != line.company_id.foreign_currency_id and line.currency_id != line.company_id.currency_id:
+                     line.foreign_debit = line.company_id.currency_id._convert(
+                         line.debit,
+                         line.company_id.foreign_currency_id,
+                         line.company_id,
+                         line.date or fields.Date.context_today(line)
+                     )
+                     line.foreign_credit = line.company_id.currency_id._convert(
+                         line.credit,
+                         line.company_id.foreign_currency_id,
+                         line.company_id,
+                         line.date or fields.Date.context_today(line)
+                     )
+                else:
+                    line.foreign_debit = line.debit * line.foreign_inverse_rate
+                    line.foreign_credit = line.credit * line.foreign_inverse_rate
                 continue
 
             if line.display_type == "product":

--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -37,7 +37,8 @@ class AccountPayment(models.Model):
             self.currency_id.id or self.env.ref("base.VEF").id,
             self.date or fields.Date.today(),
         )
-        return rate_values.get("foreign_rate", 0)
+        rate = rate_values.get("foreign_rate", 0)
+        return rate
 
     def default_inverse_rate(self):
         """
@@ -52,7 +53,8 @@ class AccountPayment(models.Model):
             self.currency_id.id or self.env.ref("base.VEF").id,
             self.date or fields.Date.today(),
         )
-        return rate_values.get("foreign_inverse_rate", 0)
+        rate = rate_values.get("foreign_inverse_rate", 0)
+        return rate
 
     foreign_rate = fields.Float(
         compute="_compute_rate",

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "1.5",
+    "version": "1.7",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_payment.py
+++ b/l10n_ve_payment_extension/models/account_payment.py
@@ -51,10 +51,8 @@ class AccountPayment(models.Model):
 
     @api.depends("date")
     def _compute_rate(self):
-        for payment in self:
-            if payment.is_retention and payment.foreign_rate:
-                continue
-            return super()._compute_rate()
+        to_compute = self.filtered(lambda p: not (p.is_retention and p.foreign_rate))
+        super(AccountPayment, to_compute)._compute_rate()
 
     def _synchronize_to_moves(self, changed_fields):
         """


### PR DESCRIPTION
Problema:
-Al hacer un pago en una moneda que no sea la principal o la foránea, los foreign_debit y foreign_credit se calculaban mal, mostraban el mismo valor que tenía el pago hecho. EJEMPLO: Pago en euros: 1.14
TASA:
280bs POR USD
320 POR EUR

En foreígn_debit o foreign_debit del asiento del pago según el caso, en vez de mostrar $1, mostraba el mismo $1.14 Solución:
En _compute_foreign_debit_credit
se agrega el flujo para cuando un pago no está en moneda principal ni secundaria, se hace uso del debit y credit (que ya odoo transformó a moneda principal) y se les hace convert para asignarlos así a foreign_credit o foreign_debit según corresponda.

En l10n_ve_payment_extension, se soluciona un bug que no permitía seguir la ejecución de _compute_rate en todos los pagos.

Tarea (Link):
https://binaural.odoo.com/web#id=61865&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []