### PR TITLE
[FIX] l10n_ve_invoice

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.1.4",
+    "version": "17.0.0.1.5",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/report/report_invoice_free_form.xml
+++ b/l10n_ve_invoice/report/report_invoice_free_form.xml
@@ -71,7 +71,7 @@
                                 <span>
                                     <strong>Total facturado:</strong>
                                         <t 
-                                            t-out="o.reversed_entry_id.amount_total if currency_base else o.reversed_entry_id.foregn_total_billed" 
+                                            t-out="o.reversed_entry_id.amount_total if currency_base else o.reversed_entry_id.foreign_total_billed" 
                                             t-options='{"widget": "monetary", "display_currency": o.currency_id if currency_base else o.foreign_currency_id}'
                                         />
                                 </span>


### PR DESCRIPTION
Ticket 11764
-Corregir error en código de formato para Nota de credito 
-Problema: error por inexstencia de campo mala escrito -Solucion: Se arregla campo mal escrito
-https://binaural.odoo.com/web#cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form&id=11764