### PR TITLE
[FIX] ln10_ve_accountant,ln10_ve_igtf: redondear calculo en bs

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.1.9",
+    "version": "17.0.0.1.10",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.46",
+    "version": "17.0.0.1.9",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -168,11 +168,13 @@ class AccountMove(models.Model):
 
     foreign_amount_residual = fields.Monetary('Foreign Amount Residual',copy=False, compute = "_compute_foreign_amount_residual", currency_field="foreign_currency_id",readonly=False)
 
-    @api.depends('amount_residual','company_currency_id','foreign_inverse_rate')
+    @api.depends('tax_totals')
     def _compute_foreign_amount_residual(self):
         for rec in self:
-            
-            rec.foreign_amount_residual = float_round(rec.amount_residual,rec.currency_id.decimal_places) * float_round(rec.foreign_inverse_rate,rec.currency_id.decimal_places)
+            if rec.tax_totals and "foreign_total_residual" in rec.tax_totals:
+                rec.foreign_amount_residual = rec.tax_totals.get("foreign_total_residual", 0.0)
+            else:
+                rec.foreign_amount_residual = float_round(rec.amount_residual,rec.currency_id.decimal_places) * float_round(rec.foreign_inverse_rate,rec.currency_id.decimal_places)
             
          
 

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -171,7 +171,8 @@ class AccountMove(models.Model):
     @api.depends('amount_residual','company_currency_id','foreign_inverse_rate')
     def _compute_foreign_amount_residual(self):
         for rec in self:
-            rec.foreign_amount_residual = rec.amount_residual * rec.foreign_inverse_rate
+            
+            rec.foreign_amount_residual = float_round(rec.amount_residual,rec.currency_id.decimal_places) * float_round(rec.foreign_inverse_rate,rec.currency_id.decimal_places)
             
          
 

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -135,16 +135,23 @@ class AccountPaymentRegister(models.TransientModel):
         super()._compute_amount()
 
         for wizard in self:
-            if not wizard.is_igtf and wizard.currency_id == wizard.company_id.currency_foreign_id:
+            if wizard.currency_id == wizard.company_id.currency_foreign_id:
+                
                 exact_rate = wizard.foreign_inverse_rate
                 if not exact_rate:
                     Rate = self.env["res.currency.rate"]
                     rate_values = Rate.compute_rate(wizard.source_currency_id.id, wizard.payment_date)
                     exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
                 
-                if exact_rate:
-                    wizard.amount = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
-
+                if exact_rate and wizard.company_id.currency_foreign_id == wizard.currency_id:
+                    
+                    moves = wizard.line_ids.mapped('move_id')
+                    total_foreign_debt = sum(moves.mapped('foreign_amount_residual')) if moves else 0.0
+                    
+                    if total_foreign_debt:
+                        wizard.amount = total_foreign_debt
+                    else:
+                        wizard.amount = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
 
     @api.depends('can_edit_wizard', 'amount', 'foreign_inverse_rate')
     def _compute_payment_difference(self):
@@ -152,13 +159,18 @@ class AccountPaymentRegister(models.TransientModel):
         
         for wizard in self:
             if wizard.can_edit_wizard and wizard.currency_id == wizard.company_id.currency_foreign_id:
-                exact_rate = wizard.foreign_inverse_rate
-                if not exact_rate:
-                    Rate = self.env["res.currency.rate"]
-                    rate_values = Rate.compute_rate(wizard.source_currency_id.id, wizard.payment_date)
-                    exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
+                moves = wizard.line_ids.mapped('move_id')
+                total_foreign_debt = sum(moves.mapped('foreign_amount_residual')) if moves else 0.0
                 
-                if exact_rate:
-                    exact_debt = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
+                if total_foreign_debt:
+                    wizard.payment_difference = total_foreign_debt - wizard.amount
+                else:
+                    exact_rate = wizard.foreign_inverse_rate
+                    if not exact_rate:
+                        Rate = self.env["res.currency.rate"]
+                        rate_values = Rate.compute_rate(wizard.source_currency_id.id, wizard.payment_date)
+                        exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
                     
-                    wizard.payment_difference = exact_debt - wizard.amount
+                    if exact_rate:
+                        exact_debt = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
+                        wizard.payment_difference = exact_debt - wizard.amount

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -159,6 +159,6 @@ class AccountPaymentRegister(models.TransientModel):
                     exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
                 
                 if exact_rate:
-                    deuda_exacta = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
+                    exact_debt = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
                     
