### PR TITLE
[FIX] l10n_ve_location: corregir filtrado de ciudades por estado

### DIFF
--- a/l10n_ve_location/__manifest__.py
+++ b/l10n_ve_location/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "1.0",
+    "version": "1.1",
     "depends": ["base", "contacts"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_ve_location/views/res_partner_views.xml
+++ b/l10n_ve_location/views/res_partner_views.xml
@@ -18,7 +18,7 @@
 						</div>
 						<div class="o_row">
 							<field name="state_id" placeholder="Estado"/>
-							<field name="city_id" placeholder="Ciudad" required='1'/>	
+							<field name="city_id" placeholder="Ciudad" domain="[('state_id', '=', state_id)]" required='1'/>	
 						</div>
 						<field name="city" invisible='1'/>
 						<div class="o_row">
@@ -40,7 +40,7 @@
 				</xpath>
 
 				<xpath expr="//sheet/notebook/page[@name='contact_addresses']/field[@name='child_ids']/form//field[@name='city']" position="replace">
-					<field name="city_id" placeholder="Ciudad" />
+					<field name="city_id" placeholder="Ciudad" domain="[('state_id', '=', state_id)]" />
 					<field name="city" invisible="1" />
 				</xpath>
 				<xpath expr="//sheet/notebook/page[@name='contact_addresses']/field[@name='child_ids']/form//field[@name='street2']" position="after">


### PR DESCRIPTION
Se añadió el dominio [('state_id', '=', state_id)] al campo city_id en las vistas del partner (formulario principal y contactos hijos). Esto asegura que al seleccionar una ciudad, el buscador solo muestre las ciudades pertenecientes al estado previamente seleccionado.

References: https://binaural.odoo.com/web#id=65221&model=project.task