### PR TITLE
[IMP]l10n_ve_stock_account:Ahora se enviara a la factura la cantidad …

### DIFF
--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -481,7 +481,7 @@ class StockPicking(models.Model):
                         else move_id.product_id.categ_id.property_account_income_categ_id.id
                     ),
                     "tax_ids": tax_ids,
-                    "quantity": move_id.quantity,
+                    "quantity": move_id.sale_line_id.qty_delivered if move_id.sale_line_id else move_id.quantity,
                     "from_picking_line": from_picking_line,
                 },
             )


### PR DESCRIPTION
…entregada.

Anteriormente se llevaba a la factura la cantidad de los stock.moves,es decir que si el stock.move tenia 10 unidades se llevaba esas 10 a la linea de la factura,pero esto no contemplaba entregas parciales ni devoluaciones entonces se cambia a usar el campo qty_delivered de las lineas de venta.

Link:https://www.binauraldev.com/web#id=66614&cids=2&menu_id=257&action=341&model=project.task&view_type=form