### PR TITLE
FEAT #62591: l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.23",
+    "version": "1.25",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -1,4 +1,3 @@
-
 from odoo import api, fields, models, _
 from odoo.tools import float_compare
 from odoo.exceptions import UserError, ValidationError
@@ -101,32 +100,6 @@ class AccountMoveLine(models.Model):
     config_deductible_tax = fields.Boolean(related='company_id.config_deductible_tax')
 
     not_deductible_tax = fields.Boolean(default=False)
-
-    # override
-    @api.depends("product_id", "product_uom_id", "move_id.currency_id")
-    def _compute_price_unit(self):
-        for line in self:
-            if (
-                not line.product_id
-                or line.display_type in ("line_section", "line_subsection", "line_note")
-                or line.is_imported
-            ):
-                continue
-            if line.move_id.is_sale_document(include_receipts=True):
-                document_type = "sale"
-            elif line.move_id.is_purchase_document(include_receipts=True):
-                document_type = "purchase"
-            else:
-                document_type = "other"
-            line.price_unit = line.product_id._get_tax_included_unit_price(
-                line.move_id.company_id,
-                line.move_id.currency_id,
-                line.move_id.date,
-                document_type,
-                fiscal_position=line.move_id.fiscal_position_id,
-                product_uom=line.product_uom_id,
-                product_price_unit=line.price_unit,
-            )
 
     @api.onchange("amount_currency", "currency_id")
     def _inverse_amount_currency(self):


### PR DESCRIPTION
Problema:
-Al seleccionar un producto, este no trae el precio que contiene en la lista de precios seleccionada, dejandolo en 0.

Solución:
-Se elimina el override a _compute_price_unit.

Tarea (Link):
https://binaural.odoo.com/web#id=62591&cids=2&menu_id=1063&action=345&active_id=2230&model=project.task&view_type=form Tarea de proyecto [x]
Ticket de soporte []