### PR TITLE
FIX #11517 l10n_ve_invoice

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.1.3",
+    "version": "17.0.0.1.4",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -5,6 +5,7 @@ import calendar
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import format_date
+from odoo.tools import format_date, float_is_zero, float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -72,15 +73,27 @@ class AccountMove(models.Model):
     def _check_price_in_zero(self):
         from_pos = self.env.context.get('from_pos', False)
         for line in self.filtered(lambda m: m.is_invoice()).mapped("invoice_line_ids"):
-            if line.price_unit <= 0 and line.display_type not in ("line_section","line_note"):
+            if line.display_type in ("line_section", "line_note"):
+                continue
+
+            precision = line.currency_id.decimal_places
+            if float_is_zero(line.price_unit, precision_digits=precision):
                 from_loyalty = self.env.context.get('from_loyalty', False)
-                if (
-                    self.env.company.sale_discount_product_id
-                    and line.product_id == self.env.company.sale_discount_product_id
-                ):
-                    continue
                 if not from_pos and not from_loyalty:
                     raise ValidationError(_("An invoice cannot have a line with a price of zero"))
+
+            if float_compare(line.price_unit, 0, precision_digits=precision) == -1:
+                from_loyalty = self.env.context.get('from_loyalty', False)
+                
+                is_official_discount = (
+                    self.env.company.sale_discount_product_id
+                    and line.product_id == self.env.company.sale_discount_product_id
+                )
+                
+                is_reward = any(l.reward_id or l.coupon_id for l in line.sale_line_ids)
+                
+                if not from_pos and not from_loyalty and not is_official_discount and not is_reward:
+                    raise ValidationError(_("An invoice cannot have a line with a negative price unless it is a registered discount or reward"))
 
     def action_post(self):
         for record in self:


### PR DESCRIPTION
Problema: La validacion era sumamente determinante para numeros negativos, cosa que en el modelo de negocio con descuentos, promociones y otras cosas relacionadas a lineas con precio negativo, nos impedian crear una factura con dichas lineas

Solucion:Solución: Se refinó la validación

_check_price_in_zero
 para permitir montos negativos exclusivamente en líneas de Descuento oficial o Promociones/Cupones (verificando reward_id/coupon_id en Odoo 17). Se incorporó el uso de float_utils y la precisión decimal de la moneda (decimal_places) para garantizar exactitud contable y evitar errores de redondeo.

link:https://binaural.odoo.com/web#id=11517&cids=2&menu_id=293&action=390&model=helpdesk.ticket&view_type=form

Ticket de TRIAJE [x]