### PR TITLE
FIX 66270 Crear nuevo estado en invoice_status

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "1.12",
+    "version": "1.13",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/i18n/es_VE.po
+++ b/l10n_ve_sale/i18n/es_VE.po
@@ -587,3 +587,8 @@ msgstr "tasa"
 #: code:addons/l10n_ve_sale/models/sale_order.py:0
 msgid "{}. Only has {} units of the {} demanded."
 msgstr "{}. Solo tiene {} unidades de {} exigidas."
+
+#. module: l10n_ve_sale
+#: model:ir.model.fields.selection,name:l10n_ve_sale.selection__sale_order__invoice_status__partially_billed
+msgid "Partially billed"
+msgstr "Parcialmente facturado"

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -672,3 +672,18 @@ class SaleOrder(models.Model):
             else:
                 order.amount_untaxed_total_signed = order.amount_untaxed
                 order.amount_total_signed = order.amount_total
+
+    invoice_status = fields.Selection(
+        selection_add=[('partially_billed', 'Partially billed')],
+    )
+    
+    @api.depends('order_line.qty_invoiced', 'order_line.qty_delivered')
+    def _compute_invoice_status(self):
+        for order in self:
+            if order.state in ('sale', 'done'):
+                total_invoiced = sum(order.order_line.mapped('qty_invoiced'))
+                total_delivered = sum(order.order_line.mapped('qty_delivered'))
+                if total_invoiced > 0 and total_invoiced <= total_delivered:
+                    order.invoice_status = 'partially_billed'
+                    continue
+            super(SaleOrder, order)._compute_invoice_status()


### PR DESCRIPTION
 Se añade el nuevo valor 'partially_billed' al campo de selección invoice_status.
 Se extiende el método _compute_invoice_status para identificar pedidos donde
 la cantidad facturada es mayor a cero pero menor o igual a la entregada.
 Se mantiene la lógica original del sistema mediante super() para otros casos.

NOTA: Se agrega la traduccion
URL: https://binaural.odoo.com/web#id=66270&cids=2&menu_id=1063&action=345&active_id=3124&model=project.task&view_type=form

NOTA: falto subir este pr a la rama de mantenimiento 