### PR TITLE
Cambios Faltantes IGTF

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.1.0",
+    "version": "17.0.0.1.1",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.1.1",
+    "version": "17.0.0.1.2",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/res_currency.py
+++ b/l10n_ve_accountant/models/res_currency.py
@@ -1,12 +1,4 @@
 from odoo import models, fields, api, _
-from odoo.exceptions import UserError
-
-import logging
-
-_logger = logging.getLogger(__name__)
-from odoo.fields import Monetary
-from odoo.tools import float_repr
-
 class ResCurrency(models.Model):
     _inherit = "res.currency"
 
@@ -24,30 +16,24 @@ class ResCurrency(models.Model):
                 )
             )
 
-    def _convert(self, from_amount, to_currency, company=None, date=None, round=True):  
+    def _convert(self, from_amount, to_currency, company=None, date=None, round=False):  
+        """Returns the converted amount of ``from_amount``` from the currency
+           ``self`` to the currency ``to_currency`` for the given ``date`` and
+           company.
+
+           :param company: The company from which we retrieve the convertion rate
+           :param date: The nearest date from which we retriev the conversion rate.
+           :param round: Round the result or not
+        """
         
         self, to_currency = self or to_currency, to_currency or self
         assert self, "convert amount from unknown currency"
         assert to_currency, "convert amount to unknown currency"
+        # apply conversion rate
         if from_amount:
             to_amount = from_amount * self._get_conversion_rate(self, to_currency, company, date)
         else:
             return 0.0
 
-        return to_amount
-
-
-    def round(self, amount):
-        
-        self.ensure_one()
-        amount_float = float(amount)
-
-        try:
-            amount_float = float(amount)
-        except (ValueError, TypeError):
-            return super(ResCurrency, self).round(amount)
-
-        if abs(amount_float - round(amount_float, 6)) > 1e-9:
-            return amount_float
-
-        return super(ResCurrency, self).round(amount_float)
+        # apply rounding
+        return to_currency.round(to_amount) if round else to_amount

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -70,16 +70,10 @@ class AccountPaymentRegister(models.TransientModel):
             if not bool(payment.foreign_rate):
                 return
 
-            batch_result = payment._get_batches()[0]
             payment.foreign_inverse_rate = Rate.compute_inverse_rate(
                 payment.foreign_rate
             )
-            total_amount_residual_in_wizard_currency = (
-                payment._get_total_amount_in_wizard_currency_to_full_reconcile(
-                    batch_result, early_payment_discount=False
-                )[0]
-            )
-            payment.amount = total_amount_residual_in_wizard_currency
+            
 
     @api.onchange("payment_date")
     def _onchange_invoice_date(self):
@@ -108,23 +102,6 @@ class AccountPaymentRegister(models.TransientModel):
             }
         )
         return payment_vals
-
-    @api.depends("can_edit_wizard", "amount", "foreign_inverse_rate")
-    def _compute_payment_difference(self):
-        for wizard in self:
-            if wizard.can_edit_wizard:
-                batch_result = wizard._get_batches()[0]
-                total_amount_residual_in_wizard_currency = (
-                    wizard._get_total_amount_in_wizard_currency_to_full_reconcile(
-                        batch_result, early_payment_discount=False
-                    )[0]
-                )
-                wizard.payment_difference = (
-                    total_amount_residual_in_wizard_currency - wizard.amount
-                )
-            else:
-                wizard.payment_difference = 0.0
-
 
 
     @api.model

--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.0.0.45",
+    "version": "17.0.0.0.46",
         "depends": [
         "base",
         "l10n_ve_accountant",

--- a/l10n_ve_igtf/models/account_payment.py
+++ b/l10n_ve_igtf/models/account_payment.py
@@ -63,21 +63,25 @@ class AccountPaymentIgtf(models.Model):
         
         currency = invoice.currency_id
         precision = currency.rounding
-        
-        principal_debt = invoice.amount_residual if invoice.company_currency_id != self.env.ref("base.VEF") else invoice.foreign_amount_residual
+
+        due_amount = invoice.amount_residual
+
+        due_currency_id = invoice.currency_id
+
+        principal_debt = due_amount
 
         principal_amount = min(payment_amount, principal_debt)
         
 
         igtf_unrounded = principal_amount * (self.env.company.igtf_percentage / 100)
 
-        igtf_top = invoice.igtf_top_aply
+        igtf_top = due_currency_id._convert( invoice.alter_igtf_top_aply,invoice.currency_id,company=self.company_id,date=fields.Date.today()) if invoice.company_currency_id == self.env.ref("base.VEF") else invoice.igtf_top_aply
 
         alter_bi_igtf = invoice.alter_bi_igtf
 
         igtf= igtf_unrounded
 
-        invoice_residual = invoice.amount_residual if self.company_currency_id != self.env.ref("base.VEF") else invoice.foreign_amount_residual
+        invoice_residual = due_amount
     
         if not float_is_zero(igtf, precision_rounding=precision) and igtf_top == invoice_residual:
             
@@ -89,12 +93,14 @@ class AccountPaymentIgtf(models.Model):
         if float_compare(residual_igtf, 0.0, precision_rounding=precision) == 0.0:
             return 0.0
         
-        if igtf > residual_igtf and not float_is_zero(residual_igtf, precision_rounding=precision):
+        if igtf > residual_igtf and  not float_is_zero(residual_igtf, precision_rounding=precision):
+            
             igtf = residual_igtf
 
         if float_compare(igtf_top, 0.0, precision_rounding=precision) >= 0.0 and float_compare(igtf, igtf_top, precision_rounding=precision) > 0.0:
+            
             return 0.0
- 
+        
         return igtf
     
     def _create_igtf_moves_in_payments(self, vals, write_off_line_vals = False):

--- a/l10n_ve_igtf/wizard/account_payment_register.py
+++ b/l10n_ve_igtf/wizard/account_payment_register.py
@@ -218,7 +218,6 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
 
         igtf_top = due_currency_id._convert( invoice.alter_igtf_top_aply,self.currency_id,company=self.company_id,date=self.payment_date) if invoice.company_currency_id == self.env.ref("base.VEF") else invoice.igtf_top_aply
 
-        #raise UserError(igtf_top)
         alter_bi_igtf = invoice.alter_bi_igtf
 
         igtf= igtf_unrounded


### PR DESCRIPTION
Se iguala funcion de calculate_igtf_for_payment en account.payment para que funcione igual a la del wizard de pago, ya que la misma debe tomar en consideracion la diferencia de fechas con respecto a lo que se cancela de igual manera en el cruce de asiento anticipos ya que esta funcion se ejecuto en ese momento, se elimina funcion inversa del amount_currency, se corrige funcion convert para que la misma tenga el redondeo por defecto en falso eliminado de esta forma la necesidad del monkeypatch del round.