### PR TITLE
Add Widget Monetary precision Decimal in view

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.1.3",
+    "version": "17.0.0.1.4",
     "depends": [
         "base",
         "web",
@@ -47,9 +47,9 @@
         "wizard/payment_report.xml",
         "wizard/move_action_post_alert_views.xml",
     ],
-    """ "assets": {
+    "assets": {
         "web.assets_backend": ["l10n_ve_accountant/static/src/js/*"],
-    }, """
+    }, 
     "images": ["static/description/icon.png"],
     "application": True,
     "pre_init_hook": "pre_init_hook",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -112,14 +112,14 @@ class AccountMove(models.Model):
     foreign_rate = fields.Float(
         compute="_compute_rate",
         store=True,
-       
+        
         tracking=True,
         readonly=False,
     )
     foreign_inverse_rate = fields.Float(
         help="Rate that will be used as factor to multiply of the foreign currency for this move.",
         compute="_compute_rate",
-        
+        digits=(16, 15),
         store=True,
         index=True,
         readonly=False,

--- a/l10n_ve_accountant/models/res_currency.py
+++ b/l10n_ve_accountant/models/res_currency.py
@@ -16,24 +16,4 @@ class ResCurrency(models.Model):
                 )
             )
 
-    def _convert(self, from_amount, to_currency, company=None, date=None, round=False):  
-        """Returns the converted amount of ``from_amount``` from the currency
-           ``self`` to the currency ``to_currency`` for the given ``date`` and
-           company.
-
-           :param company: The company from which we retrieve the convertion rate
-           :param date: The nearest date from which we retriev the conversion rate.
-           :param round: Round the result or not
-        """
-        
-        self, to_currency = self or to_currency, to_currency or self
-        assert self, "convert amount from unknown currency"
-        assert to_currency, "convert amount to unknown currency"
-        # apply conversion rate
-        if from_amount:
-            to_amount = from_amount * self._get_conversion_rate(self, to_currency, company, date)
-        else:
-            return 0.0
-
-        # apply rounding
-        return to_currency.round(to_amount) if round else to_amount
+ 

--- a/l10n_ve_accountant/static/src/js/format_currency.js
+++ b/l10n_ve_accountant/static/src/js/format_currency.js
@@ -1,72 +1,51 @@
 /** @odoo-module **/
 
+import { MonetaryField } from "@web/views/fields/monetary/monetary_field";
 import { patch } from "@web/core/utils/patch";
-import * as formatters from "@web/views/fields/formatters";
-import { MonetaryField, monetaryField } from "@web/views/fields/monetary/monetary_field";
+import { formatMonetary } from "@web/views/fields/formatters";
 import { session } from "@web/session";
 
-/**
- * Obtiene la configuración de decimales a partir de un nombre 
- * de Precisión Decimal (decimal.precision) desde la sesión.
- */
-function getDigitsFromDP(dpName) {
-    if (!dpName || !session.dp_stats) {
-        return null;
-    }
-    const precision = session.dp_stats[dpName];
-    if (precision !== undefined) {
-        return [16, precision]; 
-    }
-    return null;
-}
-
-// 1. EXTENDER LA DEFINICIÓN DE PROPS (Para que Owl las acepte)
-if (MonetaryField.props) {
-    MonetaryField.props = {
+patch(MonetaryField, {
+    props: {
         ...MonetaryField.props,
         precision: { type: String, optional: true },
-    };
-}
+    },
+});
 
