### PR TITLE
FEAT #64877: l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.25",
+    "version": "1.30",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -165,6 +165,10 @@ class AccountMoveLine(models.Model):
     )
     def _compute_foreign_debit_credit(self):
         for line in self:
+            if line.move_id.journal_id == line.company_id.currency_exchange_journal_id:
+                line.foreign_debit = 0.0
+                line.foreign_credit = 0.0
+                continue
             if line.not_foreign_recalculate:
                 continue
 


### PR DESCRIPTION
Problema:
-Se requiere que no genere foreign_credit y foreign_debit en las líneas del asiento de diferencia de cambio.

Solución:
-Se condiciona en _compute_foreign_debit_credit que el foreign_debit y foreign_credit sean 0 cuando el asiento tiene el diario configurado para diferencia de cambio. 

Tarea (Link):
https://binaural.odoo.com/web#id=64877&cids=2&menu_id=1063&action=345&active_id=3056&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []