### PR TITLE
[FIX]ordenar reporte z fecha

### DIFF
--- a/l10n_ve_iot_mf/__manifest__.py
+++ b/l10n_ve_iot_mf/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "LGPL-3",
     "category": "Accounting",
 
-    "version": "17.0.0.1.1",
+    "version": "17.0.0.1.2",
     "author": "binaural-dev",
     "website": "https://binauraldev.com",
     "depends": [

--- a/l10n_ve_iot_mf/wizards/accounting_reports.py
+++ b/l10n_ve_iot_mf/wizards/accounting_reports.py
@@ -239,4 +239,11 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                             range_last = move.mf_invoice_number
                             continue
                         range_last = move.mf_invoice_number
+        sale_book_lines = sorted(
+                    sale_book_lines,
+                    key=lambda row: (
+                        datetime.strptime(row['document_date'], "%d/%m/%Y"),
+                        int(row.get('mf_reportz', 0) or 0)
+                    )
+                )                       
         return sale_book_lines


### PR DESCRIPTION
Por que: por fecha esta ordenando bien ahora quieren que tambien ordenen por fe reporte z aparte de fecha

Solucion: ordenar por fecha y luego por reporte z

Archivo: l10n_ve_iot_mf/wizards/accounting_reports.py

Funcion: parse_sale_book_data

Tarea de proyecto []

Ticket de soporte [x]

Ticket(Link):https://binaural.odoo.com/web#id=10590&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form