-                    wizard.payment_difference = deuda_exacta - wizard.amount
+                    wizard.payment_difference = exact_debt - wizard.amount

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -129,3 +129,20 @@ class AccountPaymentRegister(models.TransientModel):
             'source_amount': source_amount,
             'source_amount_currency': source_amount_currency,
         }
+
+    @api.depends('can_edit_wizard', 'source_amount', 'source_amount_currency', 'source_currency_id', 'company_id', 'currency_id', 'payment_date')
+    def _compute_amount(self):
+        super()._compute_amount()
+
+        for wizard in self:
+
+            if not wizard.is_igtf and wizard.currency_id == wizard.company_id.currency_foreign_id:
+                tasa_exacta = wizard.foreign_inverse_rate
+                if not tasa_exacta:
+                    Rate = self.env["res.currency.rate"]
+                    rate_values = Rate.compute_rate(wizard.source_currency_id.id, wizard.payment_date)
+                    tasa_exacta = rate_values.get('foreign_inverse_rate', 0.0)
+                
+                if tasa_exacta:
+                    monto_exacto = round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * round(tasa_exacta, wizard.currency_id.decimal_places)
+                    wizard.amount = monto_exacto

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -144,5 +144,5 @@ class AccountPaymentRegister(models.TransientModel):
                     exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
                 
                 if exact_rate:
-                    monto_exacto = round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * round(tasa_exacta, wizard.currency_id.decimal_places)
-                    wizard.amount = monto_exacto
+                    exact_amount = round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * round(exact_rate, wizard.currency_id.decimal_places)
+                    wizard.amount = exact_amount

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -136,7 +136,7 @@ class AccountPaymentRegister(models.TransientModel):
 
         for wizard in self:
 
-            if not wizard.is_igtf and wizard.currency_id == wizard.company_id.currency_foreign_id:
+            if wizard.currency_id == wizard.company_id.currency_foreign_id:
                 exact_rate = wizard.foreign_inverse_rate
                 if not exact_rate:
                     Rate = self.env["res.currency.rate"]

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -144,5 +144,5 @@ class AccountPaymentRegister(models.TransientModel):
                     exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
                 
                 if exact_rate:
-                    exact_amount = round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * round(exact_rate, wizard.currency_id.decimal_places)
+                    exact_amount = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
                     wizard.amount = exact_amount

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -137,12 +137,12 @@ class AccountPaymentRegister(models.TransientModel):
         for wizard in self:
 
             if not wizard.is_igtf and wizard.currency_id == wizard.company_id.currency_foreign_id:
-                tasa_exacta = wizard.foreign_inverse_rate
-                if not tasa_exacta:
+                exact_rate = wizard.foreign_inverse_rate
+                if not exact_rate:
                     Rate = self.env["res.currency.rate"]
                     rate_values = Rate.compute_rate(wizard.source_currency_id.id, wizard.payment_date)
-                    tasa_exacta = rate_values.get('foreign_inverse_rate', 0.0)
+                    exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
                 
-                if tasa_exacta:
+                if exact_rate:
                     monto_exacto = round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * round(tasa_exacta, wizard.currency_id.decimal_places)
                     wizard.amount = monto_exacto

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -129,14 +129,13 @@ class AccountPaymentRegister(models.TransientModel):
             'source_amount': source_amount,
             'source_amount_currency': source_amount_currency,
         }
-
+    
     @api.depends('can_edit_wizard', 'source_amount', 'source_amount_currency', 'source_currency_id', 'company_id', 'currency_id', 'payment_date')
     def _compute_amount(self):
         super()._compute_amount()
 
         for wizard in self:
-
-            if wizard.currency_id == wizard.company_id.currency_foreign_id:
+            if not wizard.is_igtf and wizard.currency_id == wizard.company_id.currency_foreign_id:
                 exact_rate = wizard.foreign_inverse_rate
                 if not exact_rate:
                     Rate = self.env["res.currency.rate"]
@@ -144,5 +143,22 @@ class AccountPaymentRegister(models.TransientModel):
                     exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
                 
                 if exact_rate:
-                    exact_amount = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
-                    wizard.amount = exact_amount
+                    wizard.amount = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
+
+
+    @api.depends('can_edit_wizard', 'amount', 'foreign_inverse_rate')
+    def _compute_payment_difference(self):
+        super()._compute_payment_difference()
+        
+        for wizard in self:
+            if wizard.can_edit_wizard and wizard.currency_id == wizard.company_id.currency_foreign_id:
+                exact_rate = wizard.foreign_inverse_rate
+                if not exact_rate:
+                    Rate = self.env["res.currency.rate"]
+                    rate_values = Rate.compute_rate(wizard.source_currency_id.id, wizard.payment_date)
+                    exact_rate = rate_values.get('foreign_inverse_rate', 0.0)
+                
+                if exact_rate:
+                    deuda_exacta = float_round(wizard.source_amount_currency, wizard.currency_id.decimal_places) * float_round(exact_rate, wizard.currency_id.decimal_places)
+                    
+                    wizard.payment_difference = deuda_exacta - wizard.amount

