### PR TITLE
[MIG]19.0  #62064 enhancements for cancel button out of fiscal period

### DIFF
--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -65,12 +65,12 @@ class AccountMove(models.Model):
                         move.entry_in_period = True
 
     def _get_period_limit(self, today, taxpayer_type):
-            """Returns the tax period deadline according to the taxpayer type."""
-            if taxpayer_type == "special":
-                if today.day < 15:
-                    return today.replace(day=15)
-            last_day = calendar.monthrange(today.year, today.month)[1]
-            return date(today.year, today.month, last_day)
+        """Returns the tax period deadline according to the taxpayer type."""
+        if taxpayer_type == "special":
+            if today.day < 15:
+                return today.replace(day=15)
+        last_day = calendar.monthrange(today.year, today.month)[1]
+        return date(today.year, today.month, last_day)
 
     @api.constrains("invoice_line_ids")
     def _check_price_in_zero(self):

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -37,7 +37,7 @@ class AccountMove(models.Model):
         compute="_compute_entry_in_period",
     )
 
-    @api.depends("invoice_date", "entry_in_period", "state")
+    @api.depends("invoice_date", "state")
     def _compute_entry_in_period(self):
         """Computing that allows determining whether a debit or credit note is within the current fiscal period."""
         today = date.today()

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date, timedelta
 import json
 import logging
 
@@ -32,6 +32,39 @@ class AccountMove(models.Model):
         compute="_compute_is_debit_journal",
         store=True
     )
+
+    entry_in_period = fields.Boolean(
+        compute="_compute_entry_in_period",
+    )
+
+    @api.depends("invoice_date", "entry_in_period", "state")
+    def _compute_entry_in_period(self):
+        """Computing that allows determining whether a debit or credit note is within the current fiscal period."""
+        today = date.today()
+        taxpayer_type = self.env.company.taxpayer_type
+        period_limit = self._get_period_limit(today, taxpayer_type)
+
+        for move in self:
+            move.entry_in_period = False
+
+            if move.state == "cancel":
+                continue
+
+            if move.move_type == "out_refund" or (move.move_type == "out_invoice" and move.debit_origin_id):
+                if (move.invoice_date.year, move.invoice_date.month) == (period_limit.year, period_limit.month) and move.invoice_date <= period_limit:
+                    if taxpayer_type == "special" and move.invoice_date.day < 15 < period_limit.day:
+                        move.entry_in_period = False
+                    else:
+                        move.entry_in_period = True
+
+    def _get_period_limit(self, today, taxpayer_type):
+            """Returns the tax period deadline according to the taxpayer type."""
+            if taxpayer_type == "special":
+                if today.day < 15:
+                    return today.replace(day=15)
+            last_day = date(today.year, today.month, 28) + timedelta(days=4)
+            return last_day - timedelta(days=1)
+
     @api.constrains("invoice_line_ids")
     def _check_price_in_zero(self):
         from_pos = self.env.context.get('from_pos', False)

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -1,7 +1,7 @@
 from datetime import datetime, date, timedelta
 import json
 import logging
-
+import calendar
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import format_date
@@ -62,8 +62,8 @@ class AccountMove(models.Model):
             if taxpayer_type == "special":
                 if today.day < 15:
                     return today.replace(day=15)
-            last_day = date(today.year, today.month, 28) + timedelta(days=4)
-            return last_day - timedelta(days=1)
+            last_day = calendar.monthrange(today.year, today.month)[1]
+            return date(today.year, today.month, last_day)
 
     @api.constrains("invoice_line_ids")
     def _check_price_in_zero(self):

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -50,7 +50,14 @@ class AccountMove(models.Model):
             if move.state == "cancel":
                 continue
 
-            if move.move_type == "out_refund" or (move.move_type == "out_invoice" and move.debit_origin_id):
+            if move.move_type in ("in_invoice", "in_refund", "in_receipt"):
+                move.entry_in_period = True
+                continue
+
+            if move.move_type in ("out_invoice", "out_refund"):
+                if not move.invoice_date:
+                    continue
+
                 if (move.invoice_date.year, move.invoice_date.month) == (period_limit.year, period_limit.month) and move.invoice_date <= period_limit:
                     if taxpayer_type == "special" and move.invoice_date.day < 15 < period_limit.day:
                         move.entry_in_period = False

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -39,7 +39,7 @@ class AccountMove(models.Model):
 
     @api.depends("invoice_date", "state")
     def _compute_entry_in_period(self):
