### PR TITLE
Asientos no balanceados con Anticipo - IGTF

### DIFF
--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -19,7 +19,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "19.0.0.1.9",
+    "version": "19.0.0.1.10",
 
     "depends": [
         "base",

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -451,12 +451,13 @@ class AccountMove(models.Model):
             )
         
         vef_line1 = payment.currency_id.round(_to_vef(amount_line1))
-        vef_line2 = payment.currency_id.round(_to_vef(amount_line2))
+        vef_igtf = payment.currency_id.round(_to_vef(igtf_amount))
 
-        if abs(vef_line1) > abs(self.amount_residual_signed) and self.invoice_date == payment.date:
+        vef_line2 = abs(vef_line1) - abs(vef_igtf)
+
+        if abs(vef_line1) > abs(self.amount_residual_signed) and self.invoice_date == payment.date and igtf_amount == 0.0:
             vef_line2 = abs(self.amount_residual_signed)
 
-        vef_igtf = abs(vef_line1) - abs(vef_line2)
         vef_igtf = float(float_repr(vef_igtf, precision_digits= payment.currency_id.decimal_places))
 
         amount_currency_igtf = abs(amount_line1) - abs(amount_line2)
@@ -512,7 +513,6 @@ class AccountMove(models.Model):
             "account_id": account_rp,
             "amount_currency": amount_line2,
             "currency_id": payment.currency_id.id,
-            #line_2:vef_line2,
             **common_vals
         }))
 
@@ -522,8 +522,6 @@ class AccountMove(models.Model):
             "account_id": account_adv,
             "amount_currency": amount_line1,
             "currency_id": payment.currency_id.id,
-            #"debit": vef_line1 if is_customer else 0.0,
-            #"credit": vef_line1 if not is_customer else 0.0,
             **common_vals
         }))
 
@@ -534,9 +532,14 @@ class AccountMove(models.Model):
                 "account_id": igtf_account,
                 "amount_currency": amount_currency_igtf,
                 "currency_id": payment.currency_id.id,
-                #igtf_line:vef_igtf,
+                igtf_line:vef_igtf,
                 **common_vals
             }))
+
+            line_vals[0][2][line_2] = vef_line2
+    
+            line_vals[1][2]["debit"] = vef_line1 if is_customer else 0.0
+            line_vals[1][2]["credit"] = vef_line1 if not is_customer else 0.0
 
         # --- Creación del Asiento ---
         advance_journal = self.env.company.advance_payment_igtf_journal_id


### PR DESCRIPTION
[FIX] l10n_ve_igtf: Asientos no balanceados con Anticipo - IGTF
- Bug: Asientos no balanceados al momento de realizar cruce de pagos desde facturas(Asientos de IGTf)

- Solucion:  Se requeria ajustar validacion la validacion ya que el igtf era resultado de la resta de la cxc y el anticipo o banco, se ajusto para q la cuenta por cobrar fuera el residuo del calculo del monto con el IGTF en el codigo q realizaba los cruces, esto para garantizar mayor exactitud.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/12059?debug=1
- Tarea:
- PR:
- Otros: