### PR TITLE
[FIX] l10n_ve_pos_mf: prevenir impresión fiscal si falla validación contable

### DIFF
--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -37,3 +37,4 @@
     "auto_install": False,
     "binaural": True,
 }
+

--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
-    "version": "17.0.1.0.4",
+    "version": "17.0.1.0.5",
     "category": "Accounting",
     "summary": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
     "description": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",

--- a/l10n_ve_pos_mf/models/pos_order.py
+++ b/l10n_ve_pos_mf/models/pos_order.py
@@ -1,4 +1,5 @@
 from odoo import models, fields, api, _
+from odoo.exceptions import UserError
 
 import logging
 
@@ -43,3 +44,27 @@ class PosOrderInherit(models.Model):
         res["mf_reportz"] = self.mf_reportz
         res["iot_mf"] = self.config_id.iface_fiscal_data_module.id
         return res
+
+    @api.model
+    def validate_order_dry_run(self, orders):
+        sequence = self.env['ir.sequence'].search([('code', '=', 'pos.order')], limit=1)
+        last_next_number = False
+        
+        if sequence:
+            last_next_number = sequence.number_next_actual
+
+        self.env.cr.execute('SAVEPOINT pos_dry_run')
+        
+        try:
+            self.create_from_ui(orders)
+        except Exception as e:
+            self.env.cr.execute('ROLLBACK TO SAVEPOINT pos_dry_run')
+            if sequence and last_next_number:
+                sequence.write({'number_next_actual': last_next_number})
+            raise e
+                
+        self.env.cr.execute('ROLLBACK TO SAVEPOINT pos_dry_run')
+        if sequence and last_next_number:
+            sequence.write({'number_next_actual': last_next_number})
+                
+        return True

--- a/l10n_ve_pos_mf/models/pos_order.py
+++ b/l10n_ve_pos_mf/models/pos_order.py
@@ -47,9 +47,18 @@ class PosOrderInherit(models.Model):
 
     @api.model
     def validate_order_dry_run(self, orders):
-        sequence = self.env['ir.sequence'].search([('code', '=', 'pos.order')], limit=1)
+        session_id = False
+        if orders and isinstance(orders, list):
+            session_id = orders[0].get('data', {}).get('pos_session_id')
+
+        sequence = False
         last_next_number = False
-        
+
+        if session_id:
+            session = self.env['pos.session'].browse(session_id)
+            
+            sequence = session.config_id.sequence_id
+
         if sequence:
             last_next_number = sequence.number_next_actual
 
@@ -60,11 +69,11 @@ class PosOrderInherit(models.Model):
         except Exception as e:
             self.env.cr.execute('ROLLBACK TO SAVEPOINT pos_dry_run')
             if sequence and last_next_number:
-                sequence.write({'number_next_actual': last_next_number})
+                sequence.sudo().write({'number_next_actual': last_next_number})
             raise e
                 
         self.env.cr.execute('ROLLBACK TO SAVEPOINT pos_dry_run')
         if sequence and last_next_number:
-            sequence.write({'number_next_actual': last_next_number})
+            sequence.sudo().write({'number_next_actual': last_next_number})
                 
         return True

--- a/l10n_ve_pos_mf/static/src/js/PosState.js
+++ b/l10n_ve_pos_mf/static/src/js/PosState.js
@@ -254,13 +254,36 @@ patch(PosStore.prototype, {
     }
   },
   async push_single_order(order, opts) {
+    try {
+      const order_payload = [{
+        'data': order.export_as_JSON()
+      }];
+      
+      await this.orm.call("pos.order", "validate_order_dry_run", [order_payload]);
+      
+    } catch (error) {
+      let msg = _t("Error desconocido en Odoo");
+      if (error.data && error.data.message) {
+        msg = error.data.message;
+      } else if (error.message) {
+        msg = error.message;
+      }
+      
+      this.env.services.popup.add(ErrorPopup, {
+        title: _t("Validación Contable"),
+        body: msg,
+      });
+      
+      return;
+    }
+    
     if (this.useFiscalMachine() && !order.mf_invoice_number) {
       
       const response = await this.pushToMF(order)
 
-    if (response.printer_connection == false || !("printer_connection" in response)) {
-      return
-    }
+      if (response.printer_connection == false || !("printer_connection" in response)) {
+        return
+      }
 
     }
     return await super.push_single_order.apply(this, [order, opts]);

--- a/l10n_ve_pos_mf/tests/__init__.py
+++ b/l10n_ve_pos_mf/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_pos_order_dry_run

--- a/l10n_ve_pos_mf/tests/test_pos_order_dry_run.py
+++ b/l10n_ve_pos_mf/tests/test_pos_order_dry_run.py
@@ -22,6 +22,16 @@ class TestPosOrderDryRun(TransactionCase):
                 'number_next_actual': 1,
             })
 
