### PR TITLE
[FIX] #66363: l10n_ve_sale

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "1.11",
+    "version": "1.12",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order_line.py
+++ b/l10n_ve_sale/models/sale_order_line.py
@@ -74,18 +74,21 @@ class SaleOrderLine(models.Model):
             )
             line.invoiced = invoiced
 
-    @api.depends("price_unit", "foreign_inverse_rate")
+    @api.depends("price_unit", "order_id.date_order", "currency_id")
     def _compute_foreign_price(self):
         for line in self:
 
-            invoice_date = (
-                line.invoice_lines and line.invoice_lines.move_ids.date
-            ) or fields.Date.today()
+            order_date = line.order_id.date_order or fields.Date.today()
 
             company_currency = line.company_id.currency_id
             foreign_currency = line.company_id.foreign_currency_id
             if line.currency_id.id == company_currency.id:
-                line.foreign_price = line.price_unit * line.foreign_inverse_rate
+                line.foreign_price = line.currency_id._convert(
+                    line.price_unit,
+                    foreign_currency,
+                    line.company_id,
+                    order_date,
+                )
             elif line.currency_id.id == foreign_currency.id:
                 line.foreign_price = line.price_unit
             else:
@@ -93,9 +96,14 @@ class SaleOrderLine(models.Model):
                     line.price_unit,
                     company_currency,
                     line.company_id,
-                    invoice_date,
+                    order_date,
                 )
-                line.foreign_price = price_in_company * line.foreign_inverse_rate 
+                line.foreign_price = company_currency._convert(
+                    price_in_company,
+                    foreign_currency,
+                    line.company_id,
+                    order_date,
+                )
 
     @api.depends("product_uom_qty", "foreign_price", "discount")
     def _compute_foreign_subtotal(self):

--- a/l10n_ve_sale/models/sale_order_line.py
+++ b/l10n_ve_sale/models/sale_order_line.py
@@ -74,7 +74,12 @@ class SaleOrderLine(models.Model):
             )
             line.invoiced = invoiced
 
-    @api.depends("price_unit", "order_id.date_order", "currency_id")
+    @api.depends(
+        "price_unit",
+        "order_id.date_order",
+        "currency_id",
+        "company_id",
+    )
     def _compute_foreign_price(self):
         for line in self:
 

--- a/l10n_ve_sale/tests/test_pricelist.py
+++ b/l10n_ve_sale/tests/test_pricelist.py
@@ -39,8 +39,10 @@ class TestSaleOrderForeignPricelist(TransactionCase):
             'company_id': company.id,
         }])
         
-        company.currency_id = usd.id
-        company.foreign_currency_id = eur.id
+        company.write({
+            'currency_id': usd.id,
+            'foreign_currency_id': eur.id,
+        })
 
         pricelist_usd = self.env['product.pricelist'].create({
             'name': 'USD Pricelist',


### PR DESCRIPTION
Problema:

-Error al modificar cantidades en orden de venta confirmada:
  File "/home/odoo/src/user/odoo-venezuela/l10n_ve_sale/models/sale_order_line.py", line 82, in _compute_foreign_price
    line.invoice_lines and line.invoice_lines.move_ids.date
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'account.move.line' object has no attribute 'move_ids'. Did you mean: 'move_id'?

Solución:

-Se refactoriza para que _compute_foreign_price use la fecha de la orden, en vez de la fecha errada de la factura. También se modifican las multiplicaciones * foreign_inverse_rate para que usen _convert y evitar diferencias en los decimales del monto, se borra foreign_inverse_rate de la función y se agrega currency_id.

Tarea (Link):
https://binaural.odoo.com/web#id=66363&cids=2&menu_id=257&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []