### PR TITLE
[FIX]l10n_ve_iot_mf

### DIFF
--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -726,6 +726,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             return "03-ANU"
 
     def search_moves(self):
+        #TODO: Revisar si este uso de order es correcto
         order = "invoice_date asc" if self.report == "purchase" else "correlative asc"
         env = self.env
         move_model = env["account.move"]

--- a/l10n_ve_iot_mf/__manifest__.py
+++ b/l10n_ve_iot_mf/__manifest__.py
@@ -7,8 +7,7 @@
     """,
     "license": "LGPL-3",
     "category": "Accounting",
-
-    "version": "17.0.0.1.1",
+    "version": "17.0.0.1.2",
     "author": "binaural-dev",
     "website": "https://binauraldev.com",
     "depends": [

--- a/l10n_ve_iot_mf/wizards/accounting_reports.py
+++ b/l10n_ve_iot_mf/wizards/accounting_reports.py
@@ -25,6 +25,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
         if self.with_fiscal_machine:
             res = super().search_moves()
             res = res.filtered_domain([("mf_serial", "!=", False)])
+            res = res.sorted(key=lambda r: r.invoice_date)
             return res
 
         move_model = self.env["account.move"]


### PR DESCRIPTION
Se corrije el orden en el que se mostraban las facturas del libro de ventas con maquina fiscal.
Se añade un comentario para tener presente que hace falta una revisión con el flujo de forma libre.
Link:https://binaural.odoo.com/web#cids=2&menu_id=293&action=393&active_id=87&model=helpdesk.ticket&view_type=form&id=11006