### PR TITLE
Se corrige nombre del archivo de la vista para q concuerde con el mafest

### DIFF
--- a/l10n_ve_tax/__manifest__.py
+++ b/l10n_ve_tax/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.11",
+    "version": "17.0.0.0.12",
     # any module necessary for this one to work correctly
     "depends": ["base", "account", "l10n_ve_base", "l10n_ve_rate"],
     "data": [


### PR DESCRIPTION
l10n_ve_tax/__manifest__.py
el archivo account_journal.xml tenia el nombre incorrecto : account_jounal.xml, se corrigio