### PR TITLE
Remove translation for 'residual amount'

### DIFF
--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -1750,7 +1750,3 @@ msgstr "Todos los métodos de pagos deben tener una cuenta asignada."
 msgid "foreign_amount"
 msgstr "Importe alterno"
 
-#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__amount_residual_company
-#: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__amount_residual_company
-msgid "residual amount"
-msgstr "Importe adeudado"


### PR DESCRIPTION
Removed translation for 'residual amount' in Spanish.