### PR TITLE
[FIX] l10n_ve_stock_account: corregir errores en generación de factura desde guía de despacho

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.1.1",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/i18n/es_VE.po
+++ b/l10n_ve_stock_account/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 19.0+e-20260105\n"
+"Project-Id-Version: Odoo Server 19.0+e-20260313\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-14 00:43+0000\n"
-"PO-Revision-Date: 2026-02-14 00:43+0000\n"
+"POT-Creation-Date: 2026-03-31 10:11+0000\n"
+"PO-Revision-Date: 2026-03-31 10:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -269,7 +269,7 @@ msgstr ""
 #. module: l10n_ve_stock_account
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.dispatch_layout_body
 msgid "Cod."
-msgstr ""
+msgstr "Cód."
 
 #. module: l10n_ve_stock_account
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_transfer_reason__code
@@ -284,7 +284,7 @@ msgstr "Empresas"
 #. module: l10n_ve_stock_account
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.dispatch_layout_header
 msgid "Company Logo"
-msgstr ""
+msgstr "Logo de la Compañía"
 
 #. module: l10n_ve_stock_account
 #: model:ir.model,name:l10n_ve_stock_account.model_res_config_settings
@@ -315,13 +315,11 @@ msgid "Contact"
 msgstr "Contacto"
 
 #. module: l10n_ve_stock_account
-#: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.stock_picking_form_view_inherited
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.stock_picking_guide_dispatch_views
 msgid "Create Bill"
 msgstr "Crear factura"
 
 #. module: l10n_ve_stock_account
-#: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.stock_picking_form_view_inherited
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.stock_picking_guide_dispatch_views
 msgid "Create Credit Note"
 msgstr "Crear nota de crédito"
@@ -344,15 +342,9 @@ msgid "Create Invoice/Bill"
 msgstr "Crear Factura/Recibo"
 
 #. module: l10n_ve_stock_account
-#: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.stock_picking_form_view_inherited
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.stock_picking_guide_dispatch_views
 msgid "Create Vendor Credit"
 msgstr "Crear crédito de proveedor"
-
-#. module: l10n_ve_stock_account
-#: model:ir.model,website_form_label:l10n_ve_stock_account.model_res_partner
-msgid "Create a Customer"
-msgstr "Crear un cliente"
 
 #. module: l10n_ve_stock_account
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_picking_invoice_wizard__create_uid
@@ -452,7 +444,7 @@ msgstr "Guías de Despacho"
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_stock_warehouse__display_name
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_transfer_reason__display_name
 msgid "Display Name"
-msgstr "Nombre en pantalla"
+msgstr "Nombre para mostrar"
 
 #. module: l10n_ve_stock_account
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_sale_order__document
@@ -582,51 +574,9 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_ve_stock_account
-#: model:ir.model.fields,help:l10n_ve_stock_account.field_res_company__indexed_dispatch_guide
-#: model:ir.model.fields,help:l10n_ve_stock_account.field_res_config_settings__indexed_dispatch_guide
-msgid ""
-"If enabled, dispatch guide amounts will use the date of the stock picking "
-"for currency conversion."
-msgstr ""
-"Si está habilitado, los montos de la guía de despacho utilizarán la fecha "
-"efectiva del picking de stock para la conversión de moneda."
-
-#. module: l10n_ve_stock_account
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.dispatch_layout_body
 msgid "IVA"
 msgstr ""
