### PR TITLE
[FIX] l10n_ve_accountant: corregir residuo de redondeo en facturas

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "1.46",
+    "version": "1.47",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -173,6 +173,9 @@ class AccountMoveLine(models.Model):
                 continue
 
             if line.display_type in ("payment_term", "tax"):
+                # 1 Case: Payment Term / Tax
+                # foreign_balance is set by _sync_tax_lines / _inverse_foreign_balance.
+                # payment_term will be overwritten by the residue block below.
                 line.foreign_debit = (
                     abs(line.foreign_balance) if line.foreign_balance > 0 else 0.0
                 )
@@ -180,31 +183,27 @@ class AccountMoveLine(models.Model):
                     abs(line.foreign_balance) if line.foreign_balance < 0 else 0.0
                 )
                 continue
-                # 1 Case: Payment Term
-                # In this case, we don't want to calculate the foreign debit and credit
 
             if line.display_type in ("line_section", "line_note"):
+                # 2 Case: Section / Note — no foreign amount
                 line.foreign_debit = line.foreign_credit = 0.0
-                # 2 Case: not Product
-                # In this case, we don't want to calculate the foreign debit and credit
                 continue
 
             if line.foreign_debit_adjustment:
+                # 3 Case: Foreign Debit Adjustment (manual override)
                 line.foreign_debit = abs(line.foreign_debit_adjustment)
-                # 3 Case: Foreign Debit Adjustment
-                # In this case, we need to set the foreign debit manually
                 continue
 
             if line.foreign_credit_adjustment:
+                # 4 Case: Foreign Credit Adjustment (manual override)
                 line.foreign_credit = abs(line.foreign_credit_adjustment)
-                # 4 Case: Foreign Credit Adjustment
-                # In this case, we need to set the foreign credit manually
                 continue
 
             if (
                 line.currency_id == line.company_id.foreign_currency_id
                 and line.amount_currency
             ):
+                # 5 Case: Line already in foreign currency — use amount_currency directly
                 line.foreign_debit = (
                     abs(line.amount_currency) if line.amount_currency > 0 else 0.0
                 )
@@ -218,8 +217,7 @@ class AccountMoveLine(models.Model):
                 and "retention_foreign_amount" in self.env["account.payment"]._fields
                 and line.move_id.origin_payment_id.is_retention
             ):
