### PR TITLE
17.0 feat ta 63473 international columns in sale book 2

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.1.6",
+    "version": "17.0.0.1.7",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.1.7",
+    "version": "17.0.0.1.8",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.1.5",
+    "version": "17.0.0.1.6",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/models/account_move_line.py
+++ b/l10n_ve_invoice/models/account_move_line.py
@@ -74,3 +74,37 @@ class AccountMoveLine(models.Model):
             return False
 
         return True
+    
+    def _get_computed_taxes(self):
+        """
+        Override to determine the applicable taxes for invoice lines, specifically
+        handling international sales scenarios.
+
+        This method extends the standard tax computation by replacing the default
+        taxes with the company's configured zero-aliquot taxes when the following
+        conditions are met:
+            - The move is a sale document (including receipts).
+            - The journal is marked as an international sale.
+
+        If these conditions are not satisfied, the method falls back to the default
+        tax computation provided by the parent implementation.
+
+        Additionally, the resulting taxes are filtered to ensure they belong to the
+        same company as the invoice.
+
+        Returns:
+            recordset: A recordset of `account.tax` representing the applicable taxes.
+        """
+
+        tax_ids = super()._get_computed_taxes()
+
+        is_sale_international = self.move_id.journal_id.is_sale_international
+
+        if not self.move_id.is_sale_document(include_receipts=True) or not is_sale_international:
+            return tax_ids
+        
+        company_domain = self.env['account.tax']._check_company_domain(self.move_id.company_id)
+        filtered_taxes_id = self.env.company.zero_aliquot_sale_international.filtered_domain(company_domain)
+        tax_ids = filtered_taxes_id or self.product_id.taxes_id.filtered_domain(company_domain)
+
+        return tax_ids

--- a/l10n_ve_invoice/tests/__init__.py
+++ b/l10n_ve_invoice/tests/__init__.py
@@ -1,3 +1,5 @@
 from . import test_account_move
 from . import test_common_purchase_international
 from . import test_purchase_book_international
+from . import test_common_sale_international
+from . import test_sale_book_international

--- a/l10n_ve_invoice/tests/__init__.py
+++ b/l10n_ve_invoice/tests/__init__.py
@@ -1,4 +1,6 @@
 from . import test_account_move
+from . import test_accounting_reports
+from . import test_account_move_line
 from . import test_common_purchase_international
 from . import test_purchase_book_international
 from . import test_common_sale_international

--- a/l10n_ve_invoice/tests/test_account_move_line.py
+++ b/l10n_ve_invoice/tests/test_account_move_line.py
@@ -1,0 +1,29 @@
+import logging
+from dateutil.relativedelta import relativedelta
+from odoo.tests.common import Form
+from odoo.tests import tagged
+from odoo.tests import TransactionCase, tagged
+from odoo.exceptions import UserError, ValidationError
+from odoo import Command, fields
+
+from .test_common_sale_international import TestCommonSaleInternational
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("igtf_providers_usd", "igtf_run", "-at_install", "post_install")
+class TestsAccountMoveLine(TestCommonSaleInternational):
+
+    def test01_payment_from_invoice(self,product_id=None,create_reversal=False):
+        
+        invoice_amount = float(2681.20)
+        invoice = self._create_invoice_usd(invoice_amount,product_id)
+
+        for line in invoice.invoice_line_ids:
+
+            if line.move_id.journal_id.is_sale_international:
+
+                tax_zero = line._get_computed_taxes()
+
+                self.assertEqual(tax_zero,self.company.zero_aliquot_sale_international)
+                self.assertEqual(line.tax_ids,self.company.zero_aliquot_sale_international)

--- a/l10n_ve_invoice/tests/test_accounting_reports.py
+++ b/l10n_ve_invoice/tests/test_accounting_reports.py
@@ -1,0 +1,130 @@
+import logging
+from dateutil.relativedelta import relativedelta
+from odoo.tests.common import Form
+from odoo.tests import tagged
+from odoo.tests import TransactionCase, tagged
+from odoo.exceptions import UserError, ValidationError
+from odoo import Command, fields
+
+from .test_common_purchase_international import TestCommonPurchaseInternational
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("igtf_providers_usd", "igtf_run", "-at_install", "post_install")
+class TestsAccountingReports(TransactionCase):
+
+    def get_sales_book_wizard(self):
+
+        with Form(self.env['wizard.accounting.reports']) as wiz_form:
+            wiz_form.report = 'sale'
+            wiz_form.date_from = fields.Date.today()
+            wiz_form.date_to = fields.Date.today()
+            wizard = wiz_form.save()
+
+        return wizard
+    
+    def test_default_date_to(self):
+        wizard = self.env['wizard.accounting.reports'].create({
+            'report': 'sale'
+        })
+
+        date_to = wizard._default_date_to()
+
+        self.assertEqual(
+            date_to,
+            fields.Date.today(),
+            "date_to debería ser la fecha actual"
+        )
+
+    def test_default_date_from(self):
+        wizard = self.env['wizard.accounting.reports'].create({
+            'report': 'sale'
+        })
+
+        expected_date = fields.Date.today() + relativedelta(months=-1)
+
+        date_from = wizard._default_date_from()
+
+        self.assertEqual(
+            date_from,
+            expected_date,
+            "date_from debería ser un mes antes de hoy"
+        )
+
+    def test_default_company(self):
+        wizard = self.env['wizard.accounting.reports'].create({
+            'report': 'sale'
+        })
+
+        company_id = self.env['res.company'].browse(wizard._default_company_id())
+
+        self.assertEqual(
+            company_id,
+            self.env.company,
+            "La compañía por defecto debería ser la actual"
+        )
+
+    def test_default_check_currency_system(self):
+
+        wizard = self.env['wizard.accounting.reports'].create({
+            'report': 'sale'
+        })
+
+        is_vef = wizard._default_check_currency_system()
+
+        self.assertEqual(
+            is_vef,
+            False,
+            "check currency system no coincide con la lógica esperada"
+        )
+
+    def test_default_currency_system(self):
+
+        wizard = self.env['wizard.accounting.reports'].create({
+            'report': 'sale'
+        })
+
+        is_vef = wizard._default_currency_system()
+
+        self.assertEqual(
+            is_vef,
+            False,
+            "currency system no coincide con la lógica esperada"
+        )
+
+    def test_default_check_currency_system_vef(self):
+
+        self.env.company.currency_id = self.env.ref("base.VEF").id
+
+        self.env.company.currency_foreign_id = self.env.ref("base.USD").id
+
+        wizard = self.env['wizard.accounting.reports'].create({
+            'report': 'sale'
+        })
+
+        is_vef = wizard._default_check_currency_system()
+
+        self.assertEqual(
+            is_vef,
+            True,
+            "check currency system no coincide con la lógica esperada"
+        )
+
+    def test_default_currency_system_vef(self):
+
+        self.env.company.currency_id = self.env.ref("base.VEF").id
+
+        self.env.company.currency_foreign_id = self.env.ref("base.USD").id
+
+        wizard = self.env['wizard.accounting.reports'].create({
+            'report': 'sale'
+        })
+
+        is_vef = wizard._default_currency_system()
+
+        self.assertEqual(
+            is_vef,
+            True,
+            "currency system no coincide con la lógica esperada"
+        )