-        """Computing that allows determining whether a debit or credit note is within the current fiscal period."""
+        """Computing that allows determining whether an account move (invoice, debit/credit note or receipt) is within the current fiscal period."""
         today = date.today()
         taxpayer_type = self.env.company.taxpayer_type
         period_limit = self._get_period_limit(today, taxpayer_type)

--- a/l10n_ve_invoice/tests/__init__.py
+++ b/l10n_ve_invoice/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_account_move
+from . import test_cancel_visibility

--- a/l10n_ve_invoice/tests/test_cancel_visibility.py
+++ b/l10n_ve_invoice/tests/test_cancel_visibility.py
@@ -1,0 +1,165 @@
+import datetime
+from unittest.mock import patch
+from odoo.tests import TransactionCase, tagged
+from odoo import fields, Command
+
+@tagged("post_install", "-at_install", "l10n_ve_invoice")
+class TestCancelVisibility(TransactionCase):
+
+    def setUp(self):
+        super(TestCancelVisibility, self).setUp()
+        self.company = self.env.user.company_id
+        # Ensure 'taxpayer_type' exists, otherwise likely added by this module
+        # Set default to ordinary
+        if 'taxpayer_type' in self.company._fields:
+            self.company.taxpayer_type = 'ordinary'
+        
+        # Setup Accounts with modern 'account_type' field (v15+)
+        self.account_receivable = self.env['account.account'].create({
+            'name': 'Receivable',
+            'code': '1111111',
+            'account_type': 'asset_receivable',
+            'reconcile': True,
+        })
+        self.account_payable = self.env['account.account'].create({
+            'name': 'Payable',
+            'code': '2222222',
+            'account_type': 'liability_payable',
+            'reconcile': True,
+        })
+        self.account_revenue = self.env['account.account'].create({
+            'name': 'Revenue',
+            'code': '4444444',
+            'account_type': 'income',
+        })
+        self.account_expense = self.env['account.account'].create({
+            'name': 'Expense',
+            'code': '5555555',
+            'account_type': 'expense',
+        })
+
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'property_account_receivable_id': self.account_receivable.id,
+            'property_account_payable_id': self.account_payable.id,
+        })
+        
+        self.currency = self.env.ref('base.VEF')
+        self.foreign_currency = self.env.ref('base.USD')
+        self.company.currency_id = self.currency
+        self.company.foreign_currency_id = self.foreign_currency
+
+        self.journal_sale = self.env['account.journal'].create({
+            'name': 'Sale Journal',
+            'type': 'sale',
+            'code': 'SALE1',
+            'default_account_id': self.account_revenue.id,
+        })
+        self.journal_purchase = self.env['account.journal'].create({
+            'name': 'Purchase Journal',
+            'type': 'purchase',
+            'code': 'PURCH1',
+            'default_account_id': self.account_expense.id,
+        })
+        
+        self.product = self.env['product.product'].create({
+            'name': 'Product Test',
+            'type': 'service',
+            'property_account_income_id': self.account_revenue.id,
+            'property_account_expense_id': self.account_expense.id,
+        })
+        
+    def _create_invoice(self, move_type, date_str):
+        invoice = self.env['account.move'].create({
+            'move_type': move_type,
+            'partner_id': self.partner.id,
+            'invoice_date': date_str,
+            'date': date_str,
+            'journal_id': self.journal_sale.id if 'out' in move_type else self.journal_purchase.id,
+            'invoice_line_ids': [Command.create({
+                'name': 'product',
+                'product_id': self.product.id, # Ensure product is used to trigger onchange/defaults if any
+                'price_unit': 100.0,
+            })],
+        })
+        return invoice
+
+    def test_ordinary_in_period(self):
+        """Ordinary: Invoice inside period -> Cancel available (entry_in_period=True)"""
+        if 'taxpayer_type' not in self.company._fields:
+            return
+            
+        self.company.taxpayer_type = 'ordinary'
+        
+        # Today: 2025-10-30
+        # Invoice: 2025-10-29
+        # Expect: True
+        
+        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+            mock_date.today.return_value = datetime.date(2025, 10, 30)
+            mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
+
+            inv = self._create_invoice('out_invoice', '2025-10-29')
+            # Trigger compute
+            inv._compute_entry_in_period()
+            # Currently fails because code excludes 'out_invoice' unless debit_origin_id
+            self.assertTrue(inv.entry_in_period, "Ordinary: Standard Invoice in period should be True")
+            
+    def test_ordinary_out_period(self):
+        """Ordinary: Invoice outside period -> Cancel unavailable (entry_in_period=False)"""
+        if 'taxpayer_type' not in self.company._fields:
+            return
+        self.company.taxpayer_type = 'ordinary'
+        
+        # Today: 2025-11-01
+        # Invoice: 2025-10-29
+        # Expect: False
+        
+        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+            mock_date.today.return_value = datetime.date(2025, 11, 1)
+            mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
+
+            inv = self._create_invoice('out_invoice', '2025-10-29')
+            inv._compute_entry_in_period()
+            self.assertFalse(inv.entry_in_period, "Ordinary: Invoice last month should be False")
+
+    def test_special_in_period_first_half(self):
+        """Special: Invoice 10th, Today 14th -> True"""
+        if 'taxpayer_type' not in self.company._fields:
+            return
+        self.company.taxpayer_type = 'special'
+        
+        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+            mock_date.today.return_value = datetime.date(2025, 10, 14)
+            mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
+
+            inv = self._create_invoice('out_invoice', '2025-10-10')
+            inv._compute_entry_in_period()
+            self.assertTrue(inv.entry_in_period, "Special: Same fortnight (1st) should be True")
+
+    def test_special_out_period_cross_half(self):
+        """Special: Invoice 10th, Today 16th -> False"""
+        if 'taxpayer_type' not in self.company._fields:
+            return
+        self.company.taxpayer_type = 'special'
+        
+        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+            mock_date.today.return_value = datetime.date(2025, 10, 16)
+            mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
+
+            inv = self._create_invoice('out_invoice', '2025-10-10')
+            inv._compute_entry_in_period()
+            self.assertFalse(inv.entry_in_period, "Special: Cross fortnight should be False")
+    
+    def test_vendor_bill_always_true(self):
+        """Vendor Bill: Should always be True"""
+        self.company.taxpayer_type = 'ordinary'
+        
+        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+            mock_date.today.return_value = datetime.date(2025, 12, 1)
+            mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
+
+            inv = self._create_invoice('in_invoice', '2025-01-01')
+            inv._compute_entry_in_period()
+            
+            self.assertTrue(inv.entry_in_period, "Vendor Bill should always be True")

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -6,7 +6,11 @@
         <field name="arch" type="xml">
             <field name="invoice_has_outstanding" position="after">
                 <field name="is_contingency" invisible="1" />
