### PR TITLE
[FIX]l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "17.0.0.1.21",
+    "version": "17.0.0.1.22",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_move.py
+++ b/l10n_ve_stock_account/models/stock_move.py
@@ -1,10 +1,18 @@
-from odoo import models
+from odoo import models, api, fields
 import logging
 
 _logger = logging.getLogger(__name__)
 
 class StockMove(models.Model):
     _inherit = "stock.move"
+
+    qty_return = fields.Float(string="Quantity Return", compute="_compute_qty_return",store=True,default=0.0)
+
+    @api.depends("returned_move_ids")
+    def _compute_qty_return(self):
+        for line in self:
+            line.qty_return = sum(line.returned_move_ids.mapped("quantity"))
+
 
     def _get_line_values(self, use_foreign_currency=False):
         """

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -114,22 +114,22 @@ class StockPicking(models.Model):
     )
 
     @api.depends(
-        "move_ids_without_package",
-        "move_ids_without_package.qty_return",
-        "move_ids_without_package.quantity",
+        "move_ids",
+        "move_ids.qty_return",
+        "move_ids.quantity",
     )
     def _compute_type_of_return(self):
         for picking in self:
             if (
-                not picking.move_ids_without_package
+                not picking.move_ids
                 or not any(
-                    l.returned_move_ids for l in picking.move_ids_without_package
+                    l.returned_move_ids for l in picking.move_ids
                 )
-                or all(l.qty_return == 0 for l in picking.move_ids_without_package)
+                or all(l.qty_return == 0 for l in picking.move_ids)
             ):
                 picking.type_of_return = "n/a"
             elif all(
-                l.qty_return == l.quantity for l in picking.move_ids_without_package
+                l.qty_return == l.quantity for l in picking.move_ids
             ):
                 picking.type_of_return = "total"
             else:

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -822,9 +822,20 @@ class StockPicking(models.Model):
             cond_step = picking.type_delivery_step == "out" or (
                 picking.type_delivery_step == "int" and picking.is_dispatch_guide
             )
+            cond_return = picking.is_return == False
+
+            cond_type_of_return = picking.type_of_return != "total"
 
             picking.match_guide_dispatch_domain = all(
-                [cond_state, cond_type, cond_reason, cond_doc, cond_step]
+                [
+                    cond_state,
+                    cond_type,
+                    cond_reason,
+                    cond_doc,
+                    cond_step,
+                    cond_return,
+                    cond_type_of_return,
+                ]
             )
 
     @api.depends("picking_type_id", "partner_id", "sale_id")
@@ -906,7 +917,9 @@ class StockPicking(models.Model):
 
                 if record.operation_code == "outgoing":
                     record.show_create_invoice = (
-                        not record.is_return and record.sale_id.document != "invoice"
+                        not record.is_return
+                        and record.sale_id.document != "invoice"
+                        and record.type_of_return != "total"
                     )
                     record.show_create_customer_credit = record.is_return
 
@@ -1234,7 +1247,7 @@ class StockPicking(models.Model):
                 _logger.error(f"Error invoicing picking {picking.name}: {str(e)}")
                 picking.message_post(body=f"Error en facturación automática: {str(e)}")
 
-    def alert_views(self,company_ids_str):
+    def alert_views(self, company_ids_str):
 
         company_ids = [
             int(cid) for cid in str(company_ids_str).split(",") if cid.strip().isdigit()
@@ -1242,11 +1255,7 @@ class StockPicking(models.Model):
         domain = self._get_domain_for_return_picking()
         domain.append(("company_id", "in", company_ids))
 
-        pickings_combined = (
-            self.env["stock.picking"]
-            .sudo()
-            .search(domain)
-        )
+        pickings_combined = self.env["stock.picking"].sudo().search(domain)
 
         today = date.today()
         taxpayer_type = self.env.company.taxpayer_type

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -217,7 +217,6 @@ class StockPicking(models.Model):
     # === MAIN FUNCTIONS ===#
 
     def create_multi_invoice(self, pickings):
-
         lines = self._get_multiple_invoice_lines_for_invoice(
             pickings, from_picking_line=True
         )
@@ -733,7 +732,7 @@ class StockPicking(models.Model):
                     vendor_journal_id = self.env.company.vendor_journal_id
                     if not vendor_journal_id:
                         raise UserError(
-                            _("Please configure the journal from " "the settings.")
+                            _("Please configure the journal from the settings.")
                         )
                     for picking_id in self:
                         for (
@@ -806,6 +805,7 @@ class StockPicking(models.Model):
         "transfer_reason_id.code",
         "sale_id.document",
         "is_dispatch_guide",
+        "type_of_return",
     )
     def _compute_match_guide_dispatch_domain(self):
         for picking in self:
@@ -1020,7 +1020,6 @@ class StockPicking(models.Model):
         )
 
         for picking in self:
-
             picking.is_dispatch_guide = (
                 False
                 if picking.is_dispatch_guide is None
@@ -1108,7 +1107,6 @@ class StockPicking(models.Model):
 
             # Internal
             elif picking.operation_code == "internal":
-
                 consignment_reason = reasons.get("consignment")
                 transfer_between_warehouses_reason = reasons.get(
                     "transfer_between_warehouses"
@@ -1163,7 +1161,6 @@ class StockPicking(models.Model):
             record.show_other_causes_transfer_reason = False
 
             if record.transfer_reason_id:
-
                 record.is_dispatch_guide = (
                     False
                     if record.is_dispatch_guide is None
@@ -1210,7 +1207,6 @@ class StockPicking(models.Model):
         if config_type == "last_day":
             return today == last_day
         else:
-
             while last_day.weekday() >= 5:
                 last_day -= timedelta(days=1)
             return today == last_day
@@ -1248,7 +1244,6 @@ class StockPicking(models.Model):
                 picking.message_post(body=f"Error en facturación automática: {str(e)}")
 
     def alert_views(self, company_ids_str):
-
         company_ids = [
             int(cid) for cid in str(company_ids_str).split(",") if cid.strip().isdigit()
         ]

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -21,6 +21,7 @@ class StockPicking(models.Model):
         copy=False,
     )
     operation_code = fields.Selection(related="picking_type_id.code")
+
     is_return = fields.Boolean()
 
     guide_number = fields.Char(
@@ -99,6 +100,40 @@ class StockPicking(models.Model):
 
     is_consignment = fields.Boolean(compute="_compute_is_consignment", store=True)
     is_consignment_readonly = fields.Boolean(default=False)
+
+    type_of_return = fields.Selection(
+        [
+            ("total", "Total"),
+            ("partial", "Partial"),
+            ("n/a", "N/A"),
+        ],
+        string="Type of Return",
+        default="n/a",
+        compute="_compute_type_of_return",
+        store=True,
+    )
+
+    @api.depends(
+        "move_ids_without_package",
+        "move_ids_without_package.qty_return",
+        "move_ids_without_package.quantity",
+    )
+    def _compute_type_of_return(self):
+        for picking in self:
+            if (
+                not picking.move_ids_without_package
+                or not any(
+                    l.returned_move_ids for l in picking.move_ids_without_package
+                )
+                or all(l.qty_return == 0 for l in picking.move_ids_without_package)
+            ):
+                picking.type_of_return = "n/a"
+            elif all(
+                l.qty_return == l.quantity for l in picking.move_ids_without_package
+            ):
+                picking.type_of_return = "total"
+            else:
+                picking.type_of_return = "partial"
 
     @api.depends("transfer_reason_id")
     def _compute_reasons_optional_guide(self):
@@ -541,11 +576,6 @@ class StockPicking(models.Model):
         res = super()._action_done()
         self._set_guide_number()
         # TODO Add picking type logic either here or in the set_guide_number method
-        return res
-
-    def get_foreign_currency_is_vef(self):
-
-        res = self.company_id.currency_foreign_id == self.env.ref("base.VEF")
         return res
 
     # === METHODS ===#
@@ -995,7 +1025,8 @@ class StockPicking(models.Model):
                 continue
             elif (
                 picking.transfer_reason_id
-                and picking.transfer_reason_id.id == consignment_reason.id or picking.transfer_reason_id.id == other_causes_reason.id
+                and picking.transfer_reason_id.id == consignment_reason.id
+                or picking.transfer_reason_id.id == other_causes_reason.id
             ):
                 picking.is_dispatch_guide = True
 
@@ -1203,47 +1234,50 @@ class StockPicking(models.Model):
                 _logger.error(f"Error invoicing picking {picking.name}: {str(e)}")
                 picking.message_post(body=f"Error en facturación automática: {str(e)}")
 
-    def alert_views(self, id_company):
+    def alert_views(self,company_ids_str):
 
         company_ids = [
-            int(cid) for cid in str(id_company).split(",") if cid.strip().isdigit()
+            int(cid) for cid in str(company_ids_str).split(",") if cid.strip().isdigit()
         ]
+        domain = self._get_domain_for_return_picking()
+        domain.append(("company_id", "in", company_ids))
 
         pickings_combined = (
             self.env["stock.picking"]
             .sudo()
-            .search(
-                [
-                    ("state", "=", "done"),
-                    ("type_delivery_step", "!=", "int"),
-                    ("transfer_reason_id.code", "!=", "self_consumption"),
-                    ("state_guide_dispatch", "=", "to_invoice"),
-                    ("sale_id.document", "!=", "invoice"),
-                    ("company_id", "in", company_ids),
-                    ("is_return", "=", False),
-                ]
-            )
+            .search(domain)
         )
 
-        hoy = date.today()
+        today = date.today()
         taxpayer_type = self.env.company.taxpayer_type
-        result = hoy  # Valor por defecto
+        result = today  # Valor por defecto
 
         if taxpayer_type == "special":
-            if hoy.day < 15:
+            if today.day < 15:
                 # Si es antes del 15: mostrar día 15
-                result = hoy.replace(day=15)
+                result = today.replace(day=15)
             else:
                 # Si es 15 o después: último día del mes
-                last_day = calendar.monthrange(hoy.year, hoy.month)[1]
-                result = date(hoy.year, hoy.month, last_day)
+                last_day = calendar.monthrange(today.year, today.month)[1]
+                result = date(today.year, today.month, last_day)
 
         elif taxpayer_type in ("ordinary", "formal"):
             # Siempre último día del mes para estos tipos
-            last_day = calendar.monthrange(hoy.year, hoy.month)[1]
-            result = date(hoy.year, hoy.month, last_day)
+            last_day = calendar.monthrange(today.year, today.month)[1]
+            result = date(today.year, today.month, last_day)
 
         return f"Tienes {len(pickings_combined)} guías de despacho sin facturar al {result.strftime('%d-%m-%Y')}. De facturarse en el siguiente periodo el Seniat será Notificado."
+
+    def _get_domain_for_return_picking(self):
+        return [
+            ("state", "=", "done"),
+            ("type_delivery_step", "!=", "int"),
+            ("transfer_reason_id.code", "!=", "self_consumption"),
+            ("state_guide_dispatch", "=", "to_invoice"),
+            ("sale_id.document", "!=", "invoice"),
+            ("is_return", "=", False),
+            ("type_of_return", "!=", "total"),
+        ]
 
     def get_foreign_currency_is_vef(self):
         return self.env.company.currency_foreign_id == self.env.ref("base.VEF")

--- a/l10n_ve_stock_account/views/alert_views.xml
+++ b/l10n_ve_stock_account/views/alert_views.xml
@@ -3,10 +3,10 @@
     <xpath expr="//body" position="inside">
 
       <t t-set="result" t-value="request.httprequest.cookies"/>
-      <t t-set="company_id_str" t-value="result.get('cids', '')"/>           
+      <t t-set="company_ids_str" t-value="result.get('cids', '')"/>           
       
       <t t-set="env" t-value="request.env(context=ctx)" />
-      <t t-set="result" t-value="env['stock.picking'].sudo().alert_views(company_id_str)"/>
+      <t t-set="result" t-value="env['stock.picking'].sudo().alert_views(company_ids_str)"/>
 
       <div>
         <span id="oe_neutralize_banner"

--- a/l10n_ve_stock_account/views/stock_picking_views.xml
+++ b/l10n_ve_stock_account/views/stock_picking_views.xml
@@ -29,6 +29,12 @@
                 <attribute name="required">partner_required or is_dispatch_guide</attribute> 
                 <attribute name="readonly">order_is_consignment or partner_required</attribute>
             </xpath>
+            <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="before">
+                <field name="is_return" invisible="1"/>
+            </xpath>
+            <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="attributes">
+                <attribute name="invisible">state != 'done' or is_return</attribute>
+            </xpath>
             <xpath expr="//form//header" position="inside">
                 <field name="dispatch_guide_controls" invisible="1" />
                 <button 
@@ -76,6 +82,7 @@
                     name="guide_number"
                     readonly="1"
                     invisible="not dispatch_guide_controls"/>
+                <field name="type_of_return" />
             </xpath>
             <xpath expr="//field[@name='picking_type_id']" position="after">
                 <field name="operation_code" invisible="1"/>


### PR DESCRIPTION
Se requiere lo siguiente:
- Cuando se haga una devolución completa, se debe restar la guía de despacho de las pendientes por facturar.
- Cuando se haga una devolución parcial, no se debe restar la guía de despacho de las pendientes por facturar.
- En ningún momento una devolución de guía de despacho debe sumar al cintillo de guías pendientes por facturar.

Por lo tanto:
-Se añada el field qty_return para rastrear las cantidades que se devolvieron
-Se añade el field type_of_return para comparar las cantidades del movimiento de Salida y las cantidades a retornar para saber si el picking fue parcialmente devuelto o totalmente devuelto. -Usando estos campos se modifica el dominio de busqueda del "Cintillo" para que solo tome en cuenta las guias de despacho que no hayan sido devueltas totalmente.

Link:https://binaural.odoo.com/web#id=11398&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form