--- a/l10n_ve_invoice/tests/test_common_sale_international.py
+++ b/l10n_ve_invoice/tests/test_common_sale_international.py
@@ -184,23 +184,42 @@ class TestCommonSaleInternational(TransactionCase):
             'tax_group_id': self.tax_group_zero.id,
         })
 
+        self.company.general_aliquot_sale = self.env['account.tax'].create({
+            'name': 'IVA 16%', 'amount': 16, 'amount_type': 'percent', 
+            'type_tax_use': 'sale',
+            'company_id': self.company.id,
+            'tax_group_id': self.tax_group_general.id,
+        })
+
         self.product_zero_aliquot_sale_international = self.env["product.product"].create(
             {
                 "name": "Servicio",
                 "list_price": 100,
                 "sale_ok": True,
                 "property_account_expense_id": self.acc_expense.id,
-                "taxes_id": [(6, 0, [self.company.zero_aliquot_sale_international.id])],
+                "taxes_id": [(6, 0, [self.company.general_aliquot_sale.id])],
             }
         )
 
    
     def _create_invoice_usd(self, amount,product_id, date=None): 
+
+        sequence = self.env["ir.sequence"].sudo().search([("code", "=", "invoice.correlative"), ("company_id", "=", self.env.company.id)])
+        sequence.unlink()
         sale_journal = self.Journal.create({
             'name': 'Diario Venta', 'type': 'sale', 'code': 'SAIN',
+            'is_debit':True,
             'company_id': self.company.id, 'currency_id': self.currency_usd.id,
+            'sequence_number_next':1,
+            'refund_sequence_number_next':2,
+            'refund_sequence':True,
             'is_sale_international':True,
         })
+
+        sale_journal.sequence_id.use_date_range = False 
+        sale_journal.refund_sequence_id.use_date_range = False
+
+        sale_journal.sequence_id.code = "invoice.correlative" 
 
         with Form(self.env["account.move"].with_context(default_move_type='out_invoice')) as inv_form:
             # inv_form.correlative = "12345698741256"