-                # 5 Case: Retention
-                # In this case, we need to set the foreign debit and credit of the retention
+                # 6 Case: Retention — use the retention's own foreign amount
                 if not line.currency_id.is_zero(line.debit):
                     line.foreign_debit = (
                         line.move_id.origin_payment_id.retention_foreign_amount
@@ -232,54 +230,92 @@ class AccountMoveLine(models.Model):
                     continue
 
             if not line.move_id.is_invoice(include_receipts=True):
-                # 6 Case: Not Invoice
-                # In this case, we need to calculate the foreign debit and credit with rate
+                # 7 Case: Not Invoice (journal entry, payment, etc.)
                 foreign_lines = line.move_id.line_ids.filtered(
                     lambda l: l.currency_id == l.company_id.foreign_currency_id
                 )
                 currency_lines = line.move_id.line_ids.filtered(
                     lambda l: l.currency_id == l.company_id.currency_id
                 )
-
                 balance = sum((foreign_lines).mapped("amount_currency"))
                 if balance and len(currency_lines) == 1:
                     line.foreign_debit = abs(balance) if balance < 0 else 0.0
                     line.foreign_credit = abs(balance) if balance > 0 else 0.0
                     continue
-
                 if line.currency_id and line.currency_id != line.company_id.foreign_currency_id and line.currency_id != line.company_id.currency_id:
-                     line.foreign_debit = line.company_id.currency_id._convert(
-                         line.debit,
-                         line.company_id.foreign_currency_id,
-                         line.company_id,
-                         line.date or fields.Date.context_today(line)
-                     )
-                     line.foreign_credit = line.company_id.currency_id._convert(
-                         line.credit,
-                         line.company_id.foreign_currency_id,
-                         line.company_id,
-                         line.date or fields.Date.context_today(line)
-                     )
+                    line.foreign_debit = line.company_id.currency_id._convert(
+                        line.debit,
+                        line.company_id.foreign_currency_id,
+                        line.company_id,
+                        line.date or fields.Date.context_today(line)
+                    )
+                    line.foreign_credit = line.company_id.currency_id._convert(
+                        line.credit,
+                        line.company_id.foreign_currency_id,
+                        line.company_id,
+                        line.date or fields.Date.context_today(line)
+                    )
                 else:
                     line.foreign_debit = line.debit * line.foreign_inverse_rate
                     line.foreign_credit = line.credit * line.foreign_inverse_rate
                 continue
 
             if line.display_type in ("product", "cogs"):
-                # 7 Case: Product
-                # In this case, we need to calculate the foreign debit and credit with subtotal
+                # 8 Case: Product / COGS — use foreign_subtotal
                 sign = line.move_id.direction_sign * -1
                 amount = line.foreign_subtotal * sign
                 line.foreign_debit = abs(amount) if amount < 0 else 0.0
                 line.foreign_credit = abs(amount) if amount > 0 else 0.0
                 continue
 
-            # line.foreign_debit = (
-            #     abs(line.foreign_balance) if line.foreign_balance < 0 else 0.0
-            # )
-            # line.foreign_credit = (
-            #     abs(line.foreign_balance) if line.foreign_balance > 0 else 0.0
-            # )
+        # ── Ajuste de residuo: payment_term en facturas ───────────────────────
+        # El loop calcula payment_term con foreign_balance (conversión individual),
+        # lo que introduce diferencia de centavo al sumar múltiples líneas con tasa.
+        # Leemos move.line_ids completo (no solo self) porque Odoo puede disparar
+        # este compute solo para la payment_term cuando las otras ya están en DB.
+        for move in self.mapped("move_id"):
+            if not move.is_invoice(include_receipts=True):
+                continue
+            pt_lines = self.filtered(
+                lambda l: l.move_id == move
+                and l.display_type == "payment_term"
+                and not l.not_foreign_recalculate
+            )
+            if not pt_lines:
+                continue
+            all_other = move.line_ids.filtered(
+                lambda l: l.display_type != "payment_term"
+            )
+            total_debit = sum(all_other.mapped("foreign_debit"))
+            total_credit = sum(all_other.mapped("foreign_credit"))
+            foreign_currency = move.company_id.foreign_currency_id
+            pt_sorted = pt_lines.sorted("id")
+            n = len(pt_sorted)
+            total_balance = sum(abs(l.balance) for l in pt_sorted)
+
+            for i, pt_line in enumerate(pt_sorted):
+                is_credit_side = pt_line.credit > 0
+                foreign_total = total_debit if is_credit_side else total_credit
+
+                if n == 1:
+                    my_foreign = foreign_total
+                elif i < n - 1:
+                    ratio = abs(pt_line.balance) / total_balance if total_balance else 0.0
+                    my_foreign = foreign_currency.round(ratio * foreign_total)
+                else:
+                    assigned = sum(
+                        foreign_currency.round(abs(l.balance) / total_balance * foreign_total)
+                        if total_balance else 0.0
+                        for l in list(pt_sorted)[:-1]
+                    )
+                    my_foreign = foreign_total - assigned
+
+                if is_credit_side:
+                    pt_line.foreign_credit = my_foreign
+                    pt_line.foreign_debit = 0.0
+                else:
+                    pt_line.foreign_debit = my_foreign
+                    pt_line.foreign_credit = 0.0
 
     @api.depends("foreign_credit", "foreign_debit")
     def _compute_foreign_balance(self):

--- a/l10n_ve_accountant/tests/test_foreign_balance.py
+++ b/l10n_ve_accountant/tests/test_foreign_balance.py
@@ -136,6 +136,84 @@ class TestForeignBalance(TransactionCase):
             }
         )
 