--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
         "depends": [
         "base",
         "l10n_ve_accountant",

--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.0.2",
         "depends": [
         "base",
         "l10n_ve_accountant",

--- a/l10n_ve_igtf/wizard/account_payment_register.py
+++ b/l10n_ve_igtf/wizard/account_payment_register.py
@@ -84,10 +84,8 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
                         base_amount, 
                         wizard.igtf_percentage
                     )
-
-                    total_igtf_amount += igtf_for_invoice
+                total_igtf_amount += float_round(igtf_for_invoice,wizard.currency_id.decimal_places)
                 final_amount = base_amount + total_igtf_amount
-            
                 wizard.amount = final_amount
                 wizard.igtf_amount = total_igtf_amount
                 wizard.igtf_to_show = total_igtf_amount
@@ -217,7 +215,7 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
         
 
         igtf_unrounded = principal_amount * (self.env.company.igtf_percentage / 100)
-
+      
         igtf_top = invoice.igtf_top_aply
 
         alter_bi_igtf = invoice.alter_bi_igtf

--- a/l10n_ve_igtf/wizard/account_payment_register.py
+++ b/l10n_ve_igtf/wizard/account_payment_register.py
@@ -61,6 +61,7 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
     @api.depends('can_edit_wizard', 'source_amount', 'source_amount_currency', 'source_currency_id', 'company_id', 'currency_id', 'payment_date')
     def _compute_amount(self):
         
+        super()._compute_amount()
         for wizard in self:
             
             base_amount = 0.0
@@ -75,7 +76,6 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
             final_amount = base_amount
             total_igtf_amount = 0.0
             if wizard.is_igtf:
-
                 move_ids = wizard.get_moves()
 
                 for invoice in move_ids:
@@ -87,10 +87,11 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
 
                     total_igtf_amount += igtf_for_invoice
                 final_amount = base_amount + total_igtf_amount
-            wizard.amount = final_amount
-            wizard.igtf_amount = total_igtf_amount
-            wizard.igtf_to_show = total_igtf_amount
-            wizard.last_computed_amount = final_amount
+            
+                wizard.amount = final_amount
+                wizard.igtf_amount = total_igtf_amount
+                wizard.igtf_to_show = total_igtf_amount
+                wizard.last_computed_amount = final_amount
       
            
     

--- a/l10n_ve_tax/__manifest__.py
+++ b/l10n_ve_tax/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.18",
+    "version": "17.0.0.0.19",
     # any module necessary for this one to work correctly
     "depends": ["base", "account", "l10n_ve_base", "l10n_ve_rate"],
     "data": [

--- a/l10n_ve_tax/models/account_tax.py
+++ b/l10n_ve_tax/models/account_tax.py
@@ -2,6 +2,7 @@ from odoo.tools.float_utils import float_round, float_compare
 from odoo import api, models, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools.misc import formatLang
+from odoo.tools.float_utils import float_is_zero
 
 import logging
 
@@ -131,9 +132,15 @@ class AccountTax(models.Model):
 
         foreign_amount_total = res.get('foreign_amount_total', 0.0)
 
-        res["foreign_total_residual"] = foreign_amount_total - res["foreign_total_amount_paid"]
-
-        formatted_result = 0 if float_compare(res['foreign_total_residual'], 0, precision_digits=foreign_currency.decimal_places) < 0 else res['foreign_total_residual']
+        raw_residual = foreign_amount_total - res.get("foreign_total_amount_paid", 0.0)
+        
+        if float_is_zero(raw_residual, precision_digits=foreign_currency.decimal_places):
+            res["foreign_total_residual"] = 0.0
+            formatted_result = 0.0
+        else:
+            res["foreign_total_residual"] = raw_residual
+            formatted_result = 0.0 if raw_residual < 0 else raw_residual
+            
         res["foreign_formatted_total_residual"] = formatLang(
             self.env,
             formatted_result,


### PR DESCRIPTION
Descripción: Redondear el calculo en bs al realizar un pago en bs, sin afectar el igtf

References:
- Ticket: https://binaural.odoo.com/web?debug=1#id=11732&cids=2&menu_id=306&action=393&active_id=89&model=helpdesk.ticket&view_type=form
- Tarea:
- PR:
- Otros: