### PR TITLE
[FIX]Precisión decimal en apuntes contables de los pagos

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.6",
+    "version": "17.0.0.0.7",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/models/pos_payment.py
+++ b/l10n_ve_pos/models/pos_payment.py
@@ -61,5 +61,5 @@ class PosPayment(models.Model):
                         "foreign_credit":  abs(payment.foreign_amount) if line.credit > 0 else 0,
                     }
                 )
-            return move_id
+        return move_id
         

--- a/l10n_ve_pos/models/pos_payment.py
+++ b/l10n_ve_pos/models/pos_payment.py
@@ -48,8 +48,18 @@ class PosPayment(models.Model):
 
             payment_move.write(
                 {
+                    "foreign_rate": payment.foreign_rate,
+                    "foreign_inverse_rate": payment.foreign_rate,
                     "manually_set_rate": True,
                 }
             )
-            
-        return move_id
+            for line in payment_move.line_ids:
+                line.write(
+                    {
+                        "not_foreign_recalculate": True,
+                        "foreign_debit": abs(payment.foreign_amount) if line.debit > 0 else 0,
+                        "foreign_credit":  abs(payment.foreign_amount) if line.credit > 0 else 0,
+                    }
+                )
+            return move_id
+        

--- a/l10n_ve_pos_igtf/models/pos_payment.py
+++ b/l10n_ve_pos_igtf/models/pos_payment.py
@@ -57,7 +57,7 @@ class PosPayment(models.Model):
                 payment.payment_date,
             )
             amount_igtf = payment.igtf_amount
-                
+            
             if payment.include_igtf:
                 if not (amounts["amount"] - amount_igtf == 0):
                     amount_without_igtf = payment.foreign_amount - payment.foreign_igtf_amount
@@ -68,6 +68,13 @@ class PosPayment(models.Model):
                             ).property_account_receivable_id.id,
                             "partner_id": accounting_partner.id,
                             "move_id": payment_move.id,
+                            "not_foreign_recalculate": True,
+                            "foreign_debit": abs(amount_without_igtf)
+                            if amount_without_igtf < 0
+                            else 0,
+                            "foreign_credit": abs(amount_without_igtf)
+                            if amount_without_igtf > 0
+                            else 0,
                             
                         },
                         amounts["amount"] - amount_igtf,
@@ -79,6 +86,13 @@ class PosPayment(models.Model):
                         "account_id": self.env.company.customer_account_igtf_id.id,
                         "partner_id": accounting_partner.id,
                         "move_id": payment_move.id,
+                        "not_foreign_recalculate": True,
+                        "foreign_debit": abs(payment.foreign_igtf_amount)
+                        if payment.foreign_igtf_amount < 0
+                        else 0,
+                        "foreign_credit": abs(payment.foreign_igtf_amount)
+                        if payment.foreign_igtf_amount > 0
+                        else 0,
                         
                     },
                     amount_igtf,
@@ -92,7 +106,13 @@ class PosPayment(models.Model):
                         ).property_account_receivable_id.id,  # The field being company dependant, we need to make sure the right value is received.
                         "partner_id": accounting_partner.id,
                         "move_id": payment_move.id,
-                       
+                        "not_foreign_recalculate": True,
+                        "foreign_debit": abs(payment.foreign_amount)
+                        if payment.foreign_amount < 0
+                        else 0,
+                        "foreign_credit": abs(payment.foreign_amount)
+                        if payment.foreign_amount > 0
+                        else 0,
                     },
                     amounts["amount"],
                     amounts["amount_converted"],
@@ -119,6 +139,13 @@ class PosPayment(models.Model):
                     "partner_id": accounting_partner.id
                     if is_split_transaction and is_reverse
                     else False,
+                    "not_foreign_recalculate": True,
+                    "foreign_debit": abs(payment.foreign_amount)
+                    if payment.foreign_amount > 0
+                    else 0,
+                    "foreign_credit": abs(payment.foreign_amount)
+                    if payment.foreign_amount < 0
+                    else 0,
                     
                 },
                 amounts["amount"],


### PR DESCRIPTION
-Se agregan nuevamente los campos y metodos de calcular los apuntes contables de los pagos que vienen de POS.
-Este bug fue introducido el PR #455.

Link:https://binaural.odoo.com/web#id=10981&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form