+    def _set_usd_rate(self, rate):
+        currency_rate = self.env["res.currency.rate"].search(
+            [
+                ("name", "=", fields.Date.today()),
+                ("currency_id", "=", self.currency_usd.id),
+                ("company_id", "=", self.company.id),
+            ],
+            limit=1,
+        )
+        if currency_rate:
+            currency_rate.write({"inverse_company_rate": rate})
+            return currency_rate
+
+        return self.env["res.currency.rate"].create(
+            {
+                "name": fields.Date.today(),
+                "currency_id": self.currency_usd.id,
+                "inverse_company_rate": rate,
+                "company_id": self.company.id,
+            }
+        )
+
+    def _assert_foreign_balance_squares(self, lines, label, places=2):
+        sum_foreign_debit = sum(lines.mapped("foreign_debit"))
+        sum_foreign_credit = sum(lines.mapped("foreign_credit"))
+
+        self.assertAlmostEqual(
+            sum_foreign_debit,
+            sum_foreign_credit,
+            places=places,
+            msg=(
+                f"Foreign balance mismatch on {label}: debit={sum_foreign_debit} "
+                f"credit={sum_foreign_credit}"
+            ),
+        )
+        return sum_foreign_debit, sum_foreign_credit
+
+    def _assert_non_payment_term_lines_convert(self, lines, move_date, label, delta=0.02):
+        tested_lines = lines.filtered(
+            lambda line: line.display_type not in ("payment_term", "line_section", "line_note")
+        )
+
+        for line in tested_lines:
+            expected_foreign_debit = self.currency_vef._convert(
+                line.debit,
+                self.currency_usd,
+                self.company,
+                move_date,
+            )
+            expected_foreign_credit = self.currency_vef._convert(
+                line.credit,
+                self.currency_usd,
+                self.company,
+                move_date,
+            )
+
+            if line.debit > 0:
+                self.assertAlmostEqual(
+                    line.foreign_debit,
+                    expected_foreign_debit,
+                    delta=delta,
+                    msg=(
+                        f"{label}: foreign_debit incorrect for line {line.name}. "
+                        f"Expected {expected_foreign_debit}, got {line.foreign_debit}"
+                    ),
+                )
+
+            if line.credit > 0:
+                self.assertAlmostEqual(
+                    line.foreign_credit,
+                    expected_foreign_credit,
+                    delta=delta,
+                    msg=(
+                        f"{label}: foreign_credit incorrect for line {line.name}. "
+                        f"Expected {expected_foreign_credit}, got {line.foreign_credit}"
+                    ),
+                )
+
     def test_invoice_foreign_balance_simple(self):
         """Testea el balance de débito/crédito en divisa extranjera (USD) para una factura."""
         # Create invoice in USD (Foreign Currency now)
@@ -679,4 +757,201 @@ class TestForeignBalance(TransactionCase):
                         f"its VEF credit ({line.credit}). VEF value was used as USD (bug)."
                     ),
                 )