-
-#. module: l10n_ve_stock_account
-#: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.l10n_ve_stock_inherit_l10n_ve_stock_account
-msgid "If checked, the discount field will be hidden in the dispatch guide."
-msgstr "Si está marcado, el campo de descuento se ocultará en la guía de despacho."
-
-#. module: l10n_ve_stock_account
-#: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.l10n_ve_stock_inherit_l10n_ve_stock_account
-msgid "If checked, the weight field will be hidden in the dispatch guide."
-msgstr "Si está marcado, el campo de peso se ocultará en la guía de despacho."
-
-#. module: l10n_ve_stock_account
-#: model:ir.model.fields,help:l10n_ve_stock_account.field_res_company__indexed_dispatch_guide
-#: model:ir.model.fields,help:l10n_ve_stock_account.field_res_config_settings__indexed_dispatch_guide
-msgid ""
-"If enabled, dispatch guide amounts will use the date of the stock picking "
-"for currency conversion."
-msgstr ""
-"Si está habilitado, los montos de la guía de despacho utilizarán la fecha "
-"efectiva del picking de stock para la conversión de moneda."
-
-#. module: l10n_ve_stock_account
-#: model:ir.model.fields,help:l10n_ve_stock_account.field_res_company__hide_disc_field_dispatch_guide
-#: model:ir.model.fields,help:l10n_ve_stock_account.field_res_config_settings__hide_disc_field_dispatch_guide
-msgid "If enabled, the discount field will be hidden in the dispatch guide."
-msgstr "Si está habilitado, el campo de descuento se ocultará en la guía de despacho."
-
-#. module: l10n_ve_stock_account
-#: model:ir.model.fields,help:l10n_ve_stock_account.field_res_company__hide_weight_field_dispatch_guide
-#: model:ir.model.fields,help:l10n_ve_stock_account.field_res_config_settings__hide_weight_field_dispatch_guide
-msgid "If enabled, the weight field will be hidden in the dispatch guide."
-msgstr "Si está habilitado, el campo de peso se ocultará en la guía de despacho."
 
 #. module: l10n_ve_stock_account
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.l10n_ve_stock_inherit_l10n_ve_stock_account
@@ -667,7 +617,9 @@ msgstr ""
 #. module: l10n_ve_stock_account
 #: model:ir.model.fields,help:l10n_ve_stock_account.field_stock_picking__pricelist_id
 msgid "If you change the pricelist, only newly added lines will be affected."
-msgstr "Si cambia la lista de precios, solo las líneas recién agregadas se verán afectadas."
+msgstr ""
+"Si cambia la lista de precios, solo las líneas recién agregadas se verán "
+"afectadas."
 
 #. module: l10n_ve_stock_account
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_res_company__indexed_dispatch_guide
@@ -840,6 +792,11 @@ msgstr ""
 #. module: l10n_ve_stock_account
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_stock_picking__match_guide_dispatch_domain
 msgid "Match Guide Dispatch Domain"
+msgstr "Dominio de Coincidencia de Guía de Despacho"
+
+#. module: l10n_ve_stock_account
+#: model:ir.model.fields.selection,name:l10n_ve_stock_account.selection__stock_picking__type_of_return__n/a
+msgid "N/A"
 msgstr ""
 
 #. module: l10n_ve_stock_account
@@ -886,6 +843,11 @@ msgid "Order Is Consignment"
 msgstr "Pedido es Consignación"
 
 #. module: l10n_ve_stock_account
+#: model:ir.model.fields.selection,name:l10n_ve_stock_account.selection__stock_picking__type_of_return__partial
+msgid "Partial"
+msgstr "Parcial"
+
+#. module: l10n_ve_stock_account
 #: model:ir.model.fields.selection,name:l10n_ve_stock_account.selection__stock_picking__state_guide_dispatch__invoiced_partial
 msgid "Partially Invoiced"
 msgstr "Parcialmente Facturada"
@@ -927,6 +889,14 @@ msgstr "Lista de traslados"
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_picking_invoice_wizard__pickings_ids
 msgid "Pickings"
 msgstr "Guías de Despacho"
+
+#. module: l10n_ve_stock_account
+#. odoo-python
+#: code:addons/l10n_ve_stock_account/models/stock_picking.py:0
+msgid ""
+"Please configure the income account for the product '%s' or its category."
+msgstr ""
+"Por favor configure la cuenta de ingresos para el producto '%s' o su categoría."
 
 #. module: l10n_ve_stock_account
 #. odoo-python
@@ -991,6 +961,11 @@ msgstr "Cantidad despachada"
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_stock_move_line__qty_invoiced
 msgid "Quantity Invoiced"
 msgstr "Cantidad Facturada"
+
+#. module: l10n_ve_stock_account
+#: model:ir.model.fields,field_description:l10n_ve_stock_account.field_stock_move__qty_return
+msgid "Quantity Return"
+msgstr "Cantidad Devuelta"
 
 #. module: l10n_ve_stock_account
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_stock_warehouse__readonly_is_consignation_warehouse
@@ -1212,6 +1187,7 @@ msgid "To add vendor journal"
 msgstr "Para agregar diario de proveedores"
 
 #. module: l10n_ve_stock_account
