### PR TITLE
fix(accounting-reports): Verificar reporte de libro de compras que no…

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.1.5",
+    "version": "17.0.0.1.6",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/controllers/accounting_reports.py
+++ b/l10n_ve_invoice/controllers/accounting_reports.py
@@ -13,8 +13,9 @@ class AccountingReportsController(http.Controller):
         sale_book_model_su = env_su["wizard.accounting.reports"]
 
         company_id = int(kw.get("company_id", 1))
-
-        sale_book = sale_book_model_su.search([], order="id desc", limit=1)
+        wizard_id = int(kw.get("wizard_id", 0) or 0)
+        domain = [("id", "=", wizard_id)] if wizard_id else [("create_uid", "=", env_request.uid)]
+        sale_book = sale_book_model_su.search(domain, order="id desc", limit=1)
 
         file = sale_book.generate_sales_book(company_id)
 
@@ -41,8 +42,9 @@ class AccountingReportsController(http.Controller):
         purchase_book_model_su = env_su["wizard.accounting.reports"]
 
         company_id = int(kw.get("company_id", 1))
-
-        purchase_book = purchase_book_model_su.search([], order="id desc", limit=1)
+        wizard_id = int(kw.get("wizard_id", 0) or 0)
+        domain = [("id", "=", wizard_id)] if wizard_id else [("create_uid", "=", env_request.uid)]
+        purchase_book = purchase_book_model_su.search(domain, order="id desc", limit=1)
 
         file = purchase_book.generate_purchases_book(company_id)
         

--- a/l10n_ve_invoice/tests/__init__.py
+++ b/l10n_ve_invoice/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_account_move
 from . import test_common_purchase_international
 from . import test_purchase_book_international
+from . import test_accounting_reports_controller

--- a/l10n_ve_invoice/tests/test_accounting_reports_controller.py
+++ b/l10n_ve_invoice/tests/test_accounting_reports_controller.py
@@ -1,0 +1,122 @@
+from io import BytesIO
+from unittest.mock import patch
+from zipfile import ZipFile
+
+from odoo import fields
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.l10n_ve_invoice.controllers.accounting_reports import AccountingReportsController
+
+
+class _FakeRequest:
+    def __init__(self, env):
+        self.env = env
+
+    def make_response(self, data, headers=None):
+        return {"data": data, "headers": headers or []}
+
+
+@tagged("post_install", "-at_install", "l10n_ve_invoice")
+class TestAccountingReportsController(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.controller = AccountingReportsController()
+        self.company = self.env.company
+
+    def _create_wizard(self, user=None, report="purchase"):
+        vals = {
+            "company_id": self.company.id,
+            "report": report,
+            "date_from": fields.Date.today(),
+            "date_to": fields.Date.today(),
+        }
+        model = self.env["wizard.accounting.reports"]
+        if user:
+            model = model.with_user(user)
+        return model.create(vals)
+
+    def test_download_purchase_book_uses_wizard_id(self):
+        wizard = self._create_wizard(report="purchase")
+
+        with patch(
+            "odoo.addons.l10n_ve_invoice.controllers.accounting_reports.http.request",
+            _FakeRequest(self.env),
+        ), patch(
+            "odoo.addons.l10n_ve_invoice.wizard.accounting_reports.WizardAccountingReportsBinauralInvoice.generate_purchases_book",
+            autospec=True,
+            side_effect=lambda wiz, company_id: f"purchase:{wiz.id}:{company_id}".encode(),
+        ):
+            response = self.controller.download_purchase_book.__wrapped__(
+                self.controller,
+                company_id=str(self.company.id),
+                wizard_id=str(wizard.id),
+            )
+
+        self.assertEqual(response["data"], f"purchase:{wizard.id}:{self.company.id}".encode())
+        headers = dict(response["headers"])
+        self.assertIn("Libro_de_compra.xlsx", headers.get("Content-Disposition", ""))
+
+    def test_download_sales_book_uses_wizard_id(self):
+        wizard = self._create_wizard(report="sale")
+
+        with patch(
+            "odoo.addons.l10n_ve_invoice.controllers.accounting_reports.http.request",
+            _FakeRequest(self.env),
+        ), patch(
+            "odoo.addons.l10n_ve_invoice.wizard.accounting_reports.WizardAccountingReportsBinauralInvoice.generate_sales_book",
+            autospec=True,
+            side_effect=lambda wiz, company_id: f"sale:{wiz.id}:{company_id}".encode(),
+        ):
+            response = self.controller.download_sales_book.__wrapped__(
+                self.controller,
+                company_id=str(self.company.id),
+                wizard_id=str(wizard.id),
+            )
+
+        self.assertEqual(response["data"], f"sale:{wizard.id}:{self.company.id}".encode())
+        headers = dict(response["headers"])
+        self.assertIn("Libro_de_venta.xlsx", headers.get("Content-Disposition", ""))
+
+    def test_download_purchase_book_fallback_to_current_user(self):
+        group_user = self.env.ref("base.group_user")
+        other_user = self.env["res.users"].with_context(no_reset_password=True).create(
+            {
+                "name": "Tmp Other User",
+                "login": "tmp_other_user_ci",
+                "email": "tmp_other_user_ci@example.com",
+                "groups_id": [(6, 0, [group_user.id])],
+            }
+        )
+
+        own_wizard = self._create_wizard(report="purchase")
+        self._create_wizard(user=other_user, report="purchase")
+
+        with patch(
+            "odoo.addons.l10n_ve_invoice.controllers.accounting_reports.http.request",
+            _FakeRequest(self.env),
+        ), patch(
+            "odoo.addons.l10n_ve_invoice.wizard.accounting_reports.WizardAccountingReportsBinauralInvoice.generate_purchases_book",
+            autospec=True,
+            side_effect=lambda wiz, company_id: f"fallback:{wiz.id}:{company_id}".encode(),
+        ):
+            response = self.controller.download_purchase_book.__wrapped__(
+                self.controller,
+                company_id=str(self.company.id),
+            )
+
+        self.assertEqual(response["data"], f"fallback:{own_wizard.id}:{self.company.id}".encode())
+
+    def test_generate_purchase_book_without_moves_exports_zero_resume(self):
+        wizard = self._create_wizard(report="purchase")
+
+        content = wizard.generate_purchases_book(self.company)
+
+        self.assertTrue(content.startswith(b"PK"))
+
+        with ZipFile(BytesIO(content)) as workbook_zip:
+            sheet_xml = workbook_zip.read("xl/worksheets/sheet1.xml").decode()
+            shared_strings = workbook_zip.read("xl/sharedStrings.xml").decode()
+
+        self.assertIn("Compras Internas no Gravadas", shared_strings)
+        self.assertIn("Total Compras y Créditos Fiscales del Periodo", shared_strings)
+        self.assertGreaterEqual(sheet_xml.count("<v>0</v>"), 8)

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -687,12 +687,12 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
 
     def download_sales_book(self):
         self.ensure_one()
-        url = "/web/download_sales_book?company_id=%s" % self.company_id.id
+        url = "/web/download_sales_book?company_id=%s&wizard_id=%s" % (self.company_id.id, self.id)
         return {"type": "ir.actions.act_url", "url": url, "target": "self"}
 
     def download_purchases_book(self):
         self.ensure_one()
-        url = "/web/download_purchase_book?company_id=%s" % self.company_id.id
+        url = "/web/download_purchase_book?company_id=%s&wizard_id=%s" % (self.company_id.id, self.id)
         return {"type": "ir.actions.act_url", "url": url, "target": "self"}
 
     def _format_date(self, date):
@@ -1225,8 +1225,8 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 ventas_internas_format
             ) 
                 
