### PR TITLE
FIX  Se encontron unos errores en price_list y en accountant

### DIFF
--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -30,7 +30,7 @@ class AccountPaymentRegister(models.TransientModel):
             The id of the foreign currency of the company
         """
         return self.env.company.foreign_currency_id.id or False
-    
+
     def default_alternate_rate_display_amount(self):
         """
         This method is used to get the foreign currency of the company and set it as the default
@@ -41,7 +41,22 @@ class AccountPaymentRegister(models.TransientModel):
         type = int
             The id of the foreign currency of the company
         """
-        return self.env.company.foreign_currency_id.inverse_company_rate or False
+        company = self.env.company
+        foreign_currency = company.foreign_currency_id
+
+        if not foreign_currency:
+            return 0.0
+
+        rate_record = self.env['res.currency.rate'].search([
+            ('currency_id', '=', foreign_currency.id),
+            ('company_id', '=', company.id),
+            ('name', '<=', fields.Date.today())
+        ], limit=1, order="name desc")
+
+        if rate_record:
+            return rate_record.inverse_company_rate
+
+        return 0.0
 
     foreign_currency_id = fields.Many2one(
         "res.currency", default=default_alternate_currency

--- a/l10n_ve_price_list/views/product_template_view.xml
+++ b/l10n_ve_price_list/views/product_template_view.xml
@@ -4,12 +4,18 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
         <field name="arch" type="xml">
+            <xpath expr="//sheet" position="inside">
+                <field name="can_view_list_price_uom" invisible="1"/>
+            </xpath>
+
             <xpath expr="//div[@name='list_price_uom']" position="attributes">
                 <attribute name="invisible">not can_view_list_price_uom</attribute>
             </xpath>
+
             <xpath expr="//field[@name='list_price']" position="attributes">
                 <attribute name="invisible">not can_view_list_price_uom</attribute>
             </xpath>
+
             <xpath expr="//label[@for='list_price']" position="attributes">
                 <attribute name="invisible">not can_view_list_price_uom</attribute>
             </xpath>


### PR DESCRIPTION
PROBLEMA:
Se presentaba un 'AttributeError: res.currency object has no attribute inverse_company_rate' en el wizard de registro de pagos. Esto ocurría porque en Odoo 19 el sistema es más estricto con el modelo res.currency, el cual no posee el campo mencionado (este reside en res.currency.rate)

SOLUCIÓN:
1. Se modificó el método 'default_alternate_rate_display_amount' en account_payment_register.py para obtener la tasa inversa buscando directamente en el modelo 'res.currency.rate'.
2. Se eliminaron atributos obsoletos 'attrs' en las vistas XML para compatibilidad con Odoo 19.

NOTA: No tiene tarea