+#: model:ir.model.fields.selection,name:l10n_ve_stock_account.selection__stock_picking__type_of_return__total
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.dispatch_layout_body
 msgid "Total"
 msgstr ""
@@ -1220,7 +1196,7 @@ msgstr ""
 #: model:ir.model,name:l10n_ve_stock_account.model_stock_picking
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_stock_picking_self_consumption_wizard__picking_id
 msgid "Transfer"
-msgstr "Trasladar"
+msgstr "Transferir"
 
 #. module: l10n_ve_stock_account
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_account_bank_statement_line__transfer_ids
@@ -1237,6 +1213,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_ve_stock_account.field_stock_picking__operation_code
 msgid "Type of Operation"
 msgstr "Tipo de operación"
+
+#. module: l10n_ve_stock_account
+#: model:ir.model.fields,field_description:l10n_ve_stock_account.field_stock_picking__type_of_return
+msgid "Type of Return"
+msgstr "Tipo de Devolución"
 
 #. module: l10n_ve_stock_account
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock_account.dispatch_layout_body
@@ -1312,6 +1293,16 @@ msgstr ""
 
 #. module: l10n_ve_stock_account
 #. odoo-python
+#: code:addons/l10n_ve_stock_account/models/stock_picking.py:0
+msgid ""
+"You have %(pickings_combined)s unbilled dispatch guides as of %(date)s. If "
+"billed in the next period, the Seniat will be Notified."
+msgstr ""
+"Tienes %(pickings_combined)s guías de despacho sin facturar al %(date)s. De "
+"facturarse en el siguiente periodo el Seniat será Notificado."
+
+#. module: l10n_ve_stock_account
+#. odoo-python
 #: code:addons/l10n_ve_stock_account/models/res_company.py:0
 msgid "last_day"
 msgstr ""
@@ -1321,10 +1312,3 @@ msgstr ""
 #: code:addons/l10n_ve_stock_account/models/stock_picking.py:0
 msgid "transfer_ids"
 msgstr ""
-
-#. module: l10n_ve_stock_account
-#. odoo-python
-#: code:addons/l10n_ve_stock_account/models/stock_picking.py:0
-msgid "You have %(pickings_combined)s unbilled dispatch guides as of %(date)s. If billed in the next period, the Seniat will be Notified."
-msgstr "Tienes %(pickings_combined)s guías de despacho sin facturar al %(date)s. De facturarse en el siguiente periodo el Seniat será Notificado."
-

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -4,6 +4,7 @@ import logging
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
+from odoo.tools.safe_eval import safe_eval
 from datetime import date, datetime, timedelta
 import calendar
 
@@ -301,7 +302,11 @@ class StockPicking(models.Model):
             action['res_id'] = invoices.id
 
         ctx = dict(self.env.context)
