### PR TITLE
FEAT #61475: l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "1.4",
+    "version": "1.5",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -401,13 +401,12 @@ class StockPicking(models.Model):
     def _get_invoice_lines_for_invoice(self, from_picking_line=False):
         self.ensure_one()
         invoice_line_list = []
-        for move_id in self.move_ids_without_package:
+        for move_id in self.move_ids:
             price_unit = move_id.product_id.list_price
             tax_ids = [(6, 0, [self.company_id.account_sale_tax_id.id])]
             if move_id.sale_line_id:
                 price_unit = move_id.sale_line_id.price_unit
-                tax_ids = [(6, 0, move_id.sale_line_id.tax_id.ids)]
-
+                tax_ids = [(6, 0, move_id.sale_line_id.tax_ids.ids)]
             vals = (
                 0,
                 0,


### PR DESCRIPTION
Problema:
-Al correr pruebas unitarias, mostraba error al no reconocer los campos move_ids_without_package, y tax_id, de stock.picking y sale_order_line respectivamente. Solución:
-Se cambia move_ids_without_package por move_ids.
-Se cambia tax_id por tax_ids.
Tarea (Link):
https://binaural.odoo.com/web#id=61475&cids=2&menu_id=257&action=341&model=project.task&view_type=form Tarea de proyecto [x]
Ticket de soporte []