### PR TITLE
FIX   #65648:  l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.25",
+    "version": "1.26",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/views/tax_unit.xml
+++ b/l10n_ve_accountant/views/tax_unit.xml
@@ -50,7 +50,7 @@
             <field name="res_model">tax.unit</field>
             <field name="type">ir.actions.act_window</field>
             <field name="binding_view_types">form</field>
-            <field name="view_mode">tree,kanban,form</field>
+            <field name="view_mode">list,kanban,form</field>
             <field name="context">{"search_default_status":True}</field>
         </record>
         


### PR DESCRIPTION
- Error al momento de abrir vista de unidades tributarias
- solucion: se verifico que la accion que llama a las vistas del modelo de unidades tributrias todavia mantenia la vista de arbol como 'tree' , se cambio a 'list' para soluconar el problema 
- [TAREA]
- Link : https://binaural.odoo.com/web#id=65648&cids=2&model=project.task&view_type=form 
- Tarea de proyecto [X]