### PR TITLE
FIX #65047: l10n_ve_invoice

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "1.15",
+    "version": "1.16",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -120,6 +120,9 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 return None
     
 
+        amount_taxed = taxes.get("amount_taxed", 0) + taxes.get("international_amount_taxed", 0)
+        tax_base_exempt_aliquot = taxes.get("tax_base_exempt_aliquot", 0) + taxes.get("international_tax_base_exempt_aliquot", 0)
+
         fields_purchase_book_line = {
             "_id": move.id,
             "document_date": self._format_date(move.invoice_date),
@@ -134,9 +137,9 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             "reduced_aliquot": 0.08,
             "extend_aliquot": 0.31,
             "general_aliquot": 0.16,
-            "total_purchases": taxes.get("amount_taxed", 0),
-            "total_purchases_iva": taxes.get("amount_taxed", 0) - (taxes.get("tax_base_exempt_aliquot", 0) * multiplier),
-            "total_purchases_not_iva": taxes.get("tax_base_exempt_aliquot", 0) * multiplier,
+            "total_purchases": amount_taxed,
+            "total_purchases_iva": amount_taxed - (tax_base_exempt_aliquot * multiplier),
+            "total_purchases_not_iva": tax_base_exempt_aliquot * multiplier,
             "amount_reduced_aliquot": taxes.get("amount_reduced_aliquot", 0) * multiplier,
             "amount_general_aliquot": taxes.get("amount_general_aliquot", 0) * multiplier,
             "amount_extend_aliquot": taxes.get("amount_extend_aliquot", 0) * multiplier,
@@ -1074,6 +1077,24 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     tax_result.get("international_tax_base_exempt_aliquot", 0.0)
                 ),
              })
+            tax_result.update({
+                "tax_base_reduced_aliquot": 0.0,
+                "amount_reduced_aliquot": 0.0,
+                "tax_base_general_aliquot": 0.0,
+                "amount_general_aliquot": 0.0,
+                "tax_base_extend_aliquot": 0.0,
+                "amount_extend_aliquot": 0.0,
+                "tax_base_exempt_aliquot": 0.0,
+                "amount_exempt_aliquot": 0.0,
+                "amount_taxed": 0.0,
+                "amount_untaxed": 0.0,
+                "tax_base_reduced_aliquot_no_deductible": 0.0,
+                "tax_base_general_aliquot_no_deductible": 0.0,
+                "tax_base_extend_aliquot_no_deductible": 0.0,
+                "amount_reduced_aliquot_no_deductible": 0.0,
+                "amount_general_aliquot_no_deductible": 0.0,
+                "amount_extend_aliquot_no_deductible": 0.0,
+            })
 
         # Inicializar en cero los campos no deducibles si no se asignaron
         if self.company_id.config_deductible_tax and self.report == "purchase":


### PR DESCRIPTION
Problema:
-Totales nacionales e internacionales muestran montos copiados en factura de compras internacionales 

Solución:
Función:  _determinate_amount_taxeds(self, move)
Se agregó: Un bloque de código dentro de la condición if move.journal_id.is_purchase_international:. Motivo: En esta función se analizan los impuestos de la factura para clasificarlos en variables (general, reducida, exenta, etc.). Originalmente, cuando era compra internacional, Odoo copiaba esos valores capturados a nuevas variables con sufijo "_international" (ej. tax_base_general_aliquot_international), pero dejaba los montos vivos también en las variables originales (nacionales). Comportamiento nuevo: Agregamos una actualización al diccionario tax_result para que, inmediatamente después de copiar los montos a variables internacionales, fuerce a 0.0 todas las variables de impuestos nacionales base, exentas, no deducibles, IVA y totales. Esto "limpia" el lado nacional, evitando la duplicidad en el reporte.

Función:  _fields_purchase_book_line(self, move, taxes)
Se agregó/modificó: La forma en que se calcula la variable principal  amount_taxed y tax_base_exempt_aliquot sólo para el cálculo de los campos totales de la fila (específicamente total_purchases, total_purchases_iva y total_purchases_not_iva). Motivo: En esta función se mapean las variables que van a escribirse en el Excel. Como en el paso anterior forzamos a cero el  amount_taxed
 base para una factura internacional, la columna general de "Total Compras" en el libro estaba imprimiendo 0.00. Comportamiento nuevo: Ahora, antes de armar el diccionario  fields_purchase_book_line, sumamos explícitamente el monto nacional más el internacional.

Tarea (Link):
https://binaural.odoo.com/web#cids=2&model=project.task&view_type=form&id=65045 Tarea de proyecto [x]
Ticket de soporte []