### PR TITLE
[FEAT] l10n_ve_invoice: agregar campos de base e IVA para compras internacionales

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "1.17",
+    "version": "1.19",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e-20251118\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-19 13:57+0000\n"
-"PO-Revision-Date: 2025-12-19 13:57+0000\n"
+"POT-Creation-Date: 2026-03-18 14:27+0000\n"
+"PO-Revision-Date: 2026-03-18 14:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -551,6 +551,35 @@ msgstr "Mostrar total en USD en factura"
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_res_config_settings_l10n_ve_invoice
 msgid "Show Total USD on Free Form Invoice"
 msgstr "Mostrar total en USD en forma libre"
+
+#. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.tax_groups_totals_ve
+msgid "Subtotal"
+msgstr "Subtotal"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__tax_amount_for_international_purchase
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__tax_amount_for_international_purchase
+msgid "Tax Amount for International Purchase"
+msgstr "IVA 16%"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__tax_base_for_international_purchase
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__tax_base_for_international_purchase
+msgid "Tax Base for International Purchase"
+msgstr "Base imponible IVA"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_bank_statement_line__tax_amount_for_international_purchase
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_move__tax_amount_for_international_purchase
+msgid "Tax amount for international purchase to show in purchase book"
+msgstr "Monto del IVA para compras internacionales a mostrar en el libro de compras"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_bank_statement_line__tax_base_for_international_purchase
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_move__tax_base_for_international_purchase
+msgid "Tax base for international purchase to show in purchase book"
+msgstr "Base imponible para compras internacionales a mostrar en el libro de compras"
 
 #. module: l10n_ve_invoice
 #. odoo-python

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -22,6 +22,11 @@ class AccountMove(models.Model):
         default=fields.Date.today,
         help="Date of the invoice. Defaults to today when creating a new invoice."
     )
+    
+    tax_base_for_international_purchase = fields.Float(string='Tax Base for International Purchase', help='Tax base for international purchase to show in purchase book')
+    
+    tax_amount_for_international_purchase = fields.Float(string='Tax Amount for International Purchase', help='Tax amount for international purchase to show in purchase book')
+    
     invoice_reception_date = fields.Date(
         "Reception Date",
         help="Indicates when the invoice was received by the client/company",

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -8,6 +8,10 @@
                 <field name="is_contingency" invisible="1" />
                 <field name="entry_in_period" invisible="1" />
             </field>
+            <xpath expr="//field[@name='ref']" position="after">
+                <field name="tax_base_for_international_purchase" invisible="not is_purchase_international" required="is_purchase_international" readonly="state == 'posted'"/>
+                <field name="tax_amount_for_international_purchase" invisible="not is_purchase_international" required="is_purchase_international" readonly="state == 'posted'"/>
+            </xpath>
             <xpath expr="//header/button[@name='button_cancel'][2]" position="attributes">
                 <attribute name="invisible">not entry_in_period and (not id or state != 'draft' or move_type == 'entry')</attribute>
             </xpath>

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -1118,18 +1118,22 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
         })
 
         if move.journal_id.is_purchase_international:
+            # Use custom fields if available, otherwise use calculated taxes for GENERAL (16%)
+            tb_general_intl = move.tax_base_for_international_purchase or tax_base_general_aliquot
+            am_general_intl = move.tax_amount_for_international_purchase or amount_general_aliquot
+
             tax_result.update({
-                "tax_base_reduced_aliquot_international": tax_result.get("tax_base_reduced_aliquot", 0.0),
-                "amount_reduced_aliquot_international": tax_result.get("amount_reduced_aliquot", 0.0),
-                "tax_base_general_aliquot_international": tax_result.get("tax_base_general_aliquot", 0.0),
-                "amount_general_aliquot_international": tax_result.get("amount_general_aliquot", 0.0),
-                "tax_base_extend_aliquot_international": tax_result.get("tax_base_extend_aliquot", 0.0),
-                "amount_extend_aliquot_international": tax_result.get("amount_extend_aliquot", 0.0),
+                "tax_base_reduced_aliquot_international": tax_base_reduced_aliquot,
+                "amount_reduced_aliquot_international": amount_reduced_aliquot,
+                "tax_base_general_aliquot_international": tb_general_intl,
+                "amount_general_aliquot_international": am_general_intl,
+                "tax_base_extend_aliquot_international": tax_base_extend_aliquot,
+                "amount_extend_aliquot_international": amount_extend_aliquot,
                 "international_tax_base_exempt_aliquot": tax_result.get("international_tax_base_exempt_aliquot", 0.0),
                 "international_amount_taxed": (
-                    tax_result.get("tax_base_reduced_aliquot", 0.0) + tax_result.get("amount_reduced_aliquot", 0.0) +
-                    tax_result.get("tax_base_general_aliquot", 0.0) + tax_result.get("amount_general_aliquot", 0.0) +
-                    tax_result.get("tax_base_extend_aliquot", 0.0) + tax_result.get("amount_extend_aliquot", 0.0) +
+                    tax_base_reduced_aliquot + amount_reduced_aliquot +
+                    tb_general_intl + am_general_intl +
+                    tax_base_extend_aliquot + amount_extend_aliquot +
                     tax_result.get("international_tax_base_exempt_aliquot", 0.0)
                 ),
              })


### PR DESCRIPTION
Se incorporan los campos 'Base imponible IVA' y 'IVA 16%' en el modelo de facturas
para ser utilizados específicamente en compras internacionales. Se actualiza el
reporte del libro de compras para que tome los valores de estos nuevos campos
en lugar de los calculados automáticamente en el cuadro de compras internacionales.

References: https://binaural.odoo.com/web#id=66659&cids=2&menu_id=975&action=341&model=project.task&view_type=form