### PR TITLE
[FIX] l10n_ve_accountant: corrección de montos alternos en líneas COGS

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.42",
+    "version": "1.43",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -265,7 +265,7 @@ class AccountMoveLine(models.Model):
                     line.foreign_credit = line.credit * line.foreign_inverse_rate
                 continue
 
-            if line.display_type == "product":
+            if line.display_type in ("product", "cogs"):
                 # 7 Case: Product
                 # In this case, we need to calculate the foreign debit and credit with subtotal
                 sign = line.move_id.direction_sign * -1


### PR DESCRIPTION
Se habilita el cálculo de los campos foreign_debit y foreign_credit para las líneas de asiento con display_type 'cogs'. Esto corrige el problema donde los montos alternos se mostraban en 0,00$ en los apuntes contables generados por la valoración de inventario (contabilidad anglosajona) en facturas de venta y sus rectificativas.

References: https://binaural.odoo.com/web#id=67335&model=project.task