### PR TITLE
FIX:#11388 Exclude counter return

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.1.17",
+    "version": "17.0.0.1.20",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -1215,7 +1215,7 @@ class StockPicking(models.Model):
                     ("state_guide_dispatch", "=", "to_invoice"),
                     ("sale_id.document", "!=", "invoice"),
                     ("company_id", "in", company_ids),
-                    ('is_return', '=', False),
+                    ("is_return", "=", False),
                 ]
             )
         )

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -1215,6 +1215,7 @@ class StockPicking(models.Model):
                     ("state_guide_dispatch", "=", "to_invoice"),
                     ("sale_id.document", "!=", "invoice"),
                     ("company_id", "in", company_ids),
+                    ('is_return', '=', False),
                 ]
             )
         )


### PR DESCRIPTION
* Se excluye del contador del banner que muestra la cantidad de guias de despacho sin facturar las que son devoluciones

Tarea (Link):
https://binaural.odoo.com/web\#id\=11388\&cids\=2\&menu_id\=302\&action\=386\&model\=helpdesk.ticket\&view_type\=form