### PR TITLE
[FIX] l10n_ve_pos: Reporte con montos en cero

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.9",
+    "version": "17.0.0.0.10",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/report/report_saledetails.py
+++ b/l10n_ve_pos/report/report_saledetails.py
@@ -3,6 +3,9 @@ import pytz
 
 from odoo import api, fields, models, _
 from odoo.osv.expression import AND
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 class ReportSaleDetails(models.AbstractModel):
@@ -140,7 +143,21 @@ class ReportSaleDetails(models.AbstractModel):
                     tuple(payment_ids),
                 ),
             )
-            payments = self.env.cr.dictfetchall()
+            payments = []
+            for payment in self.env.cr.dictfetchall():
+                total = payment.get("total") or 0.0
+                f_total = payment.get("f_total") or 0.0
+                try:
+                    total = float(total)
+                except (TypeError, ValueError):
+                    total = 0.0
+                try:
+                    f_total = float(f_total)
+                except (TypeError, ValueError):
+                    f_total = 0.0
+                payment["total"] = total
+                payment["f_total"] = f_total
+                payments.append(payment)
         else:
             payments = []
 


### PR DESCRIPTION
El error se daba porque se intentaba mandar un monto con valor 'None'
- Se modifico para que al tener el valor 'None' o no se encuentre el campo lo mande con un valor de 0.0

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk.ticket/11988