+        self.invoice_sequence = self.env['ir.sequence'].search([('code', '=', 'account.move')], limit=1)
+        if not self.invoice_sequence:
+            self.invoice_sequence = self.env['ir.sequence'].create({
+                'name': 'Invoice Sequence',
+                'code': 'account.move',
+                'prefix': 'INV/',
+                'padding': 5,
+                'number_next_actual': 500,
+            })
+
     def test_01_validate_order_dry_run_returns_true(self):
         """Returns True when dry-run order validation completes without errors."""
         orders = [{'data': {'name': 'Test Order'}}]
@@ -47,3 +57,26 @@ class TestPosOrderDryRun(TransactionCase):
 
         self.sequence = self.env['ir.sequence'].browse(self.sequence.id)
         self.assertEqual(self.sequence.number_next_actual, original_next)
+
+    def test_03_validate_order_dry_run_restores_invoice_sequence_on_success(self):
+        """Ensures invoice sequence is restored when simulation succeeds."""
+        orders = [{'data': {
+            'name': 'Test Order Invoiced', 
+            'to_invoice': True
+        }}]
+        original_invoice_next = self.invoice_sequence.number_next_actual
+
+        def create_from_ui_side_effect_success(_orders):
+            self.invoice_sequence.write({'number_next_actual': self.invoice_sequence.number_next_actual + 1})
+            return []
+
+        with patch.object(self.pos_order_model.__class__, 'create_from_ui', side_effect=create_from_ui_side_effect_success):
+            result = self.pos_order_model.validate_order_dry_run(orders)
+
+        self.assertTrue(result)
+        self.invoice_sequence = self.env['ir.sequence'].browse(self.invoice_sequence.id)
+        self.assertEqual(
+            self.invoice_sequence.number_next_actual, 
+            original_invoice_next,
+            "The invoice sequence increased during successful simulation."
+        )

--- a/l10n_ve_pos_mf/tests/test_pos_order_dry_run.py
+++ b/l10n_ve_pos_mf/tests/test_pos_order_dry_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from odoo.tests import TransactionCase, tagged
 from odoo import fields
@@ -34,49 +34,62 @@ class TestPosOrderDryRun(TransactionCase):
 
     def test_01_validate_order_dry_run_returns_true(self):
         """Returns True when dry-run order validation completes without errors."""
-        orders = [{'data': {'name': 'Test Order'}}]
+        orders = [{'data': {'name': 'Test Order', 'pos_session_id': 1}}]
 
-        with patch.object(self.pos_order_model.__class__, 'create_from_ui', return_value=None) as create_from_ui_mock:
-            result = self.pos_order_model.validate_order_dry_run(orders)
+        session_mock = MagicMock()
+        session_mock.config_id.sequence_id = self.sequence
+
+        with patch.object(type(self.env['pos.session']), 'browse', return_value=session_mock):
+            with patch.object(self.pos_order_model.__class__, 'create_from_ui', return_value=None) as create_from_ui_mock:
+                result = self.pos_order_model.validate_order_dry_run(orders)
 
         create_from_ui_mock.assert_called_once_with(orders)
         self.assertTrue(result)
 
     def test_02_validate_order_dry_run_rolls_back_sequence_on_error(self):
         """Restores sequence counter when an exception occurs during dry-run validation."""
-        orders = [{'data': {'name': 'Test Order'}}]
+        orders = [{'data': {'name': 'Test Order', 'pos_session_id': 1}}]
         original_next = self.sequence.number_next_actual
 
         def create_from_ui_side_effect(_orders):
             self.sequence.write({'number_next_actual': self.sequence.number_next_actual + 1})
             raise UserError('Simulated failure')
 
-        with patch.object(self.pos_order_model.__class__, 'create_from_ui', side_effect=create_from_ui_side_effect):
-            with self.assertRaises(UserError):
-                self.pos_order_model.validate_order_dry_run(orders)
+        session_mock = MagicMock()
+        session_mock.config_id.sequence_id = self.sequence
+
+        with patch.object(type(self.env['pos.session']), 'browse', return_value=session_mock):
+            with patch.object(self.pos_order_model.__class__, 'create_from_ui', side_effect=create_from_ui_side_effect):
+                with self.assertRaises(UserError):
+                    self.pos_order_model.validate_order_dry_run(orders)
 
         self.sequence = self.env['ir.sequence'].browse(self.sequence.id)
         self.assertEqual(self.sequence.number_next_actual, original_next)
 
     def test_03_validate_order_dry_run_restores_invoice_sequence_on_success(self):
