### PR TITLE
[FIX]l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -862,7 +862,6 @@ class StockPicking(models.Model):
                         and record.sale_id.document != "invoice"
                         and record.type_of_return != "total"
                     )
-
                     record.show_create_customer_credit = record.is_return
 
                 if record.operation_code == "internal" and record.is_consignment:
@@ -1173,6 +1172,7 @@ class StockPicking(models.Model):
                 picking.message_post(body=f"Error en facturación automática: {str(e)}")
 
     def alert_views(self, company_ids_str):
+
         company_ids = [
             int(cid) for cid in str(company_ids_str).split(",") if cid.strip().isdigit()
         ]


### PR DESCRIPTION
-Se cambia el domain del boton de devolucion,en Odoo nativamente te permite hacer una devolucion a una devolucion contemplando el flujo de guia de despacho esto no es correcto

-Adicionalmente aquellas guias de despacho que hayan sido devueltas totalmente no deben aparecer en la vista de guias de despacho(solo se deben mostrar las guias de despacho que no tengan devoluciones o que sus devoluciones sean parciales).
Link:https://binaural.odoo.com/web#id=11398&cids=2&menu_id=302&action=386&model=helpdesk.ticket&view_type=form