### PR TITLE
[FIX] Aumentar timeout tasa bcv

### DIFF
--- a/tools/binaural_cne_query.py
+++ b/tools/binaural_cne_query.py
@@ -27,7 +27,7 @@ def get_default_name_by_vat(self, prefix_vat, vat):
         + str(vat)
     )
     try:
-        response = requests.get(URL, timeout=5)
+        response = requests.get(URL, timeout=20)
         soup = BeautifulSoup(response.text, "html.parser")
         info_table = soup.find_all("tr")
         for row in info_table:


### PR DESCRIPTION
Por que: se modifico en odoo-venezuela y integra como se sabia cual era la que realizaba la accion como tal como tenia varios dias sin actualizar la tasa

Solucion: se aumento el timeout al consultar al bcv

Archivo: tools/binaural_bcv_query.py

Funcion: get_usd_rate_of_the_day_bcv

Tarea de proyecto []

Ticket de soporte [x]

Ticket(Link):https://binaural.odoo.com/web#id=10912&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form