### PR TITLE
FIX #10777: l10n_ve_payment_extension_not_allow_retention_aproval

### DIFF
--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -5,7 +5,7 @@ from odoo.exceptions import UserError, ValidationError
 from ..utils.utils_retention import load_retention_lines, search_invoices_with_taxes
 from collections import defaultdict
 import json
-from odoo.tools.float_utils import float_round
+from odoo.tools.float_utils import float_round,float_compare
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -906,12 +906,12 @@ class AccountRetention(models.Model):
                 self._reconcile_customer_payment(payment)
 
     def _reconcile_supplier_payment(self, payment):
-
+        precision = self.company_currency_id.rounding
         if payment.payment_type == "outbound":
 
             lines = payment.move_id.line_ids.filtered(
                 lambda l: l.account_id.account_type == "liability_payable"
-                and l.debit > 0
+                and float_compare(l.debit, 0.0, precision_rounding=precision) == 1
             )
             if not lines:
                 raise ValidationError(
@@ -927,7 +927,7 @@ class AccountRetention(models.Model):
 
             lines = payment.move_id.line_ids.filtered(
                 lambda l: l.account_id.account_type == "liability_payable"
-                and l.credit > 0
+                and float_compare(l.credit, 0.0, precision_rounding=precision) == 1
             )
             if not lines:
                 raise ValidationError(
@@ -940,12 +940,12 @@ class AccountRetention(models.Model):
             )
 
     def _reconcile_customer_payment(self, payment):
-
+        precision = self.company_currency_id.rounding
         if payment.payment_type == "outbound":
 
             lines = payment.move_id.line_ids.filtered(
                 lambda l: l.account_id.account_type == "asset_receivable"
-                and l.debit > 0
+                and float_compare(l.debit, 0.0, precision_rounding=precision) == 1
             )
 
             if not lines:
@@ -961,7 +961,7 @@ class AccountRetention(models.Model):
         elif payment.payment_type == "inbound":
             lines = payment.move_id.line_ids.filtered(
                 lambda l: l.account_id.account_type == "asset_receivable"
-                and l.credit > 0
+                and float_compare(l.credit, 0.0, precision_rounding=precision) == 1
             )
 
             if not lines:

--- a/l10n_ve_payment_extension/models/account_retention_line.py
+++ b/l10n_ve_payment_extension/models/account_retention_line.py
@@ -336,17 +336,17 @@ class AccountRetentionLine(models.Model):
             if not foreign_rate:
                 foreign_rate = 1
             if not base_currency_is_vef:
-                record.retention_amount = (
+                record.retention_amount = abs((
                     record.invoice_amount
                     * (record.related_percentage_tax_base / 100)
                     * (record.related_percentage_fees / 100)
-                ) - record.related_amount_subtract_fees / foreign_rate
+                ) - record.related_amount_subtract_fees / foreign_rate)
             else:
-                record.retention_amount = (
+                record.retention_amount = abs((
                     record.invoice_amount
                     * (record.related_percentage_tax_base / 100)
                     * (record.related_percentage_fees / 100)
-                ) - record.related_amount_subtract_fees
+                ) - record.related_amount_subtract_fees)
 
             record.foreign_retention_amount = abs((
                 record.foreign_invoice_amount


### PR DESCRIPTION
Problema: No permite aprobar la retencion del ISLR

Solución: Se hicieron ajustes en el calculo de la retencion para que no diera numeros negativos, esto era lo que causaba el problema. Con un retention_amount negativo el payment se creaba en negativo Al asignarle el pago a la retencion fallaba al no encontrar pagos con debito positivo El ajuste fue agregar un abs() al momento de asignar el valor de retention_amount, de esta forma evitando el valor negativo

Tarea (Link):https://binaural.odoo.com/web#id=10777&menu_id=293&action=389&model=helpdesk.ticket&view_type=form

Tarea de proyecto []
Ticket de soporte [x]