### PR TITLE
FIX [11671] l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.1.5",
+    "version": "17.0.0.1.6",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -163,6 +163,7 @@ class AccountMove(models.Model):
     foreign_balance = fields.Monetary(
         compute="_compute_total_debit_credit", currency_field="foreign_currency_id"
     )
+    display_foreign_balance_warning = fields.Boolean(compute="_compute_total_debit_credit")
     
     foreign_inverse_rate_vef = fields.Float(compute="_compute_inverse_rate_vef",store=True)
 
@@ -209,6 +210,7 @@ class AccountMove(models.Model):
             move.foreign_debit = sum(move.line_ids.mapped("foreign_debit"))
             move.foreign_credit = sum(move.line_ids.mapped("foreign_credit"))
             move.foreign_balance = move.foreign_currency_id.round((move.foreign_debit - move.foreign_credit))
+            move.display_foreign_balance_warning = not move.foreign_currency_id.is_zero(move.foreign_balance)
 
     def _get_journal_income_account(self, journal):
         """

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -5,8 +5,8 @@
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
             <xpath expr="//header" position="after">
-                <field name="foreign_balance" invisible="1" />
-                <div class="alert alert-warning mb-0" role="alert" invisible="foreign_balance == 0">
+                <field name="display_foreign_balance_warning" invisible="1" />
+                <div class="alert alert-warning mb-0" role="alert" invisible="not display_foreign_balance_warning">
                     Warning: This account move has a foreign balance of <field
                         name="foreign_balance" />. </div>
             </xpath>


### PR DESCRIPTION
Problema:
La alerta de balance alterno se mostraba de forma errónea cuando el saldo era 0 debido a imprecisiones de coma flotante en la evaluación del lado del cliente (XML).

Solución:
Se introduce el campo computado 'display_foreign_balance_warning' que utiliza la herramienta 'is_zero' de Odoo para validar el saldo con la precisión exacta de la moneda. Se actualiza la vista para depender de este nuevo campo.

Link: https://binaural.odoo.com/web#id=11671&cids=2&model=helpdesk.ticket&view_type=form Ticket de TRIAJE [x]