--- a/l10n_ve_invoice/tests/test_common_sale_international.py
+++ b/l10n_ve_invoice/tests/test_common_sale_international.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form
+
+from odoo import fields, Command
+import logging
+
+_logger = logging.getLogger(__name__)
+
+class TestCommonSaleInternational(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.Account = self.env["account.account"]
+        self.Journal = self.env["account.journal"]
+        self.company = self.env.ref("base.main_company")
+
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_vef = self.env.ref("base.VEF")
+        self.currency_vef.rounding = 0.01
+        self.currency_usd.rounding = 0.01
+        self.currency_usd.decimal_places = 2
+        self.currency_vef.decimal_places = 2
+
+        self.rate = 201.47 
+        self.currency_vef.write({
+            'rate_ids': [
+                Command.create({
+                    'company_rate': self.rate,  
+                    'name': fields.Date.today(),
+                })
+            ],
+            'active':True
+        })
+        self.company.write(
+            {
+                "currency_id": self.currency_usd.id,
+                "currency_foreign_id": self.currency_vef.id,
+                "country_id": 28,
+                "taxpayer_type":'formal',
+            }
+        )
+        
+        def get_or_create_account(code, ttype, name, recon=False):
+            """Busca o crea una cuenta y asegura las propiedades requeridas."""
+            account_record = self.Account.search(
+                [("code", "=", code), ("company_id", "=", self.company.id)], limit=1
+            )
+            values = {
+                "name": name,
+                "code": code,
+                "account_type": ttype,
+                "reconcile": recon,
+                "company_id": self.company.id,
+            }
+
+            if not account_record:
+                account_record = self.Account.create(values)
+            else:
+                account_record.write(values)
+          
+            return account_record
+        
+        self.get_or_create_account = get_or_create_account 
+
+        self.acc_receivable = self.get_or_create_account(
+            "1101", "asset_receivable", "Cuentas por Cobrar (Clientes)", recon=True
+        )
+        self.acc_payable = self.get_or_create_account( 
+            "2101", "liability_payable", "Cuentas por Pagar (Proveedores)", recon=True
+        )
+        self.acc_expense = self.get_or_create_account("5001", "asset_current", "Costo de Mercancía/Gasto")
+        
+        self.acc_igtf_prov = self.get_or_create_account("523IGTF", "expense", "IGTF Proveedores (Gasto)")
+        
+        self.account_bank = self.get_or_create_account("1001", "asset_cash", "Cuenta de Banco USD") 
+
+        self.acc_igtf_cli = self.get_or_create_account(
+            "21600", "liability_current", "Anticipo Clientes", recon=True
+        )
+        
+        manual_in = self.env.ref("account.account_payment_method_manual_in")
+        manual_out = self.env.ref("account.account_payment_method_manual_out") 
+        
+        self.pm_line_in_usd = self.env["account.payment.method.line"].create(
+            {
+                "name": "Manual Inbound USD",
+                "payment_method_id": manual_in.id,
+                "payment_type": "inbound",
+                "payment_account_id": self.account_bank.id, 
+            }
+        )
+
+        self.pm_line_out_usd = self.env["account.payment.method.line"].create(
+            {
+                "name": "Manual Outbound USD",
+                "payment_method_id": manual_out.id,
+                "payment_type": "outbound",
+                "payment_account_id": self.account_bank.id, 
+            }
+        )
+
+        self.pm_line_out_vef = self.env["account.payment.method.line"].create(
+            {
+                "name": "Manual Outbound VEF",
+                "payment_method_id": manual_out.id,
+                "payment_type": "outbound",
+                "payment_account_id": self.account_bank.id, 
+            }
+        )
+
+        self.bank_journal_usd = self.Journal.create(
+            {
+                "name": "Banco USD IGTF",
+                "code": "BNKUS",
+                "type": "bank",
+                "currency_id": self.currency_usd.id,
+                "company_id": self.company.id,
+                "default_account_id": self.account_bank.id, 
+                "inbound_payment_method_line_ids": [(6, 0, self.pm_line_in_usd.ids)],
+                "outbound_payment_method_line_ids": [(6, 0, self.pm_line_out_usd.ids)], 
+            
+            }
+        )
+        self.pm_line_in_usd.journal_id = self.bank_journal_usd.id
+        self.pm_line_out_usd.journal_id = self.bank_journal_usd.id
+
+        self.bank_journal_bs = self.Journal.create(
+            {
+                "name": "Banco VEF (Local)",
+                "code": "BVESL",
+                "type": "bank",
+                "company_id": self.company.id,
+                "currency_id": self.currency_vef.id,
+                "default_account_id": self.account_bank.id,
+                "outbound_payment_method_line_ids": [(6, 0, self.pm_line_out_vef.ids)], 
+            }
+        )
+        self.pm_line_out_vef.journal_id = self.bank_journal_bs.id
+
+        self.partner = self.env["res.partner"].create(
+            {"name": "Cliente", 
+             "vat": "J123",
+             "property_account_receivable_id": self.acc_receivable.id,
+             "property_account_payable_id": self.acc_payable.id, # Cuentas por Pagar
+             "supplier_rank": 0, # Asegurar que es un proveedor
+             "customer_rank": 1,
+            }
+        )
+        
+        #TAXES GROUPS
+
+        self.tax_group_exempt = self.env['account.tax.group'].create({
+            'name': 'IVA EXENTO',
+            'company_id': self.company.id
+        })
+
+        self.tax_group_zero = self.env['account.tax.group'].create({
+            'name': 'IVA CERO INTERNATIONAL',
+            'company_id': self.company.id
+        })
+
+        self.tax_group_reduced = self.env['account.tax.group'].create({
+            'name': 'IVA REDUCIDO',
+            'company_id': self.company.id
+        })
+
+        self.tax_group_general = self.env['account.tax.group'].create({
+            'name': 'IVA GENERAL',
+            'company_id': self.company.id
+        })
+
+        self.tax_group_extend = self.env['account.tax.group'].create({
+            'name': 'IVA EXTENDIDO',
+            'company_id': self.company.id
+        })
+
+        #INTERNATIONAL TAXES
+
+        self.company.zero_aliquot_sale_international = self.env['account.tax'].create({
+            'name': 'IVA cero internacional', 'amount': 0, 'amount_type': 'percent', 
+            'type_tax_use': 'sale',
+            'company_id': self.company.id,
+            'tax_group_id': self.tax_group_zero.id,
+        })
+
+        self.product_zero_aliquot_sale_international = self.env["product.product"].create(
+            {
+                "name": "Servicio",
+                "list_price": 100,
+                "sale_ok": True,
+                "property_account_expense_id": self.acc_expense.id,
+                "taxes_id": [(6, 0, [self.company.zero_aliquot_sale_international.id])],
+            }
+        )
+
+   
+    def _create_invoice_usd(self, amount,product_id, date=None): 
+        sale_journal = self.Journal.create({
+            'name': 'Diario Venta', 'type': 'sale', 'code': 'SAIN',
+            'company_id': self.company.id, 'currency_id': self.currency_usd.id,
+            'is_sale_international':True,
+        })
+
+        with Form(self.env["account.move"].with_context(default_move_type='out_invoice')) as inv_form:
+            # inv_form.correlative = "12345698741256"
+            inv_form.partner_id = self.partner
+            inv_form.journal_id = sale_journal
+            inv_form.invoice_date = date or fields.Date.today()
+        
+        inv = inv_form.save()
+
+        with Form(inv) as inv_form_edit:
+            with inv_form_edit.invoice_line_ids.new() as line:
+                line.product_id = product_id if product_id else self.product_zero_aliquot_sale_international
+                line.quantity = 1
+                line.price_unit = amount
+                
+        inv = inv_form_edit.save() 
+
+        return inv
+    
+    def _reverse_invoice_usd(self, move,date=None):
+
+        move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=move.ids).create({
+            'date': date or fields.Date.today(),
+            'journal_id': move.journal_id.id,
+        })
+
+        reversal = move_reversal.reverse_moves()
+        reversed_move = self.env['account.move'].browse(reversal['res_id'])
+        reversed_move.action_post()
+        reversed_move.write({'state': 'posted'})

--- a/l10n_ve_invoice/tests/test_sale_book_international.py
+++ b/l10n_ve_invoice/tests/test_sale_book_international.py
@@ -80,6 +80,95 @@ class TestSaleBook(TestCommonSaleInternational):
             line_fields["amount_general_aliquot"], 0
         )
 
+    def test_sale_book_line_fields_international_zero_none(self):
+
+        self.company.zero_aliquot_sale_international = False
+
+        invoice_amount = float(2681.20)
+        invoice = self._create_invoice_usd(invoice_amount,self.product_zero_aliquot_sale_international)
+
+        invoice.with_context(move_action_post_alert=True).action_post()
+        invoice = self.env['account.move'].search([('move_type','=','out_invoice')], order="id desc", limit=1)
+
+        wizard = self.get_sales_book_wizard()
+
+        taxes = wizard._determinate_amount_taxeds(invoice)
+
+        line_fields = wizard._fields_sale_book_line(invoice, taxes)
+
+        self.assertIsNone(
+            line_fields,
+            "Para ventas internacionales sin el impuesto cero configurado, debe devolver None"
+        )
+
+    def test_parse_sale_book_data_international(self):
+
+        invoice_amount = float(2681.20)
+        invoice = self._create_invoice_usd(invoice_amount,self.product_zero_aliquot_sale_international)
+
+        invoice.with_context(move_action_post_alert=True).action_post()
+        invoice = self.env['account.move'].search([('move_type','=','out_invoice')], order="id desc", limit=1)
+
+        wizard = self.get_sales_book_wizard()
+
+        data = wizard.parse_sale_book_data()
+
+        self.assertTrue(data, "No se generaron líneas válidas")
+
+        line = data[0]
+
+        # ✅ 3. Validar estructura completa (campos clave reales)
+        expected_keys = [
+            "_id",
+            "document_date",
+            "accounting_date",
+            "vat",
+            "partner_name",
+            "document_number",
+            "move_type",
+            "transaction_type",
+            "correlative",
+            "total_sales",
+            "total_sales_iva",
+            "total_sales_not_iva",
+            "amount_zero_aliquot_international",
+            "tax_base_zero_aliquot_international",
+        ]
+
+        for key in expected_keys:
+            self.assertIn(key, line, f"Falta el campo {key}")
+
+        _logger.info(f'AMOUNT ZERO ALIQUOT INTERNATIONAL:{line["amount_zero_aliquot_international"]}')
+
+        self.assertEqual(
+            line["amount_zero_aliquot_international"],
+            0,
+            "Debe haber monto en alícuota 0 internacional"
+        )
+
+        _logger.info(f'BASE ZERO ALIQUOT INTERNATIONAL:{line["tax_base_zero_aliquot_international"]}')
+
+        self.assertEqual(
+            line["tax_base_zero_aliquot_international"],
+            540181.36,
+            "Debe haber base imponible internacional"
+        )
+
+        # ✅ 7. No debería haber otros impuestos
+        self.assertEqual(line["amount_general_aliquot"], 0)
+        self.assertEqual(line["amount_reduced_aliquot"], 0)
+        self.assertEqual(line["amount_extend_aliquot"], 0)
+
+        # ✅ 8. Validar totales coherentes
+        self.assertGreaterEqual(line["total_sales"], 0)
+
+        self.assertAlmostEqual(
+            line["total_sales"],
+            line["total_sales_iva"] + line["total_sales_not_iva"],
+            places=2,
+            msg="Los totales no cuadran"
+        )
+
     def test_sale_book_line_fields_international_zero(self):
         self.test01_payment_from_invoice(self.product_zero_aliquot_sale_international,True)
         invoice = self.env['account.move'].search([('move_type','=','out_refund')], order="id desc", limit=1)