-        ctx.update(action.get('context', {}) or {})
+        action_ctx = action.get('context') or {}
+        if isinstance(action_ctx, str):
+            action_ctx = safe_eval(action_ctx, {'uid': self.env.uid})
+        ctx.update(action_ctx if isinstance(action_ctx, dict) else {})
+
         ctx.update({
             'default_move_type': 'out_invoice',
             'default_partner_id': self.partner_id.id,
@@ -493,6 +498,18 @@ class StockPicking(models.Model):
             if move_id.sale_line_id:
                 price_unit = move_id.sale_line_id.price_unit
                 tax_ids = [(6, 0, move_id.sale_line_id.tax_ids.ids)]
+            account = (
+                move_id.product_id.property_account_income_id.id
+                if move_id.product_id.property_account_income_id
+                else move_id.product_id.categ_id.property_account_income_categ_id.id
+            )
+            if not account:
+                raise UserError(
+                    _(
+                        "Please configure the income account for the product '%s' or its category."
+                    )
+                    % move_id.product_id.name
+                )
             vals = (
                 0,
                 0,
@@ -500,11 +517,7 @@ class StockPicking(models.Model):
                     "name": move_id.description_picking,
                     "product_id": move_id.product_id.id,
                     "price_unit": price_unit,
-                    "account_id": (
-                        move_id.product_id.property_account_income_id.id
-                        if move_id.product_id.property_account_income_id
-                        else move_id.product_id.categ_id.property_account_income_categ_id.id
-                    ),
+                    "account_id": account,
                     "tax_ids": tax_ids,
                     "quantity": move_id.sale_line_id.qty_delivered if move_id.sale_line_id else move_id.quantity,
                     "from_picking_line": from_picking_line,

--- a/l10n_ve_stock_account/tests/test_create_invoice.py
+++ b/l10n_ve_stock_account/tests/test_create_invoice.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from unittest.mock import patch
 from odoo.tests import TransactionCase, tagged
 from odoo.exceptions import UserError
 from odoo import Command
@@ -7,7 +8,7 @@ from odoo import Command
 _logger = logging.getLogger(__name__)
 
 
-@tagged("post_install", "-at_install")
+@tagged("post_install", "-at_install", "test_create_invoice")
 class TestCreateInvoiceFromPicking(TransactionCase):
     """
     Tests for create_invoice and create_multi_invoice methods
@@ -324,3 +325,41 @@ class TestCreateInvoiceFromPicking(TransactionCase):
         invoice = picking1.create_multi_invoice(pickings)
 
         self.assertTrue(invoice, "Invoice should be created even without explicit pricelist")
+
+    # =========================================================================
+    # action_view_invoice context handling tests
+    # =========================================================================
+
+    def test_action_view_invoice_parses_string_context(self):
+        """Regression: action context may come as a python-literal string."""
+        picking = self._create_sale_order(pricelist=self.pricelist_ves)
+        invoice = picking.create_invoice()
+
+        fake_action = {
+            "views": [(False, "list"), (False, "form")],
+            "context": "{'default_move_type': 'out_invoice', 'default_filter_partner': 'customer'}",
+        }
+
+        with patch.object(type(self.env["ir.actions.actions"]), "_for_xml_id", return_value=fake_action):
+            action = picking.action_view_invoice(invoices=invoice)
+
+        self.assertEqual(action["res_id"], invoice.id)
+        self.assertEqual(action["context"].get("default_filter_partner"), "customer")
+        self.assertEqual(action["context"].get("default_partner_id"), picking.partner_id.id)
+
+    def test_action_view_invoice_ignores_non_dict_context(self):
+        """If context evaluates to a non-dict value, method should not crash."""
+        picking = self._create_sale_order(pricelist=self.pricelist_ves)
+        invoice = picking.create_invoice()
+
+        fake_action = {
+            "views": [(False, "list"), (False, "form")],
+            "context": "'invalid_context'",
+        }
+
+        with patch.object(type(self.env["ir.actions.actions"]), "_for_xml_id", return_value=fake_action):
+            action = picking.action_view_invoice(invoices=invoice)
+
+        self.assertEqual(action["res_id"], invoice.id)
+        self.assertEqual(action["context"].get("default_move_type"), "out_invoice")
+        self.assertEqual(action["context"].get("default_partner_id"), picking.partner_id.id)

--- a/l10n_ve_stock_account/views/stock_picking_guide_dispatch_views.xml
+++ b/l10n_ve_stock_account/views/stock_picking_guide_dispatch_views.xml
@@ -39,7 +39,7 @@
                  <field name="invoice_ids" widget="many2many_tags" optional="hide"/>
                  <field name="pricelist_id" string="Pricelist" optional="hide"/>
                 <button 
-                    name="create_invoice" 
+                    name="action_create_invoice" 
                     class="btn btn-link text-info" 
                     icon="fa-file-text" 
                     string="Create Invoice" 


### PR DESCRIPTION
Se realizan las siguientes correcciones técnicas:
- Se implementa el uso de safe_eval para el manejo del contexto de la acción,
  asegurando que los contextos definidos como strings sean procesados correctamente.
- Se añade validación obligatoria de la cuenta de ingresos para productos y
  categorías, arrojando un UserError informativo si falta configuración,
  evitando fallos de integridad en la creación de facturas.

References: https://binaural.odoo.com/odoo/my-tickets/12042