### PR TITLE
[FIX]11058 Diferencia base imponible

### DIFF
--- a/l10n_ve_payment_extension/models/account_move.py
+++ b/l10n_ve_payment_extension/models/account_move.py
@@ -1,8 +1,7 @@
 from odoo import models, fields, api, _, Command
 from odoo.exceptions import UserError
-
+from odoo.tools.float_utils import float_compare
 import logging
-
 _logger = logging.getLogger(__name__)
 
 
@@ -171,7 +170,8 @@ class AccountMoveRetention(models.Model):
                 "invoice_amount"
             )
         )
-        if sum_invoice_amount > self.tax_totals["amount_untaxed"]:
+        invoice_base = self.tax_totals.get("amount_untaxed", 0.0)
+        if float_compare(sum_invoice_amount, invoice_base, precision_digits=2) == 1:
             raise UserError(
                 _(
                     "The amount of the retention is greater than the total amount of the invoice %s."
@@ -194,7 +194,7 @@ class AccountMoveRetention(models.Model):
         for line in islr_retention_lines:
             move = line.move_id
             invoice_base = move.tax_totals.get("amount_untaxed", 0.0)
-            if line.invoice_amount > invoice_base:
+            if float_compare(line.invoice_amount, invoice_base, precision_digits=2) == 1:
                 raise UserError(
                     _(
                         "The taxable base of one of the withholding lines is greater than the taxable base of the invoice"


### PR DESCRIPTION
Por que: Al aprobar una factura de un proveedor en especifico entonces daba una diferencia de que la base imponible de la retencion es mayor a la de la factura

Solucion: Por unas decimas la base imponible de la factura era menor, ahora la base imponible de la retencion estaba redondeada pero la de la factura no por ende se redondeado

Funcion: _validate_islr_retention

Tarea de proyecto []

Ticket de soporte [x]

Ticket(Link):https://binaural.odoo.com/web#id=11058&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form