### PR TITLE
FIX #64877: l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -34,7 +34,7 @@ class AccountPayment(models.Model):
             The rate of the payment
         """
         rate_values = self.env["res.currency.rate"].compute_rate(
-            self.currency_id.id or self.env.ref("base.VEF").id,
+            self.foreign_currency_id.id or self.company_id.currency_id,
             self.date or fields.Date.today(),
         )
         rate = rate_values.get("foreign_rate", 0)
@@ -50,7 +50,7 @@ class AccountPayment(models.Model):
             The inverse rate of the payment
         """
         rate_values = self.env["res.currency.rate"].compute_rate(
-            self.currency_id.id or self.env.ref("base.VEF").id,
+            self.foreign_currency_id.id or self.company_id.currency_id,
             self.date or fields.Date.today(),
         )
         rate = rate_values.get("foreign_inverse_rate", 0)
@@ -157,7 +157,7 @@ class AccountPayment(models.Model):
         Rate = self.env["res.currency.rate"]
         for payment in self:
             rate_values = Rate.compute_rate(
-                payment.currency_id.id, payment.date or fields.Date.today()
+                payment.foreign_currency_id.id, payment.date or fields.Date.today()
             )
             payment.update(rate_values)
 

--- a/l10n_ve_accountant/views/account_payment.xml
+++ b/l10n_ve_accountant/views/account_payment.xml
@@ -11,7 +11,7 @@
                 <label for="foreign_rate" invisible="not is_foreign_currency and currency_id != company_currency_id"/>
                 <div class="o_row d-flex" invisible="not is_foreign_currency and currency_id != company_currency_id">
                     <field name="custom_rate_currency_name" readonly="1" nolabel="1" style="width: auto !important; margin-right: 20px; flex-grow: 0; font-weight: bold;"/>
-                    <field name="foreign_rate" readonly="state == 'posted'" style="width: 4rem !important; flex-grow: 0;" />
+                    <field name="foreign_rate" readonly="1" style="width: 4rem !important; flex-grow: 0;" />
                     <field name="company_currency_symbol" readonly="1" nolabel="1" style="width: auto !important; margin-left: 2px; flex-grow: 0; font-weight: bold;"/>
                 </div>
                 <field name="foreign_inverse_rate" groups="base.group_no_one" invisible="not is_foreign_currency and currency_id != company_currency_id"/>                
@@ -19,7 +19,7 @@
                 <label for="other_rate" invisible="is_foreign_currency or currency_id == company_currency_id"/>
                 <div class="o_row d-flex" invisible="is_foreign_currency or currency_id == company_currency_id">
                     <field name="custom_rate_currency_name" readonly="1" nolabel="1" style="width: auto !important; margin-right: 20px; flex-grow: 0; font-weight: bold;"/>
-                    <field name="other_rate" readonly="state == 'posted'" style="width: 4rem !important; flex-grow: 0;" />
+                    <field name="other_rate" readonly="1" style="width: 4rem !important; flex-grow: 0;" />
                     <field name="company_currency_symbol" readonly="1" nolabel="1" style="width: auto !important; margin-left: 2px; flex-grow: 0; font-weight: bold;"/>
                 </div>
                 <field name="other_rate_inverse" groups="base.group_no_one" invisible="is_foreign_currency or currency_id == company_currency_id"/>

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -31,6 +31,33 @@ class AccountPaymentRegister(models.TransientModel):
         compute="_compute_rates",
         store=True, 
     )
+    
+    foreign_rate_display = fields.Float(
+        help="The rate of the payment",
+        digits="Tasa",
+        compute="_compute_foreign_rate_display",
+        string=_("Foreign Rate Display"),
+        store=False,
+    )
+    @api.depends('currency_id', 'payment_date')
+    def _compute_foreign_rate_display(self):
+        """
+        Muestra solo el valor numérico de la tasa de la moneda seleccionada en el campo Importe.
+        """
+        Rate = self.env["res.currency.rate"]
+        for payment in self:
+            if payment.currency_id:
+                currency_id = payment.currency_id.id
+                if currency_id == payment.company_id.currency_id.id:
+                    currency_id = payment.company_id.foreign_currency_id.id
+                
+                rate_values = Rate.compute_rate(
+                    currency_id, payment.payment_date
+                )
+                payment.foreign_rate_display = rate_values.get("foreign_rate", 0.0)
+            else:
+                payment.foreign_rate_display = 0.0
+
     foreign_inverse_rate = fields.Float(
         help=(
             "Rate that will be used as factor to multiply of the foreign currency for the payment "


### PR DESCRIPTION
Problema:
-Las tasas en los pagos se  visualizaban de manera erronea. Solución:
-Se modifican default_rate y default_invese_rate para que ambas siempre reciban la moneda foranea. -En _compute_foreign_rate_display se refactoriza para que cuando se tenga seleccionada la moneda principal, muestre la tasa de cambio de la moneda secundaria. -En la vista se limita para que no pueda editar la tasa. Tarea (Link):
https://binaural.odoo.com/web#id=64877&cids=2&menu_id=1063&action=345&active_id=3056&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []