### PR TITLE
[FIX #11422 #11486] l10n_ve_pos

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.8",
+    "version": "17.0.0.0.9",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/models/pos_session.py
+++ b/l10n_ve_pos/models/pos_session.py
@@ -508,6 +508,7 @@ class PosSession(models.Model):
         # Se sobreescribe esta funcion para poder reasignar la cuenta de destino del account_payment, ya que odoo base la sobreescribe luego de crearla
         outstanding_account = payment_method.outstanding_account_id or self.company_id.account_journal_payment_debit_account_id
         destination_account = self._get_receivable_account(payment_method)
+        pos_receivable_account = destination_account
 
         if float_compare(amounts['amount'], 0, precision_rounding=self.currency_id.rounding) < 0:
             # revert the accounts because account.payment doesn't accept negative amount.
@@ -538,6 +539,11 @@ class PosSession(models.Model):
         )
 
         res = account_payment.move_id.line_ids.filtered(lambda line: line.account_id == account_payment.destination_account_id)
+
+        if float_compare(amounts['amount'], 0, precision_rounding=self.currency_id.rounding) < 0:
+            res = account_payment.move_id.line_ids.filtered(
+                lambda line: line.account_id == pos_receivable_account
+            )
 
         for line in account_payment.move_id.line_ids:
             if line.credit > 0 and amounts.get("foreign_amount", False):
@@ -571,6 +577,14 @@ class PosSession(models.Model):
             if line.debit > 0:
                 line.not_foreign_recalculate = True
                 line.foreign_debit = abs(payment.foreign_amount)
+
+        if float_compare(amounts['amount'], 0, precision_rounding=self.currency_id.rounding) < 0:
+            accounting_partner = self.env["res.partner"]._find_accounting_partner(payment.partner_id)
+            partner_receivable = accounting_partner.property_account_receivable_id
+            res = account_payment.move_id.line_ids.filtered(
+                lambda line: line.account_id == partner_receivable
+            )
+
         if account_payment.pos_payment_method_id.split_transactions:
             self._create_cross_move_payment(res, amounts)
         return res


### PR DESCRIPTION
Problema:
Se produce un crash con UserError: "Entries are not from the same account" al intentar cerrar sesiones de POS con reembolsos (cuando el monto total por método de pago es negativo o en reembolsos con split_transactions). El origen técnico es que el método base de Odoo, al procesar montos negativos en la creación de pagos, intercambia las cuentas outstanding y destination para que el pago sea positivo. Esto causa que el objeto 'res' (línea de asiento devuelta) apunte a la cuenta transitoria, mientras que su par de conciliación en la sesión POS sí se crea usando la cuenta por cobrar, provocando un descuadre de cuentas al intentar conciliar en el cierre de caja.

Solución:
Se sobreescriben _create_combine_account_payment y _create_split_account_payment en l10n_ve_pos para detectar montos negativos (reembolsos). En estos casos, se fuerza un re-filtrado del objeto 'res' hacia la cuenta por cobrar original (del método o del partner) antes de devolverlo. Esto asegura que ambas líneas destinadas a conciliación compartan la misma cuenta contable, eliminando el error de cuentas distintas y permitiendo el cierre exitoso de la sesión.

LINK: https://binaural.odoo.com/web#id=11486&cids=2&menu_id=293&action=390&model=helpdesk.ticket&view_type=form https://binaural.odoo.com/web#id=11422&cids=2&menu_id=293&action=390&model=helpdesk.ticket&view_type=form Ticket de TRIAJE [x]