-        """Ensures invoice sequence is restored when simulation succeeds."""
+        """Ensures format/POS sequence is restored when simulation succeeds."""
         orders = [{'data': {
             'name': 'Test Order Invoiced', 
-            'to_invoice': True
+            'to_invoice': True,
+            'pos_session_id': 1
         }}]
-        original_invoice_next = self.invoice_sequence.number_next_actual
+        original_next = self.sequence.number_next_actual
 
         def create_from_ui_side_effect_success(_orders):
-            self.invoice_sequence.write({'number_next_actual': self.invoice_sequence.number_next_actual + 1})
+            self.sequence.write({'number_next_actual': self.sequence.number_next_actual + 1})
             return []
 
-        with patch.object(self.pos_order_model.__class__, 'create_from_ui', side_effect=create_from_ui_side_effect_success):
-            result = self.pos_order_model.validate_order_dry_run(orders)
+        session_mock = MagicMock()
+        session_mock.config_id.sequence_id = self.sequence
+
+        with patch.object(type(self.env['pos.session']), 'browse', return_value=session_mock):
+            with patch.object(self.pos_order_model.__class__, 'create_from_ui', side_effect=create_from_ui_side_effect_success):
+                result = self.pos_order_model.validate_order_dry_run(orders)
 
         self.assertTrue(result)
-        self.invoice_sequence = self.env['ir.sequence'].browse(self.invoice_sequence.id)
+        self.sequence = self.env['ir.sequence'].browse(self.sequence.id)
         self.assertEqual(
-            self.invoice_sequence.number_next_actual, 
-            original_invoice_next,
-            "The invoice sequence increased during successful simulation."
+            self.sequence.number_next_actual, 
+            original_next,
+            "The POS billing sequence increased during successful simulation."
         )

--- a/l10n_ve_pos_mf/tests/test_pos_order_dry_run.py
+++ b/l10n_ve_pos_mf/tests/test_pos_order_dry_run.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch
+
+from odoo.tests import TransactionCase, tagged
+from odoo import fields
+from odoo.exceptions import UserError
+
+@tagged('post_install', '-at_install', 'l10n_ve_pos_mf')
+class TestPosOrderDryRun(TransactionCase):
+    """Unit tests for the POS dry-run validation helper."""
+
+    def setUp(self):
+        super().setUp()
+        self.pos_order_model = self.env['pos.order']
+        self.sequence = self.env['ir.sequence'].search([('code', '=', 'pos.order')], limit=1)
+        if not self.sequence:
+            self.sequence = self.env['ir.sequence'].create({
+                'name': 'POS Order Sequence',
+                'code': 'pos.order',
+                'prefix': 'POS',
+                'padding': 5,
+                'number_next_actual': 1,
+            })
+
+    def test_01_validate_order_dry_run_returns_true(self):
+        """Returns True when dry-run order validation completes without errors."""
+        orders = [{'data': {'name': 'Test Order'}}]
+
+        with patch.object(self.pos_order_model.__class__, 'create_from_ui', return_value=None) as create_from_ui_mock:
+            result = self.pos_order_model.validate_order_dry_run(orders)
+
+        create_from_ui_mock.assert_called_once_with(orders)
+        self.assertTrue(result)
+
+    def test_02_validate_order_dry_run_rolls_back_sequence_on_error(self):
+        """Restores sequence counter when an exception occurs during dry-run validation."""
+        orders = [{'data': {'name': 'Test Order'}}]
+        original_next = self.sequence.number_next_actual
+
+        def create_from_ui_side_effect(_orders):
+            self.sequence.write({'number_next_actual': self.sequence.number_next_actual + 1})
+            raise UserError('Simulated failure')
+
+        with patch.object(self.pos_order_model.__class__, 'create_from_ui', side_effect=create_from_ui_side_effect):
+            with self.assertRaises(UserError):
+                self.pos_order_model.validate_order_dry_run(orders)
+
+        self.sequence = self.env['ir.sequence'].browse(self.sequence.id)
+        self.assertEqual(self.sequence.number_next_actual, original_next)


### PR DESCRIPTION
Actualmente, si una orden de POS presenta errores en la validación contable (ej: configuración errónea en el tipo de cuenta por cobrar del cliente), el sistema permite la impresión en la máquina fiscal pero falla al sincronizar la orden en Odoo, generando una discrepancia legal.

Este cambio introduce un proceso de "dry run" (simulacro) que:
- Valida la creación de la orden mediante un SAVEPOINT antes de proceder.
- Revierte cualquier cambio en la base de datos y restaura la secuencia del POS para evitar saltos de numeración.
- Detiene el flujo de impresión si se detecta una excepción contable, mostrando un mensaje de error al usuario.

Se incluyen pruebas unitarias para validar:
1. El éxito del simulacro sin persistencia de datos.
2. La restauración correcta de la secuencia tras un error simulado.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/11794