+                <field name="entry_in_period" invisible="1" />
             </field>
+            <xpath expr="//header/button[@name='button_cancel'][2]" position="attributes">
+                <attribute name="invisible">not entry_in_period and (not id or state != 'draft' or move_type == 'entry')</attribute>
+            </xpath>
             <xpath expr="//field[@name='invoice_user_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -5,6 +5,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from datetime import date, datetime, timedelta
+import calendar
 
 _logger = logging.getLogger(__name__)
 
@@ -1121,13 +1122,13 @@ class StockPicking(models.Model):
                 result = hoy.replace(day=15)
             else:
                 # Si es 15 o después: último día del mes
-                result = date(hoy.year, hoy.month, 28) + timedelta(days=4)
-                result = result - timedelta(days=1)
+                last_day = calendar.monthrange(hoy.year, hoy.month)[1]
+                result = date(hoy.year, hoy.month, last_day)
 
         elif taxpayer_type in ("ordinary", "formal"):
             # Siempre último día del mes para estos tipos
-            result = date(hoy.year, hoy.month, 28) + timedelta(days=4)
-            result = result - timedelta(days=1)
+            last_day = calendar.monthrange(hoy.year, hoy.month)[1]
+            result = date(hoy.year, hoy.month, last_day)
 
         return f"Tienes {len(pickings_combined)} guías de despacho sin facturar al {result.strftime('%d-%m-%Y')}. De facturarse en el siguiente periodo el Seniat será Notificado."
     def get_foreign_currency_is_vef(self):


### PR DESCRIPTION
Problema:
-Se requiere ocultar el botón de cancelar dependiendo de si la factura están fuera o no del periodo fiscal según el tipo de contribuyente que sea la empresa. Si la factura es de proveedor, este botón siempre debe estar disponible.

Solución:
-Se refactoriza la función _compute_entry_in_period para siempre mostrar el botón cuando sea una factura o nc, nd de proveedor.

-Se agregan pruebas unitarias.

Tarea (Link):
https://binaural.odoo.com/web#id=62064&cids=2&menu_id=975&action=341&model=project.task&view_type=form
Tarea de proyecto [x]
Ticket de soporte []