-        name_columns = flat_fields 
-        total_idx = 0
+        name_columns = flat_fields
+        total_idx = INIT_LINES + len(sale_book_lines)
 
         for index, field in enumerate(name_columns):
             
@@ -1367,8 +1367,8 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
         
         last_col_index = current_col_index - 1
                 
-        name_columns = flat_fields 
-        total_idx = 0
+        name_columns = flat_fields
+        total_idx = INIT_LINES + len(purchase_book_lines)
 
         for index, field in enumerate(name_columns):
             
@@ -1422,8 +1422,6 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             worksheet.write(header_idx + 1, nidx + 1, header.get("headers")[1])
 
         moves = self.search_moves()
-        if not moves:
-            raise UserError(_('There are no moves to show'))
         resume_columns = (
             self._resume_purchase_book_fields(moves)
             if is_purchase
@@ -1695,5 +1693,4 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
         if no_deductible_fields:
             purchase_groups.append({'header': 'IMPUESTOS NO DEDUCIBLES', 'fields': no_deductible_fields})
 
-        
         return purchase_groups

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.30",
+    "version": "17.0.0.0.31",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/wizard/accounting_reports.py
+++ b/l10n_ve_payment_extension/wizard/accounting_reports.py
@@ -85,7 +85,7 @@ class WizardAccountingReports(models.TransientModel):
 
     
     def _get_sale_book_field_groups(self):
-        sale_groups = super()._get_sale_book_field_groups()
+        sale_groups = super()._get_sale_book_field_groups() or []
 
         retention_fields = [
             {"name": "Fecha Retención", "field": "retention_date", "format": "string", "size": 15},
@@ -130,7 +130,7 @@ class WizardAccountingReports(models.TransientModel):
         return fields_sale_book_line
     
     def _get_purchase_book_field_groups(self):
-        purchase_groups = super()._get_purchase_book_field_groups() 
+        purchase_groups = super()._get_purchase_book_field_groups() or []
 
         retention_fields = [
             {"name": "Fecha Retención", "field": "retention_date", "format": "string", "size": 15},


### PR DESCRIPTION
… me genera el informe en cero

Problema:
- Los endpoints de descarga tomaban el ultimo wizard global y podian mezclar datos entre usuarios.
- La generacion de libros fallaba o quedaba inconsistente cuando no existian movimientos en el periodo.
- La extension de pagos asumía que super() siempre devolvia listas, lo que podia romper la composicion de columnas.

Solucion:
- Se envio wizard_id en las URLs de descarga y el controlador ahora busca primero por ese id; si no llega, hace fallback al ultimo wizard del usuario actual.
- Se ajusto el calculo de totales para ubicarlos despues de las lineas exportadas y se permitio exportar el resumen en cero cuando no hay movimientos.
- Se agregaron pruebas para wizard_id, fallback por usuario y exportacion del libro de compras sin movimientos.
- Se reforzaron los grupos del modulo de pagos con 'or []' y se actualizaron las versiones de los modulos afectados. -https://binaural.odoo.com/odoo/all-tickets/11525