### PR TITLE
FIX # 11583 l10n_ve_purchase

### DIFF
--- a/l10n_ve_purchase/__init__.py
+++ b/l10n_ve_purchase/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ve_purchase/__manifest__.py
+++ b/l10n_ve_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Compras",
-    "version": "17.0.0.0.0",
+    "version": "17.0.0.0.1",
     "license": "LGPL-3",
     "summary": "Módulo para gestionar compras en Venezuela",
     "description": """

--- a/l10n_ve_purchase/models/__init__.py
+++ b/l10n_ve_purchase/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order_line

--- a/l10n_ve_purchase/models/purchase_order_line.py
+++ b/l10n_ve_purchase/models/purchase_order_line.py
@@ -1,0 +1,23 @@
+from odoo import models, api, fields
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    def _prepare_account_move_line(self, move=False):
+        """
+        Override the account move line to use the price total instead of the price unit discounted.
+        This fix ensures proper rounding to avoid precision residues (example, 0.0005) 
+        that cause unbalanced move errors.
+        """
+        res = super()._prepare_account_move_line(move=move)
+        if 'balance' not in res:
+            total_wo_tax = self.price_total
+            res['balance'] = self.currency_id._convert(
+                total_wo_tax,
+                self.company_id.currency_id,
+                self.company_id,
+                self.order_id.date_order or fields.Date.today(),
+                round=True,
+            )
+        return res


### PR DESCRIPTION
Problema: Error de asiento desbalanceado (residuo de 0.005 BS) al crear facturas desde órdenes de compra debido a conversiones de moneda sin redondeo.

Solución: Implementación de redondeo forzado (round=True) en la conversión de líneas de compra a factura y saneamiento de precisión en el cálculo de impuestos.

link:https://binaural.odoo.com/web#id=11583&cids=2&menu_id=293&action=390&model=helpdesk.ticket&view_type=form

Ticket de TRIAJE [x]