### PR TITLE
[FIX #11422 #11486] l10n_ve_pos_igtf

### DIFF
--- a/l10n_ve_pos_igtf/__manifest__.py
+++ b/l10n_ve_pos_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.0.0.1",
+    "version": "17.0.0.0.2",
     "depends": [
         "base",
         "l10n_ve_pos",

--- a/l10n_ve_pos_igtf/models/pos_payment.py
+++ b/l10n_ve_pos_igtf/models/pos_payment.py
@@ -99,11 +99,7 @@ class PosPayment(models.Model):
                 )
 
             is_split_transaction = payment.payment_method_id.split_transactions
-            if is_split_transaction and is_reverse:
-                reversed_move_receivable_account_id = accounting_partner.with_company(
-                    order.company_id
-                ).property_account_receivable_id.id
-            elif is_reverse:
+            if is_reverse:
                 reversed_move_receivable_account_id = (
                     payment.payment_method_id.receivable_account_id.id
                     or self.company_id.account_default_pos_receivable_account_id.id


### PR DESCRIPTION
Problema:
Error al cerrar: reembolso con cliente identificado usa Cta. por Cobrar en vez de transitoria POS
Solución:
Reembolso ahora usa misma cuenta transitoria POS
que las ventas, sin importar si tiene cliente
LINK: https://binaural.odoo.com/web#id=11486&cids=2&menu_id=293&action=390&model=helpdesk.ticket&view_type=form https://binaural.odoo.com/web#id=11422&cids=2&menu_id=293&action=390&model=helpdesk.ticket&view_type=form Ticket de TRIAJE [x]