-// 2. MODIFICAR EL REGISTRO MANUALMENTE
-// No usamos patch(monetaryField) porque no es una clase y falla el this._super.
-// Guardamos la función original y la reemplazamos.
-const originalExtractProps = monetaryField.extractProps;
-monetaryField.extractProps = function ({ attrs }) {
-    // Ejecutamos la lógica original
-    const props = originalExtractProps.apply(this, arguments);
-    
-    // Si el usuario puso precision="X" en el XML (attrs), lo pasamos al componente
-    if (attrs && attrs.precision) {
-        props.precision = attrs.precision;
-    }
-    return props;
-};
-
-// 3. PARCHE AL COMPONENTE (Aquí sí funciona patch porque es una Clase/Prototipo)
 patch(MonetaryField.prototype, {
+    /**
+     * Sobrescribimos formattedValue para inyectar la precisión decimal
+     */
     get formattedValue() {
-        // Mantenemos la lógica original de inputs numéricos
         if (this.props.inputType === "number" && !this.props.readonly && this.value) {
             return this.value;
         }
 
-        const formatOptions = {
-            digits: this.currencyDigits,
-            currencyId: this.currencyId,
-            noSymbol: !this.props.readonly || this.props.hideSymbol,
-        };
-
-        // Si existe la prop precision (inyectada por el proceso de arriba)
+        // Lógica para obtener los dígitos desde Decimal Precision
+        let digits = this.currencyDigits;
         if (this.props.precision) {
-            const dpDigits = getDigitsFromDP(this.props.precision);
-            if (dpDigits) {
-                formatOptions.digits = dpDigits;
+            const dp = session.decimal_precision;
+            if (dp && dp[this.props.precision]) {
+                // dp[this.props.precision] devuelve el número (ej: 4)
+                digits = [16, dp[this.props.precision]];
             }
         }
 
-        return formatters.formatMonetary(this.value, formatOptions);
+        return formatMonetary(this.value, {
+            digits: digits,
+            currencyId: this.currencyId,
+            noSymbol: !this.props.readonly || this.props.hideSymbol,
+        });
     }
 });
 
-export default {};
+// Modificamos el objeto de registro para capturar la opción del XML
+import { monetaryField } from "@web/views/fields/monetary/monetary_field";
+
+const originalExtractProps = monetaryField.extractProps;
+monetaryField.extractProps = (fieldInfo) => {
+    const props = originalExtractProps(fieldInfo);
+    // Extraemos 'precision' de las opciones del XML
+    props.precision = fieldInfo.options.precision;
+    return props;
+};

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -43,7 +43,7 @@
                         <t groups="base.group_no_one">
                             <field name="foreign_inverse_rate" invisible="1" />
                         </t>
-                        <field name="foreign_rate" readonly="move_type not in ['in_invoice']" force_save="1"/>
+                        <field name="foreign_rate" readonly="move_type not in ['in_invoice']" force_save="1"  options="{'precision': 'Tasa'}"/>
                     </group>
                     <group colspan="4">
                         <group class="oe_subtotal_footer oe_right"
@@ -65,15 +65,15 @@
             </xpath>
             <xpath expr="//page/field[@name='invoice_line_ids']/tree/field[@name='price_unit']"
                 position="after">
-                <field name="foreign_price" precision="Foreign Product Price" readonly="move_type != 'in_invoice'" force_save="1"/>
+                <field name="foreign_price" readonly="move_type != 'in_invoice'" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
             </xpath>
             <xpath expr="//page/field[@name='invoice_line_ids']/tree/field[@name='price_subtotal']"
                 position="after">
                 <field name="foreign_currency_id" column_invisible="True" force_save="1"/>
-                <field name="foreign_subtotal" force_save="1"
+                <field name="foreign_subtotal" force_save="1" options="{'precision': 'Foreign Product Price'}"
                 />
-                <field name="foreign_price_total" options="{'precision': 'Foreign Product Price'}" force_save="1"
-                    column_invisible="parent.tax_calculation_rounding_method == 'round_globally'" />
+                <field name="foreign_price_total"  force_save="1"
+                    column_invisible="parent.tax_calculation_rounding_method == 'round_globally'" options="{'precision': 'Foreign Product Price'}"/>
                 <field name="foreign_rate" optional="hide" force_save="1"/>
                 <field
                     name="foreign_inverse_rate"

--- a/l10n_ve_rate/__manifest__.py
+++ b/l10n_ve_rate/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.0.0.3",
+    "version": "17.0.0.0.4",
     # any module necessary for this one to work correctly
     "depends": ["base", "l10n_ve_base"],
     "data": [

--- a/l10n_ve_rate/models/res_currency.py
+++ b/l10n_ve_rate/models/res_currency.py
@@ -5,7 +5,7 @@ from odoo.exceptions import UserError, ValidationError
 class ResCurrency(models.Model):
     _inherit = "res.currency"
 
-    def _convert(self, from_amount, to_currency, company=None, date=None, round=True, custom_rate=0.0):
+    def _convert(self, from_amount, to_currency, company=None, date=None, round=False, custom_rate=0.0):
         """Returns the converted amount of ``from_amount``` from the currency
            ``self`` to the currency ``to_currency`` for the given ``date`` and
            company.


### PR DESCRIPTION
Se agrega la precision decimal para los campos monetarios desde el widget monetary, esto para aquellos campos de tipo monetario que necesiten ser almacenados con alta precision decimal ya que al hacerlo desde digits el mismo oblique a que este se alalmacene con esa cantidad exacta de digitos lo que dificultaba los calculos precisos, esto permite definilos a nivel de vistas la precision decimal con la que se busca visualizar los campos sin perder decimales importantes, se elimino override de la funcion _convert de contabilida ya que en l10nve_rate ya existia un override tambien y solo se concidiciono a que no hiciera redondeo por defecto