### PR TITLE
[FEAT] l10n_ve_accountant: bloquear partner tras publicación del pago

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.34",
+    "version": "1.35",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -79,6 +79,8 @@ class AccountPayment(models.Model):
         store=True,
     )
 
+    block_change_partner_after_post = fields.Boolean(default=False)
+
     other_rate = fields.Float(
         compute="_compute_other_rate",
         digits="Tasa",
@@ -204,6 +206,14 @@ class AccountPayment(models.Model):
             if not bool(payment.other_rate):
                 return
             payment.other_rate_inverse = Rate.compute_inverse_rate(payment.other_rate)
+
+    def action_post(self):
+        res = super().action_post()
+        for payment in self:
+            payment.block_change_partner_after_post = True
+        
+        return res
+            
 
     # @api.model
     # def _get_trigger_fields_to_synchronize(self):

--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -209,9 +209,8 @@ class AccountPayment(models.Model):
 
     def action_post(self):
         res = super().action_post()
-        for payment in self:
-            payment.block_change_partner_after_post = True
-        
+        # Establecer el booleano en todos los pagos en una sola escritura para mayor eficiencia
+        self.write({"block_change_partner_after_post": True})
         return res
             
 

--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -79,7 +79,7 @@ class AccountPayment(models.Model):
         store=True,
     )
 
-    block_change_partner_after_post = fields.Boolean(default=False)
+    block_change_partner_after_post = fields.Boolean(default=False, copy=False)
 
     other_rate = fields.Float(
         compute="_compute_other_rate",

--- a/l10n_ve_accountant/views/account_payment.xml
+++ b/l10n_ve_accountant/views/account_payment.xml
@@ -7,6 +7,15 @@
             <!-- <xpath expr="//group[1]/field[@name='ref']" position="after">
                 <field name="concept" />
             </xpath> -->
+            <xpath expr="//field[@name='partner_id']" position="before">
+                <field name="block_change_partner_after_post" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='partner_id'][1]" position="attributes">
+                <attribute name="readonly">block_change_partner_after_post</attribute>
+            </xpath>
+            <xpath expr="//field[@name='partner_id'][2]" position="attributes">
+                <attribute name="readonly">block_change_partner_after_post</attribute>
+            </xpath>
             <xpath expr="//group[2]/field[@name='partner_bank_id'][3]" position="after">                
                 <label for="foreign_rate" invisible="not is_foreign_currency and currency_id != company_currency_id"/>
                 <div class="o_row d-flex" invisible="not is_foreign_currency and currency_id != company_currency_id">


### PR DESCRIPTION
Se añade un campo técnico 'block_change_partner_after_post' para bloquear
la edición del cliente o proveedor una vez que el pago ha sido publicado.
Esto asegura que, incluso si el pago es reestablecido a borrador, el
partner original permanezca inalterado para mantener la integridad fiscal.

References: https://binaural.odoo.com/web#id=65774&cids=2&menu_id=975&action=341&model=project.task&view_type=form