+    
+    def test_invoice_pricelist_vef_two_products(self):
+        """
+        CASO REAL DEL BUG: Factura en VEF con tasa 402,3343 VEF/USD.
+          Producto 1: 23.200,00 VEF + IVA 16% (3.712,00 VEF)
+          Producto 2: 56.200,00 VEF EXENTO
+          Total:      83.112,00 VEF → ≈ 206,57 USD
+
+        Antes del fix, la línea CxC convertía 83.112 / 402,3343 = 206,58 (redondeo),
+        mientras los créditos sumaban 206,57 → descuadre de $0,01.
+        Con el fix (residuo), la CxC toma exactamente la suma de los créditos.
+        """
+        RATE = 402.3343
+        self._set_usd_rate(RATE)
+
+        product_exempt = self.env["product.product"].create(
+            {
+                "name": "Producto Exento",
+                "type": "service",
+                "list_price": 56200.0,
+                "taxes_id": [(5, 0, 0)],
+            }
+        )
+
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "journal_id": self.sale_journal.id,
+                "currency_id": self.currency_vef.id,
+                "date": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": 23200.0,
+                            "account_id": self.account_income.id,
+                            "tax_ids": [(6, 0, [self.test_tax.id])],
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "product_id": product_exempt.id,
+                            "quantity": 1.0,
+                            "price_unit": 56200.0,
+                            "account_id": self.account_income.id,
+                            "tax_ids": [(5, 0, 0)],
+                        }
+                    ),
+                ],
+            }
+        )
+        invoice.with_context(move_action_post_alert=True).action_post()
+        self.assertEqual(invoice.state, "posted", "La factura no se publicó")
+
+        # Total VEF: 23.200 + 56.200 + 3.712 (IVA) = 83.112,00
+        self.assertAlmostEqual(
+            invoice.amount_total, 83112.0, places=2,
+            msg="Total factura VEF debe ser 83.112,00",
+        )
+
+        # Cuadre exacto (este assert detecta el bug de $0,01)
+        fd, fc = self._assert_foreign_balance_squares(
+            invoice.line_ids, "invoice_two_products_rate_402"
+        )
+
+        # Total USD esperado: 83.112 / 402,3343 ≈ 206,57
+        expected_usd = 83112.0 / RATE
+        self.assertAlmostEqual(
+            fd, expected_usd, delta=0.02,
+            msg=f"Total USD debe ser ≈ {expected_usd:.2f}",
+        )
+
+        # Las líneas producto/tax deben convertir correctamente (no payment_term)
+        self._assert_non_payment_term_lines_convert(
+            invoice.line_ids, invoice.date, "invoice_two_products_per_line"
+        )
+
+    def test_vendor_invoice_foreign_balance(self):
+        """ Prueba el cuadre de foreign_balance en factura de proveedor (in_invoice) """
+        RATE = 402.3343
+        self._set_usd_rate(RATE)
+
+        purchase_journal = self.env["account.journal"].search(
+            [("type", "=", "purchase"), ("company_id", "=", self.company.id)], limit=1
+        ) or self.env["account.journal"].sudo().create(
+            {
+                "name": "Purchase Test",
+                "code": "PRCHST",
+                "type": "purchase",
+                "company_id": self.company.id,
+            }
+        )
+        
+        purchase_tax = self.env["account.tax"].create({
+            "name": "IVA 16% Compras Real",
+            "amount": 16,
+            "amount_type": "percent",
+            "type_tax_use": "purchase",
+            "company_id": self.company.id,
+            "tax_group_id": self.test_tax_group.id,
+        })
+        
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.partner.id,
+                "journal_id": purchase_journal.id,
+                "currency_id": self.currency_vef.id,
+                "date": fields.Date.today(),
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": 23200.0,
+                            "tax_ids": [(6, 0, [purchase_tax.id])],
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.with_context(move_action_post_alert=True).action_post()
+        self.assertEqual(invoice.state, "posted", "La factura de proveedor no se publicó")
+        
+        fd, fc = self._assert_foreign_balance_squares(
+            invoice.line_ids, "vendor_invoice_rate_402"
+        )
+        expected_usd = (23200.0 * 1.16) / RATE
+        self.assertAlmostEqual(
+            fd, expected_usd, delta=0.02, 
+            msg=f"Total USD debe ser ≈ {expected_usd:.2f}",
+        )
+
+    def test_invoice_multiple_payment_terms_residue(self):
+        """ Testea que el residuo se aplique correctamente al último plazo de pago fraccionado """
+        RATE = 402.3343
+        self._set_usd_rate(RATE)
+
+        payment_term = self.env['account.payment.term'].create({
+            'name': '50% - 50%',
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 50,
+                    'nb_days': 0,
+                }),
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 50,
+                    'nb_days': 15,
+                }),
+            ]
+        })
+
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "journal_id": self.sale_journal.id,
+                "currency_id": self.currency_vef.id,
+                "date": fields.Date.today(),
+                "invoice_payment_term_id": payment_term.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": 23200.0, 
+                            "account_id": self.account_income.id,
+                            "tax_ids": [(6, 0, [self.test_tax.id])],
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": 56200.0, 
+                            "account_id": self.account_income.id,
+                            "tax_ids": [(5, 0, 0)],
+                        }
+                    ),
+                ],
+            }
+        )
+        invoice.with_context(move_action_post_alert=True).action_post()
+        self.assertEqual(invoice.state, "posted")
+
+        # Debería haber 2 líneas de payment_term
+        pt_lines = invoice.line_ids.filtered(lambda l: l.display_type == 'payment_term')
+        self.assertEqual(len(pt_lines), 2, "Debe haber 2 plazos de pago")
+
+        fd, fc = self._assert_foreign_balance_squares(
+            invoice.line_ids, "invoice_multipart_term"
+        )
 


### PR DESCRIPTION
Garantiza que el asiento contable en divisa extranjera cuadre a cero mediante la asignación del residuo de redondeo a las líneas de plazo de pago (payment_term).

Se implementó una lógica que suma los débitos y créditos foráneos de las líneas de producto e impuestos, y ajusta la(s) línea(s) de CxC/CxP para absorber cualquier diferencia de /usr/bin/bash.01 causada por el redondeo de la tasa de cambio.

Se incluyeron pruebas unitarias para validar escenarios con tasas de alta precisión decimal y múltiples plazos de pago.

References: https://binaural.odoo.com/odoo/action-341/64788