--- a/l10n_ve_invoice/tests/test_sale_book_international.py
+++ b/l10n_ve_invoice/tests/test_sale_book_international.py
@@ -96,9 +96,40 @@ class TestSaleBook(TestCommonSaleInternational):
 
         line_fields = wizard._fields_sale_book_line(invoice, taxes)
 
-        self.assertIsNone(
-            line_fields,
-            "Para ventas internacionales sin el impuesto cero configurado, debe devolver None"
+        base_zero = line_fields["tax_base_zero_aliquot_international"]
+
+        tax_zero = line_fields["amount_zero_aliquot_international"]
+
+        self.assertEqual(
+            base_zero,
+            0.00,
+            "La base imponible general internacional debe ser 0 porque el impuesto de 0% no esta configurado"
+        )
+
+        self.assertEqual(
+            tax_zero,
+            base_zero * 0.00,
+            msg="El IVA general internacional no corresponde al 00% de la base"
+        )
+
+        self.assertEqual(
+            line_fields["tax_base_reduced_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["tax_base_extend_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["tax_base_general_aliquot"], 0
+        )
+
+        self.assertEqual(
+            line_fields["amount_reduced_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["amount_extend_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["amount_general_aliquot"], 0
         )
 
     def test_parse_sale_book_data_international(self):
@@ -169,7 +200,7 @@ class TestSaleBook(TestCommonSaleInternational):
             msg="Los totales no cuadran"
         )
 
-    def test_sale_book_line_fields_international_zero(self):
+    def test_sale_book_line_fields_international_zero_credit_note(self):
         self.test01_payment_from_invoice(self.product_zero_aliquot_sale_international,True)
         invoice = self.env['account.move'].search([('move_type','=','out_refund')], order="id desc", limit=1)
 

--- a/l10n_ve_invoice/tests/test_sale_book_international.py
+++ b/l10n_ve_invoice/tests/test_sale_book_international.py
@@ -1,0 +1,248 @@
+import logging
+from odoo.tests.common import Form
+from odoo.tests import tagged
+from odoo.exceptions import UserError, ValidationError
+from odoo import Command, fields
+
+from .test_common_sale_international import TestCommonSaleInternational
+
+_logger = logging.getLogger(__name__)
+
+@tagged("l10n_ve_invoice", "-at_install", "post_install")
+class TestSaleBook(TestCommonSaleInternational):
+
+    def test01_payment_from_invoice(self,product_id=None,create_reversal=False):
+        
+        invoice_amount = float(2681.20)
+        invoice = self._create_invoice_usd(invoice_amount,product_id)
+        invoice.with_context(move_action_post_alert=True).action_post()
+
+        if create_reversal:
+            self._reverse_invoice_usd(invoice)
+
+    def get_sales_book_wizard(self):
+
+        with Form(self.env['wizard.accounting.reports']) as wiz_form:
+            wiz_form.report = 'sale'
+            wiz_form.date_from = fields.Date.today()
+            wiz_form.date_to = fields.Date.today()
+            wizard = wiz_form.save()
+
+        return wizard
+    
+    def test_sale_book_line_fields_international_zero(self):
+        self.test01_payment_from_invoice(self.product_zero_aliquot_sale_international)
+        invoice = self.env['account.move'].search([('move_type','=','out_invoice')], order="id desc", limit=1)
+
+        wizard = self.get_sales_book_wizard()
+
+        taxes = wizard._determinate_amount_taxeds(invoice)
+
+        line_fields = wizard._fields_sale_book_line(invoice, taxes)
+
+        self.assertIsNotNone(
+        line_fields,
+            "Para ventas internacionales, no debe devolver None"
+        )
+
+        base_zero = line_fields["tax_base_zero_aliquot_international"]
+        tax_zero = line_fields["amount_zero_aliquot_international"]
+
+        self.assertEqual(
+            base_zero,
+            540181.36,
+            "La base imponible general internacional debe ser mayor a 0"
+        )
+
+        self.assertEqual(
+            tax_zero,
+            base_zero * 0.00,
+            msg="El IVA general internacional no corresponde al 00% de la base"
+        )
+
+        self.assertEqual(
+            line_fields["tax_base_reduced_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["tax_base_extend_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["tax_base_general_aliquot"], 0
+        )
+
+        self.assertEqual(
+            line_fields["amount_reduced_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["amount_extend_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["amount_general_aliquot"], 0
+        )
+
+    def test_sale_book_line_fields_international_zero(self):
+        self.test01_payment_from_invoice(self.product_zero_aliquot_sale_international,True)
+        invoice = self.env['account.move'].search([('move_type','=','out_refund')], order="id desc", limit=1)
+
+        wizard = self.get_sales_book_wizard()
+
+        taxes = wizard._determinate_amount_taxeds(invoice)
+
+        line_fields = wizard._fields_sale_book_line(invoice, taxes)
+
+        self.assertIsNotNone(
+        line_fields,
+            "Para ventas internacionales, no debe devolver None"
+        )
+
+        base_zero = line_fields["tax_base_zero_aliquot_international"]
+        tax_zero = line_fields["amount_zero_aliquot_international"]
+
+        self.assertEqual(
+            base_zero,
+            540181.36 * -1,
+            "La base imponible general internacional debe ser mayor a 0"
+        )
+
+        self.assertEqual(
+            tax_zero,
+            base_zero * 0.00,
+            msg="El IVA general internacional no corresponde al 00% de la base"
+        )
+
+        self.assertEqual(
+            line_fields["tax_base_reduced_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["tax_base_extend_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["tax_base_general_aliquot"], 0
+        )
+
+        self.assertEqual(
+            line_fields["amount_reduced_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["amount_extend_aliquot"], 0
+        )
+        self.assertEqual(
+            line_fields["amount_general_aliquot"], 0
+        )
+
+    def test_get_sale_book_field_international_groups(self):
+        """Validate sale international field group."""
+
+        self.test01_payment_from_invoice(self.product_zero_aliquot_sale_international)
+
+        wizard = self.get_sales_book_wizard()
+
+        groups = wizard._get_sale_book_field_groups()
+
+        group = next((g for g in groups if g.get("header") == "VENTAS INTERNACIONALES"), None)
+
+        self.assertIsNotNone(group, "Debe existir grupo VENTAS INTERNACIONALES")
+        field_names = [f["field"] for f in group["fields"]]
+        self.assertIn("tax_base_zero_aliquot_international", field_names)
+        self.assertIn("amount_zero_aliquot_international", field_names)
+
+    def test_determinate_amount_taxeds_sale_international_zero(self):
+        """
+        Verifica que _determinate_amount_taxeds retorne correctamente
+        tax_base_zero_aliquot_international y amount_zero_aliquot_international
+        para una venta internacional con alícuota 0%.
+        """
+
+        self.test01_payment_from_invoice(
+            self.product_zero_aliquot_sale_international
+        )
+
+        invoice = self.env['account.move'].search([('move_type','=','out_invoice')], order="id desc", limit=1)
+
+        wizard = self.get_sales_book_wizard()
+
+        taxes = wizard._determinate_amount_taxeds(invoice)
+
+        self.assertIn(
+            "tax_base_zero_aliquot_international",
+            taxes,
+            "Debe existir la base de IVA 0% internacional"
+        )
+        self.assertIn(
+            "amount_zero_aliquot_international",
+            taxes,
+            "Debe existir el monto de IVA 0% internacional"
+        )
+
+        base_zero = taxes["tax_base_zero_aliquot_international"]
+        amount_zero = taxes["amount_zero_aliquot_international"]
+
+        # 🔹 5. Validar valores
+        self.assertEqual(
+            base_zero,
+            540181.36,
+            "La base imponible de IVA 0% internacional debe ser mayor a 0"
+        )
+
+        self.assertEqual(
+            amount_zero,
+            0.0,
+            msg="El monto del IVA 0% internacional debe ser 0"
+        )
+
+    def test_determinate_resume_books_zero_aliquot_international(self):
+        """
+        Verifica que _determinate_resume_books calcule correctamente
+        el resumen de IVA 0% internacional para ventas.
+        """
+
+        # 🔹 1. Crear y postear factura internacional con IVA 0%
+        self.test01_payment_from_invoice(
+            self.product_zero_aliquot_sale_international,
+            True
+        )
+
+        invoices = self.env['account.move'].search([('move_type','in',['out_refund','out_invoice'])], order="id desc", limit=2)
+
+        # 🔹 2. Crear wizard de libro de ventas
+        wizard = self.get_sales_book_wizard()
+
+        # 🔹 4. Ejecutar método bajo prueba
+        resume = wizard._determinate_resume_books(
+            invoices,
+            tax_type="zero_aliquot_international"
+        )
+
+        # 🔹 5. Validaciones estructurales
+        self.assertEqual(
+            len(resume),
+            4,
+            "El resumen debe contener 4 valores"
+        )
+
+        base_moves, tax_moves, base_refunds, tax_refunds = resume
+
+        # 🔹 6. Validaciones funcionales
+        self.assertEqual(
+            base_moves,
+            540181.36,
+            "La base imponible de IVA 0% internacional debe ser igual al de la factura realizada"
+        )
+
+        self.assertEqual(
+            tax_moves,
+            0.0,
+            msg="El monto del IVA 0% internacional debe ser 0"
+        )
+
+        self.assertEqual(
+            base_refunds,
+            540181.36 * -1,
+            "No deben existir notas de crédito para esta prueba"
+        )
+
+        self.assertEqual(
+            tax_refunds,
+            0.0,
+            "No deben existir impuestos en notas de crédito"
+        )

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -1227,11 +1227,15 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             end_col_name = utility.xl_col_to_name(end_col)
             merge_range = f"{start_col_name}6:{end_col_name}6"
 
-            worksheet.merge_range(
-                merge_range, 
-                group['header'], 
-                header_format
-            )
+            if start_col == end_col:
+                worksheet.write(f"{start_col_name}6", group['header'], header_format)
+            else:
+
+                worksheet.merge_range(
+                    merge_range,
+                    group['header'],
+                    header_format
+                )
             
             if group['header'] != 'DETALLE DEL DOCUMENTO' and ventas_internas_start_col == 0:
                 ventas_internas_start_col = start_col
@@ -1399,11 +1403,15 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             end_col_name = utility.xl_col_to_name(end_col)
             merge_range = f"{start_col_name}6:{end_col_name}6"
 
-            worksheet.merge_range(
-                merge_range, 
-                group['header'], 
-                header_format
-            )
+            if start_col == end_col:
+                worksheet.write(f"{start_col_name}6", group['header'], header_format)
+            else:
+
+                worksheet.merge_range(
+                    merge_range,
+                    group['header'],
+                    header_format
+                )
             
             for field in group_fields:
                 col_index = current_col_index

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -67,16 +67,6 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             raise UserError(_("Check the move %s does not have an invoice date and its id is %s", move.name, move.id))
         multiplier = -1 if move.move_type == "out_refund" else 1
 
-        if move.journal_id.is_sale_international :
-            tax_keys_to_check = [
-                "amount_zero_aliquot_international",
-                "tax_base_zero_aliquot_international",
-            ]
-
-            total_tax_value = sum(taxes.get(key, 0) for key in tax_keys_to_check)
-            if total_tax_value == 0:
-                return None
-
         return {
             "_id": move.id,
             "document_date": self._format_date(move.invoice_date),

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -1022,6 +1022,8 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             reduced_aliquot = False
             extend_aliquot = False
 
+            zero_aliquiot_international = False
+
             if self.report == "sale":
                 if move.journal_id.is_sale_international:
                     zero_aliquiot_international = self.company_id.zero_aliquot_sale_international.tax_group_id.id

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -67,6 +67,16 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             raise UserError(_("Check the move %s does not have an invoice date and its id is %s", move.name, move.id))
         multiplier = -1 if move.move_type == "out_refund" else 1
 
+        if move.journal_id.is_sale_international :
+            tax_keys_to_check = [
+                "amount_zero_aliquot_international",
+                "tax_base_zero_aliquot_international",
+            ]
+
+            total_tax_value = sum(taxes.get(key, 0) for key in tax_keys_to_check)
+            if total_tax_value == 0:
+                return None
+
         return {
             "_id": move.id,
             "document_date": self._format_date(move.invoice_date),
@@ -82,17 +92,20 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 else move.reversed_entry_id.name or "--"
             ),
             "correlative": move.correlative or '--',
+            "zero_aliquiot_international": 0.00,
             "reduced_aliquot": 0.08,
             "general_aliquot": 0.16,
             "extend_aliquot": 0.31,
             "total_sales": taxes.get("amount_taxed", 0),
             "total_sales_iva": taxes.get("amount_taxed", 0) - (taxes.get("tax_base_exempt_aliquot", 0) * multiplier),
             "total_sales_not_iva": taxes.get("tax_base_exempt_aliquot", 0) * multiplier,
+            "amount_zero_aliquot_international": taxes.get("amount_zero_aliquot_international", 0),
             "amount_reduced_aliquot": taxes.get("amount_reduced_aliquot", 0)
             * multiplier,
             "amount_general_aliquot": taxes.get("amount_general_aliquot", 0)
             * multiplier,
             "amount_extend_aliquot": taxes.get("amount_extend_aliquot", 0) * multiplier,
+            "tax_base_zero_aliquot_international": taxes.get("tax_base_zero_aliquot_international", 0) * multiplier,
             "tax_base_reduced_aliquot": taxes.get("tax_base_reduced_aliquot", 0)
             * multiplier,
             "tax_base_general_aliquot": taxes.get("tax_base_general_aliquot", 0)
@@ -342,7 +355,42 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             )
 
             return resume_lines
+        
+        if tax_type == "zero_aliquot_international":
+            resume_lines.append(
+                sum(
+                    [
+                        self._determinate_amount_taxeds(move)["tax_base_zero_aliquot_international"]
+                        for move in moves
+                    ]
+                )
+            )
+            resume_lines.append(
+                sum(
+                    [
+                        self._determinate_amount_taxeds(move)["amount_zero_aliquot_international"]
+                        for move in moves
+                    ]
+                )
+            )
+            resume_lines.append(
+                sum(
+                    [
+                        self._determinate_amount_taxeds(note)["tax_base_zero_aliquot_international"] * -1
+                        for note in credit_notes
+                    ]
+                )
+            )
+            resume_lines.append(
+                sum(
+                    [
+                        self._determinate_amount_taxeds(note)["amount_zero_aliquot_international"] * -1
+                        for note in credit_notes
+                    ]
+                )
+            )
 
+            return resume_lines
 
         if tax_type == "general_aliquot_international":
             resume_lines.append(
@@ -760,14 +808,9 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 "values": self._determinate_resume_books(moves, "exempt_aliquot"),
             },
             {
-                "name": "Exportaciones Gravadas por Alícuota General",
+                "name": "Ventas de Exportación",
                 "format": "number",
-                "values": self._determinate_resume_books(moves),
-            },
-            {
-                "name": "Exportaciones Gravadas por Alícuota General más Adicional",
-                "format": "number",
-                "values": self._determinate_resume_books(moves),
+                "values": self._determinate_resume_books(moves, "zero_aliquot_international"),
             },
             {
                 "name": "Ventas Internas Gravadas sólo por Alícuota General",
@@ -858,6 +901,8 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 "international_amount_taxed":0.0,
                 "international_tax_base_exempt_aliquot": 0.0,
                 "amount_import_international": 0,
+                "tax_base_zero_aliquot_international": 0,
+                "amount_zero_aliquot_international": 0,
                 "tax_base_reduced_aliquot_international": 0,
                 "amount_reduced_aliquot_international": 0,
                 "tax_base_general_aliquot_international": 0,
@@ -937,6 +982,8 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 "national_tax_base_exempt_aliquot": 0.0,
                 "international_tax_base_exempt_aliquot": 0.0,
                 "amount_import_international": 0,
+                "tax_base_zero_aliquot_international": 0,
+                "amount_zero_aliquot_international": 0,
                 "tax_base_reduced_aliquot_international": 0,
                 "amount_reduced_aliquot_international": 0,
                 "tax_base_general_aliquot_international": 0,
@@ -976,10 +1023,14 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             extend_aliquot = False
 
             if self.report == "sale":
-                exent_aliquot = self.company_id.exent_aliquot_sale.tax_group_id.id
-                reduced_aliquot = self.company_id.reduced_aliquot_sale.tax_group_id.id
-                general_aliquot = self.company_id.general_aliquot_sale.tax_group_id.id
-                extend_aliquot = self.company_id.extend_aliquot_sale.tax_group_id.id
+                if move.journal_id.is_sale_international:
+                    zero_aliquiot_international = self.company_id.zero_aliquot_sale_international.tax_group_id.id
+                else:
+                    zero_aliquiot_international = False
+                    exent_aliquot = self.company_id.exent_aliquot_sale.tax_group_id.id
+                    reduced_aliquot = self.company_id.reduced_aliquot_sale.tax_group_id.id
+                    general_aliquot = self.company_id.general_aliquot_sale.tax_group_id.id
+                    extend_aliquot = self.company_id.extend_aliquot_sale.tax_group_id.id
             else:
                 if move.journal_id.is_purchase_international:
                     exent_aliquot = self.company_id.exent_aliquot_purchase_international.tax_group_id.id
@@ -1006,6 +1057,16 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
 
             for tax in taxes:
                 tax_group_id = tax.get("tax_group_id")
+
+                is_zero = tax_group_id == zero_aliquiot_international
+
+                if is_zero:
+                    tax_result.update(
+                        {
+                            "tax_base_zero_aliquot_international": tax.get("tax_group_base_amount"),
+                            "amount_zero_aliquot_international": tax.get("tax_group_amount"),
+                        }
+                    )
 
                 is_exempt = tax_group_id == exent_aliquot
                 if is_exempt:
@@ -1525,31 +1586,38 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
         ]
         sale_groups.append({'header': 'TOTALES', 'fields': total_fields})
 
-        general_aliquot_fields = [
+        national_deductible_fields = []
+
+        national_deductible_fields = [
             {"name": "Base imponible (16%)", "field": "tax_base_general_aliquot", "format": "number", "size": 16},
             {"name": "IVA 16%", "field": "amount_general_aliquot", "format": "number", "size": 16},
         ]
-        sale_groups.append({'header': 'ALÍCUOTA GENERAL (16%)', 'fields': general_aliquot_fields})
         
-        reduced_aliquot_fields = []
         if not company.not_show_reduced_aliquot_sale:
-            reduced_aliquot_fields.extend([
+            national_deductible_fields.extend([
                 {"name": "Base imponible (8%)", "field": "tax_base_reduced_aliquot", "format": "number"},
                 {"name": "IVA 8%", "field": "amount_reduced_aliquot", "format": "number"}
             ])
 
-        if reduced_aliquot_fields:
-            sale_groups.append({'header': 'ALÍCUOTA REDUCIDA (8%)', 'fields': reduced_aliquot_fields})
-
-        extend_aliquot_fields = []
         if not company.not_show_extend_aliquot_sale:
-            extend_aliquot_fields.extend([
+            national_deductible_fields.extend([
                 {"name": "Base imponible (31%)", "field": "tax_base_extend_aliquot", "format": "number"},
                 {"name": "IVA 31%", "field": "amount_extend_aliquot", "format": "number"}
             ])
-            
-        if extend_aliquot_fields:
-            sale_groups.append({'header': 'ALÍCUOTA ADICIONAL (31%)', 'fields': extend_aliquot_fields})
+
+        if national_deductible_fields:
+            sale_groups.append({'header': 'VENTAS NACIONALES', 'fields': national_deductible_fields})
+
+        international_fields = []
+        international_fields.extend([
+            {"name": "Base imponible", "field": "tax_base_zero_aliquot_international", "format": "number"},
+            {"name": "Alicuota 0%", "field": "zero_aliquiot_international", "format": "percent"},
+            {"name": "IVA 0%", "field": "amount_zero_aliquot_international", "format": "number"}
+        ])
+
+        if international_fields:
+
+            sale_groups.append({'header': 'VENTAS INTERNACIONALES', 'fields':international_fields})
 
         return sale_groups
     

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -1067,6 +1067,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                         {
                             "tax_base_zero_aliquot_international": tax.get("tax_group_base_amount"),
                             "amount_zero_aliquot_international": tax.get("tax_group_amount"),
+                            "tax_base_exempt_aliquot": tax.get("tax_group_base_amount"),
                         }
                     )
 

--- a/l10n_ve_tax/__manifest__.py
+++ b/l10n_ve_tax/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.18",
+    "version": "17.0.0.0.19",
     # any module necessary for this one to work correctly
     "depends": ["base", "account", "l10n_ve_base", "l10n_ve_rate"],
     "data": [

--- a/l10n_ve_tax/i18n/es_VE.po
+++ b/l10n_ve_tax/i18n/es_VE.po
@@ -334,6 +334,16 @@ msgstr "Alícuota reducida ventas"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Sale Tax International Rates"
+msgstr "Tasas de Impuestos de Ventas Internacionales"
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Sales Book"
+msgstr "Libro de Ventas"
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Sales Tax Rates"
 msgstr "Tasas de Impuestos de Ventas"
 
@@ -388,7 +398,90 @@ msgid "Total to pay"
 msgstr "Total a pagar"
 
 #. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__unique_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__unique_tax
-msgid "Unique Tax"
-msgstr "Impuesto único"
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__exent_aliquot_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__exent_aliquot_purchase_international
+msgid "Exent Aliquot Purchase International"
+msgstr "Alícuota exenta compras internacionales"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__extend_aliquot_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__extend_aliquot_purchase_international
+msgid "Extend Aliquot Purchase International"
+msgstr "Alícuota extendida compras internacionales"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__general_aliquot_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__general_aliquot_purchase_international
+msgid "General Aliquot Purchase International"
+msgstr "Alícuota general compras internacionales"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_international_purchase_in_book
+msgid "Hide international alicuotes"
+msgstr "Ocultar alícuotas internacionales"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_journal__is_purchase_international
+msgid "International purchase"
+msgstr "Compra internacional"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_journal__is_sale_international
+msgid "International sale"
+msgstr "Venta internacional"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_international_purchase_in_book
+msgid "Not Show International Purchase In Book"
+msgstr "No mostrar compras internacionales en el libro"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_reduced_aliquot_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_reduced_aliquot_purchase_international
+msgid "Not Show Reduced Aliquot Purchase International"
+msgstr "No mostrar alícuota reducida compras internacionales"
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Purchase Tax International Rates"
+msgstr "Tasas de Impuestos de Compras Internacionales"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__reduced_aliquot_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__reduced_aliquot_purchase_international
+msgid "Reduced Aliquot Purchase International"
+msgstr "Alícuota reducida compras internacionales"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_general_aliquot_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_general_aliquot_purchase_international
+msgid "Not Show General Aliquot Purchase International"
+msgstr "No mostrar alícuota general compras internacionales"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_extend_aliquot_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_extend_aliquot_purchase_international
+msgid "Not Show Extend Aliquot Purchase International"
+msgstr "No mostrar alícuota extendida compras internacionales"
+
+#. module: l10n_ve_tax
+#. odoo-python
+#: code:addons/l10n_ve_tax/models/account_journal.py:0
+#, python-format
+msgid ""
+"An International Purchase Journal is already enabled. Only one is allowed."
+msgstr ""
+"Ya se ha habilitado un Diario de Compras Internacional. Solo se permite uno."
+
+#. module: l10n_ve_tax
+#. odoo-python
+#: code:addons/l10n_ve_tax/models/account_journal.py:0
+#, python-format
+msgid "An International Sale Journal is already enabled. Only one is allowed."
+msgstr "Ya se ha habilitado un Diario de Ventas Internacional. Solo se permite uno."
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__zero_aliquot_sale_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__zero_aliquot_sale_international
+msgid "Zero Aliquot Sale International"
+msgstr "Alícuota cero ventas internacionales"

--- a/l10n_ve_tax/models/account_journal.py
+++ b/l10n_ve_tax/models/account_journal.py
@@ -36,7 +36,7 @@ class AccountJournal(models.Model):
         for record in self:
             if record.is_sale_international:
                 domain = [
-                    ('company_id','=',self.env.company.id),
+                    ('company_id', '=', record.company_id.id or self.env.company.id),
                     ('is_sale_international', '=', True),
                     ('id', '!=', record.id),
                 ]

--- a/l10n_ve_tax/models/account_journal.py
+++ b/l10n_ve_tax/models/account_journal.py
@@ -36,6 +36,7 @@ class AccountJournal(models.Model):
         for record in self:
             if record.is_sale_international:
                 domain = [
+                    ('company_id','=',self.env.company.id),
                     ('is_sale_international', '=', True),
                     ('id', '!=', record.id),
                 ]

--- a/l10n_ve_tax/models/account_journal.py
+++ b/l10n_ve_tax/models/account_journal.py
@@ -11,6 +11,8 @@ _logger = logging.getLogger(__name__)
 class AccountJournal(models.Model):
     _inherit = "account.journal"
 
+    is_sale_international = fields.Boolean(string="International sale",default=False)
+
     is_purchase_international = fields.Boolean(string="International purchase",default=False)
 
     @api.constrains('is_purchase_international')
@@ -26,4 +28,19 @@ class AccountJournal(models.Model):
                 if self.search_count(domain) > 0:
                     raise ValidationError(
                         _("An International Purchase Journal is already enabled. Only one is allowed.")
+                    )
+                
+    @api.constrains('is_sale_international')
+    def _check_single_international_sale_journal(self):
+        
+        for record in self:
+            if record.is_sale_international:
+                domain = [
+                    ('is_sale_international', '=', True),
+                    ('id', '!=', record.id),
+                ]
+                
+                if self.search_count(domain) > 0:
+                    raise ValidationError(
+                        _("An International Sale Journal is already enabled. Only one is allowed.")
                     )

--- a/l10n_ve_tax/models/account_journal.py
+++ b/l10n_ve_tax/models/account_journal.py
@@ -36,7 +36,7 @@ class AccountJournal(models.Model):
         for record in self:
             if record.is_sale_international:
                 domain = [
-                    ('company_id', '=', record.company_id.id or self.env.company.id),
+                    ('company_id', '=', record.company_id.id),
                     ('is_sale_international', '=', True),
                     ('id', '!=', record.id),
                 ]

--- a/l10n_ve_tax/models/res_company.py
+++ b/l10n_ve_tax/models/res_company.py
@@ -48,6 +48,10 @@ class ResCompany(models.Model):
         "account.tax", domain=[("type_tax_use", "=", "purchase")]
     )
 
+    #International sale fields
+    zero_aliquot_sale_international = fields.Many2one("account.tax", domain=[("type_tax_use", "=", "sale")])
+
+    #International purchase fields
     exent_aliquot_purchase_international = fields.Many2one("account.tax", domain=[("type_tax_use", "=", "purchase")])
     general_aliquot_purchase_international = fields.Many2one("account.tax", domain=[("type_tax_use", "=", "purchase")])
     reduced_aliquot_purchase_international = fields.Many2one("account.tax", domain=[("type_tax_use", "=", "purchase")])

--- a/l10n_ve_tax/models/res_config_settings.py
+++ b/l10n_ve_tax/models/res_config_settings.py
@@ -75,6 +75,8 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
 
+    zero_aliquot_sale_international = fields.Many2one("account.tax",
+        related="company_id.zero_aliquot_sale_international", readonly=False)
 
     exent_aliquot_purchase_international = fields.Many2one("account.tax",
         related="company_id.exent_aliquot_purchase_international", readonly=False)

--- a/l10n_ve_tax/views/account_journal.xml
+++ b/l10n_ve_tax/views/account_journal.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             
             <field name="type" position="after">
+                <field name="is_sale_international" invisible="type != 'sale'"/>
                 <field name="is_purchase_international" invisible="type != 'purchase'"/>
             </field>
             

--- a/l10n_ve_tax/views/res_config_settings.xml
+++ b/l10n_ve_tax/views/res_config_settings.xml
@@ -79,6 +79,20 @@
                             </div>
                         </div>
 
+                        <h2>Sale Tax International Rates</h2>
+                        <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_tax_rates_sale_international">
+                            <div class="o_setting_left_pane">
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <div class="content-group">
+                                    <div class="row">
+                                        <label for="zero_aliquot_sale_international" class="col-lg-6 o_light_label"/>   
+                                        <field name="zero_aliquot_sale_international"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
                         <h2>Purchases Tax Rates</h2>
                         <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_tax_rates_purchase">
                             <div class="o_setting_left_pane">


### PR DESCRIPTION
Problema: Crear columna de Exportaciones Gravadas por Alícuota General en el libro de ventas.

Solucion:

10n_ve_tax:
Account Journal:
-Se agrega un campo booleano llamado is_sale_international, para identificar si el diario es de ventas internacionales.
-Adicionalmente se agrega un constrains para impedir que haya mas de un diario de ventas internacionales.

ResConfigSettings y Res Company:
-Se agrega un nuevo impuesto llamado zero_aliquot_sale_international que representa un impuesto de cero por ciento para las ventas internacionales, no tomar como exento, sino como un impuesto aparte literalmente de cero por ciento.

l10n_ve_invoice:
Accounting Reports:
-Se reestructura la forma en que se muestran las cabeceras en la funcion _get_sale_book_field_groups, para poder anadirle el apartado internacional correctamente.
-En _fields_sale_book_line se agregan una validacion que verifica los montos internacionales cuando la factura tiene el diario de tipo ventas internacionales. Ademas, se agregan las keys de zero_aliquiot_international, amount_zero_aliquot_international y tax_base_zero_aliquot_international, para anadir los valores del porcentaje del impuesto cero, el monto del impuesto y la base imponible del mismo, respectivamente.
-En _determinate_amount_taxeds se agregan las keys tax_base_zero_aliquot_international y amount_zero_aliquot_international, para poder calcularlos y posteriormente devolverlos si la factura es de venta internacional y el impuesto es el seteado como cero por ciento en configuracion.
-Se cambia el nombre de la fila "Exportaciones Gravadas por Alicuota General" por "Ventas de Exportacion", y se elimina completamente la fila de "Exportaciones Gravadas por Alicuota General mas Adicional", en la funcion _resume_sale_book_fields.
-Para _determinate_resume_books se agrega un nuevo bloque para calcular y manejar la sumatoria de la base y los montos gravados de las facturas, notas de debito y notas de credito de las facturas de venta internacionales, es decir, las del iva del 0%.

Tests:
-Se agregan pruebas unitarias para las implementaciones realizadas en las funciones mencionadas anteriormente.

Tarea (Link): https://binaural.odoo.com/web#id=63473&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []