### PR TITLE
[FIX] ln10_ve_accountant,ln10_ve_igtf: redondear calculo en bs

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.1.7",
+    "version": "17.0.0.1.8",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -129,3 +129,20 @@ class AccountPaymentRegister(models.TransientModel):
             'source_amount': source_amount,
             'source_amount_currency': source_amount_currency,
         }
+
+    @api.depends('can_edit_wizard', 'source_amount', 'source_amount_currency', 'source_currency_id', 'company_id', 'currency_id', 'payment_date')
+    def _compute_amount(self):
+        super()._compute_amount()
+
+        for wizard in self:
+
+            if not wizard.is_igtf and wizard.currency_id == wizard.company_id.currency_foreign_id:
+                tasa_exacta = wizard.foreign_inverse_rate
+                if not tasa_exacta:
+                    Rate = self.env["res.currency.rate"]
+                    rate_values = Rate.compute_rate(wizard.source_currency_id.id, wizard.payment_date)
+                    tasa_exacta = rate_values.get('foreign_inverse_rate', 0.0)
+                
+                if tasa_exacta:
+                    monto_exacto = round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * round(tasa_exacta, wizard.currency_id.decimal_places)
+                    wizard.amount = monto_exacto

--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
         "depends": [
         "base",
         "l10n_ve_accountant",

--- a/l10n_ve_igtf/wizard/account_payment_register.py
+++ b/l10n_ve_igtf/wizard/account_payment_register.py
@@ -61,6 +61,7 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
     @api.depends('can_edit_wizard', 'source_amount', 'source_amount_currency', 'source_currency_id', 'company_id', 'currency_id', 'payment_date')
     def _compute_amount(self):
         
+        super()._compute_amount()
         for wizard in self:
             
             base_amount = 0.0
@@ -75,7 +76,6 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
             final_amount = base_amount
             total_igtf_amount = 0.0
             if wizard.is_igtf:
-
                 move_ids = wizard.get_moves()
 
                 for invoice in move_ids:
@@ -87,10 +87,18 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
 
                     total_igtf_amount += igtf_for_invoice
                 final_amount = base_amount + total_igtf_amount
+<<<<<<< HEAD
             wizard.amount = final_amount
             wizard.igtf_amount = total_igtf_amount
             wizard.igtf_to_show = total_igtf_amount
             wizard.last_computed_amount = final_amount
+=======
+            
+                wizard.amount = final_amount
+                wizard.igtf_amount = total_igtf_amount
+                wizard.igtf_to_show = total_igtf_amount
+                wizard.last_computed_amount = final_amount
+>>>>>>> 103ae5bf ([FIX] ln10_ve_accountant,ln10_ve_igtf: redondear calculo en bs)
       
            
     


### PR DESCRIPTION
Descripción: Redondear el calculo en bs al realizar un pago en bs, sin afectar el igtf

References:
- Ticket: https://binaural.odoo.com/web?debug=1#id=11732&cids=2&menu_id=306&action=393&active_id=89&model=helpdesk.ticket&view_type=form
- Tarea:
- PR:
- Otros: