### PR TITLE
[FIX]l10n_ve_pos:Se cambian funciones de redondeo en l10n_ve_pos

### DIFF
--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -237,7 +237,7 @@ patch(Order.prototype, {
         this.orderlines.reduce(function (sum, orderLine) {
           return sum + orderLine.get_foreign_tax();
         }, 0),
-        this.foreign_currency.rounding,
+        this.pos.foreign_currency.rounding,
       );
     }
   },

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -41,11 +41,11 @@ patch(Order.prototype, {
       return this.pos.config.foreign_inverse_rate;
     }
     if (this.pos.currency.name == "USD") {
-      return round_di(this.pos.config.foreign_rate, this.pos.foreign_currency.decimal_places);
+      return round_di(this.pos.config.foreign_rate, this.pos.dp["Tasa"]);
     }
   },
   get_display_rate() {
-    return round_di(this.pos.config.foreign_rate, this.pos.foreign_currency.decimal_places);
+    return round_di(this.pos.config.foreign_rate, this.pos.dp["Tasa"]);
   },
 
   add_orderline(line) {
@@ -213,7 +213,7 @@ patch(Order.prototype, {
       // 2. Round that result
       // 3. Sum all those rounded amounts
       var groupTaxes = {};
-      this.orderlines.forEach(function(line) {
+      this.orderlines.forEach(function (line) {
         var taxDetails = line.get_foreign_tax_details();
         var taxIds = Object.keys(taxDetails);
         for (var t = 0; t < taxIds.length; t++) {
@@ -245,7 +245,7 @@ patch(Order.prototype, {
     var details = {};
     var fulldetails = [];
 
-    this.orderlines.forEach(function(line) {
+    this.orderlines.forEach(function (line) {
       var ldetails = line.get_foreign_tax_details();
       for (var id in ldetails) {
         if (Object.hasOwnProperty.call(ldetails, id)) {

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -167,22 +167,22 @@ patch(Order.prototype, {
   },
   /* ---- Payment Status --- */
   get_foreign_subtotal() {
-    return round_di(
+    return round_pr(
       this.orderlines.reduce(function (sum, orderLine) {
         return sum + orderLine.get_display_foreign_price();
       }, 0),
-      4,
+      this.pos.foreign_currency.rounding,
     );
   },
   get_foreign_total_with_tax() {
     return this.get_foreign_total_without_tax() + this.get_foreign_total_tax();
   },
   get_foreign_total_without_tax() {
-    return round_di(
+    return round_pr(
       this.orderlines.reduce(function (sum, orderLine) {
         return sum + orderLine.get_foreign_price_without_tax();
       }, 0),
-      4,
+      this.pos.foreign_currency.rounding,
     );
   },
   get_foreign_total_discount() {
@@ -203,7 +203,7 @@ patch(Order.prototype, {
         }
         return sum;
       }, 0),
-      4,
+      this.pos.foreign_currency.rounding,
     );
   },
   get_foreign_total_tax() {
@@ -233,11 +233,11 @@ patch(Order.prototype, {
       }
       return sum;
     } else {
-      return round_di(
+      return round_pr(
         this.orderlines.reduce(function (sum, orderLine) {
           return sum + orderLine.get_foreign_tax();
         }, 0),
-        4,
+        this.foreign_currency.rounding,
       );
     }
   },
@@ -427,7 +427,7 @@ patch(Order.prototype, {
   },
 
   get_foreign_total_paid() {
-    return round_di(
+    return round_pr(
       this.paymentlines.reduce(function (sum, paymentLine) {
         if (paymentLine.is_done()) {
           sum += paymentLine.get_foreign_amount();

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -45,7 +45,7 @@ patch(Order.prototype, {
     }
   },
   get_display_rate() {
-    return round_di(this.pos.config.foreign_rate, this.pos.dp["Tasa"]);
+    return parseFloat(this.pos.config.foreign_rate.toFixed(this.pos.dp["Tasa"]));
   },
 
   add_orderline(line) {

--- a/l10n_ve_pos/static/src/overrides/models/pos_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/pos_model.js
@@ -93,7 +93,7 @@ patch(PosStore.prototype, {
       if (company.country && company.country.code === "IN") {
         let total_tax_amount = 0.0;
         for (const [i, tax_factor] of incl_tax_amounts.percent_taxes) {
-          const tax_amount = round_pr(base_amount * tax_factor / (100 + percent_amount), this.foreign_currency.rounding);
+          const tax_amount = round_pr(base_amount * tax_factor / (100 + percent_amount), this.pos.foreign_currency.rounding);
           total_tax_amount += tax_amount;
           cached_tax_amounts[i] = tax_amount;
           fixed_amount += tax_amount;

--- a/l10n_ve_pos/static/src/overrides/models/pos_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/pos_model.js
@@ -93,7 +93,7 @@ patch(PosStore.prototype, {
       if (company.country && company.country.code === "IN") {
         let total_tax_amount = 0.0;
         for (const [i, tax_factor] of incl_tax_amounts.percent_taxes) {
-          const tax_amount = round_di(base_amount * tax_factor / (100 + percent_amount), 4);
+          const tax_amount = round_pr(base_amount * tax_factor / (100 + percent_amount), this.foreign_currency.rounding);
           total_tax_amount += tax_amount;
           cached_tax_amounts[i] = tax_amount;
           fixed_amount += tax_amount;
@@ -117,7 +117,7 @@ patch(PosStore.prototype, {
       );
     };
 
-    var base = round_pr(price_unit * quantity, currency_rounding);
+    var base = round_pr(price_unit * quantity, initial_currency_rounding);
 
     var sign = 1;
     if (base < 0) {
@@ -173,9 +173,9 @@ patch(PosStore.prototype, {
       });
     }
 
-    var total_excluded = round_di(
+    var total_excluded = round_pr(
       recompute_base(base, incl_tax_amounts),
-      currency_rounding
+      initial_currency_rounding
     );
     var total_included = total_excluded;
 
@@ -206,10 +206,10 @@ patch(PosStore.prototype, {
         var tax_amount = self._compute_all(tax, tax_base_amount, quantity, true);
       }
 
-      tax_amount = round_di(tax_amount, 4);
-      var factorized_tax_amount = round_di(
+      tax_amount = round_pr(tax_amount, initial_currency_rounding);
+      var factorized_tax_amount = round_pr(
         tax_amount * tax.sum_repartition_factor,
-        4
+        initial_currency_rounding
       );
 
       if (tax.price_include && total_included_checkpoints[i] === undefined) {
@@ -220,7 +220,7 @@ patch(PosStore.prototype, {
         id: tax.id,
         name: tax.name,
         amount: sign * factorized_tax_amount,
-        base: sign * round_di(tax_base_amount, 4),
+        base: sign * round_pr(tax_base_amount, initial_currency_rounding),
       });
 
       if (tax.include_base_amount) {
@@ -235,8 +235,8 @@ patch(PosStore.prototype, {
     });
     return {
       taxes: taxes_vals,
-      total_excluded: sign * round_di(total_excluded, 4),
-      total_included: sign * round_di(total_included, 4),
+      total_excluded: sign * round_pr(total_excluded, initial_currency_rounding),
+      total_included: sign * round_pr(total_included, initial_currency_rounding),
     };
   },
 

--- a/l10n_ve_pos/static/src/overrides/screens/product_screen/product_screen.xml
+++ b/l10n_ve_pos/static/src/overrides/screens/product_screen/product_screen.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="l10n_ve_pos.ProductScreen" t-inherit="point_of_sale.ProductScreen" t-inherit-mode="extension">
         <xpath expr="//OrderWidget" position="attributes">
-            <attribute name="conversion_rate">env.utils.formatForeignCurrency(currentOrder.get_conversion_rate())</attribute>
+            <attribute name="conversion_rate">env.utils.formatRate(currentOrder.get_conversion_rate(), currentOrder.pos.foreign_currency)</attribute>
             <attribute name="foreign_total">env.utils.formatForeignCurrency(currentOrder.get_foreign_total_with_tax())</attribute>
             <attribute name="foreign_tax">
 !env.utils.floatIsZero(currentOrder.get_foreign_total_tax()) and env.utils.formatForeignCurrency(currentOrder.get_foreign_total_tax()) or ''

--- a/l10n_ve_pos/static/src/overrides/utils/contextual_utils_service.js
+++ b/l10n_ve_pos/static/src/overrides/utils/contextual_utils_service.js
@@ -26,7 +26,8 @@ patch(contextualUtilsService, {
       return formatCurrency(parseFloat(valueStr), hasSymbol);
     };
     const formatRate = (value) => {
-      value = String(value).replace(".", ",");
+      const decimals = pos.dp["Tasa"];
+      value = Number(value).toFixed(decimals).replace(".", ",");
       const formatted = [foreign_currency.symbol, value];
       if (foreign_currency.position === "after") {
         formatted.reverse();

--- a/l10n_ve_pos/static/src/overrides/utils/contextual_utils_service.js
+++ b/l10n_ve_pos/static/src/overrides/utils/contextual_utils_service.js
@@ -3,6 +3,7 @@
 import { contextualUtilsService } from "@point_of_sale/app/utils/contextual_utils_service";
 import { formatMonetary } from "@web/views/fields/formatters";
 import { patch } from "@web/core/utils/patch";
+import { nbsp } from "@web/core/utils/strings";
 
 patch(contextualUtilsService, {
 
@@ -24,11 +25,20 @@ patch(contextualUtilsService, {
     const formatStrForeignCurrency = (valueStr, hasSymbol = true) => {
       return formatCurrency(parseFloat(valueStr), hasSymbol);
     };
+    const formatRate = (value) => {
+      value = String(value).replace(".", ",");
+      const formatted = [foreign_currency.symbol, value];
+      if (foreign_currency.position === "after") {
+        formatted.reverse();
+      }
+      return formatted.join(nbsp);
 
+    };
     env.utils = {
       ...env.utils,
       formatForeignCurrency,
       formatStrForeignCurrency,
+      formatRate,
     };
   }
 

--- a/l10n_ve_pos_igtf/static/src/app/overrides/models/order_model.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/models/order_model.js
@@ -131,8 +131,8 @@ patch(Order.prototype, {
         return;
       }
 
-      bi_igtf += payment.amount;
-      foreign_bi_igtf += payment.get_foreign_amount();
+      bi_igtf += round_pr(payment.amount, rounding);
+      foreign_bi_igtf += round_pr(payment.get_foreign_amount(), rounding);
       repeat_same_method.push(payment.payment_method.id);
       bi_payments.push(payment.cid);
 
@@ -224,7 +224,7 @@ patch(Order.prototype, {
   },
   compute_igtf_amount(amount) {
     var rounding = this.pos.currency.rounding;
-    return amount * (this.pos.config.igtf_percentage / 100);
+    return round_pr(amount * (this.pos.config.igtf_percentage / 100), rounding);
   },
 
   get_bi_igtf() {
@@ -303,7 +303,9 @@ patch(Order.prototype, {
     }
 
     if (
-      !payment_method.apply_igtf || this.get_due() <= this.get_igtf_amount() || is_change
+      !payment_method.apply_igtf ||
+      this.get_due() <= this.get_igtf_amount() ||
+      is_change
     ) {
       let res = super.add_paymentline(...arguments);
       this.update_igtf();

--- a/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_status.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_status.js
@@ -57,7 +57,7 @@ patch(PaymentScreenStatus.prototype, {
   },
   get suggestedIgtf() {
     var rounding = this.pos.currency.rounding;
-    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), this.pos.foreign_currency.rounding);
+    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), rounding);
     return this.env.utils.formatCurrency(result);
   },
   get foreignTotalDueTextWithIGTF() {
@@ -80,7 +80,7 @@ patch(PaymentScreenStatus.prototype, {
   },
   get totalDueTextWithIGTFDisplay() {
     var rounding = this.pos.currency.rounding;
-    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), this.pos.foreign_currency.rounding);
+    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), rounding);
     return this.env.utils.formatCurrency(
       (this.props.order.get_total_with_tax() + result)
     );

--- a/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_status.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_status.js
@@ -34,7 +34,6 @@ patch(PaymentScreenStatus.prototype, {
     return is_igtf;
   },
   get amountIGTF() {
-    // Comprobamos si algún método de pago aplica IGTF
     let payment_lines = this.props.order.get_paymentlines();
     let hasIgtfMethod = false;
     payment_lines.forEach(payment_line => {
@@ -58,7 +57,7 @@ patch(PaymentScreenStatus.prototype, {
   },
   get suggestedIgtf() {
     var rounding = this.pos.currency.rounding;
-    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), 4);
+    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), this.pos.foreign_currency.rounding);
     return this.env.utils.formatCurrency(result);
   },
   get foreignTotalDueTextWithIGTF() {
@@ -81,7 +80,7 @@ patch(PaymentScreenStatus.prototype, {
   },
   get totalDueTextWithIGTFDisplay() {
     var rounding = this.pos.currency.rounding;
-    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), 4);
+    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), this.pos.foreign_currency.rounding);
     return this.env.utils.formatCurrency(
       (this.props.order.get_total_with_tax() + result)
     );


### PR DESCRIPTION
Se cambia uso de round_pr para la precision decimal en POS por sitios en los que se usaba round_di.

Link:https://binaural.odoo.com/odoo/my-tickets/10981