### PR TITLE
[FEAT] l10n_ve_tax, l10n_ve_invoice: checklist de exentos en líneas de factura

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.1.5",
+    "version": "17.0.0.2.0",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.0.2.0",
+    "version": "17.0.0.3.0",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20251118\n"
+"Project-Id-Version: Odoo Server 17.0+e-20250522\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-02 15:48+0000\n"
-"PO-Revision-Date: 2025-12-02 15:48+0000\n"
+"POT-Creation-Date: 2026-03-25 20:45+0000\n"
+"PO-Revision-Date: 2026-03-25 20:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -319,6 +319,13 @@ msgid "Debit note"
 msgstr "Notas de Débito"
 
 #. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__declaration_unique_of_customs
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__declaration_unique_of_customs
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_payment__declaration_unique_of_customs
+msgid "Declaration unique of customs"
+msgstr "Declaración Única de Aduana"
+
+#. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__display_date_warning
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__display_date_warning
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_payment__display_date_warning
@@ -411,12 +418,11 @@ msgid "Is Debit Journal"
 msgstr "Es un diario de débito"
 
 #. module: l10n_ve_invoice
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__invoice_date
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__invoice_date
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_payment__invoice_date
-msgid "Invoice/Bill Date"
-msgstr "Fecha de factura"
-
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__is_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__is_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_payment__is_purchase_international
+msgid "Is International Purchase"
+msgstr "Es Compra Internacional"
 
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_res_config_settings_l10n_ve_invoice
@@ -513,6 +519,11 @@ msgid "Nro de Pedido"
 msgstr ""
 
 #. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_account_move_filter_l10n_ve_invoice
+msgid "Number of Declaration Unique of Customs"
+msgstr "Declaración Única de Aduana"
+
+#. module: l10n_ve_invoice
 #: model:ir.model,name:l10n_ve_invoice.model_account_payment
 msgid "Payments"
 msgstr "Pagos"
@@ -558,7 +569,7 @@ msgstr "Secuencia para el número de control"
 #. module: l10n_ve_invoice
 #: model:res.groups,name:l10n_ve_invoice.group_sales_invoicing_series
 msgid "Series Invoicing Group"
-msgstr "Grupo para Series de Facturación"
+msgstr "Grupo para series de facturación"
 
 #. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_journal__series_correlative_sequence_id
@@ -599,8 +610,35 @@ msgid "Show Total USD on Free Form Invoice"
 msgstr "Mostrar total en USD en forma libre"
 
 #. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__tax_amount_for_international_purchase
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__tax_amount_for_international_purchase
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_payment__tax_amount_for_international_purchase
+msgid "Tax Amount for International Purchase"
+msgstr "IVA 16%"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__tax_base_for_international_purchase
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__tax_base_for_international_purchase
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_payment__tax_base_for_international_purchase
+msgid "Tax Base for International Purchase"
+msgstr "Base imponible IVA"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_bank_statement_line__tax_amount_for_international_purchase
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_move__tax_amount_for_international_purchase
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_payment__tax_amount_for_international_purchase
+msgid "Tax amount for international purchase to show in purchase book"
+msgstr "Monto del IVA para compras internacionales a mostrar en el libro de compras"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_bank_statement_line__tax_base_for_international_purchase
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_move__tax_base_for_international_purchase
+#: model:ir.model.fields,help:l10n_ve_invoice.field_account_payment__tax_base_for_international_purchase
+msgid "Tax base for international purchase to show in purchase book"
+msgstr "Base imponible para compras internacionales a mostrar en el libro de compras"
+
+#. module: l10n_ve_invoice
 #. odoo-python
-#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "The accounting date cannot be earlier than the invoice date."
@@ -608,7 +646,6 @@ msgstr "La fecha contable no puede ser anterior a la fecha de la factura."
 
 #. module: l10n_ve_invoice
 #. odoo-python
-#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid ""
@@ -651,11 +688,17 @@ msgstr ""
 #. module: l10n_ve_invoice
 #. odoo-python
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
-#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "The sale's series sequence must be in the selected journal."
 msgstr ""
 "La secuencia de series de ventas debe estar seleccionada en el diario."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
+#, python-format
+msgid "There are no moves to show"
+msgstr "No se encontraron registros para mostrar"
 
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.document_tax_totals
@@ -684,7 +727,6 @@ msgstr ""
 #. module: l10n_ve_invoice
 #. odoo-python
 #: code:addons/l10n_ve_invoice/models/account_move.py:0
-#: code:addons/l10n_ve_invoice/models/account_move.py:0
 #, python-format
 msgid "You can not add more than %s products to the invoice."
 msgstr "No puede agregar más de %s productos a la factura."
@@ -694,8 +736,6 @@ msgstr "No puede agregar más de %s productos a la factura."
 msgid "control number"
 msgstr "Número de control"
 
-
-
 #. module: account
 #: model:ir.actions.act_window,name:account.action_move_in_refund_type
 #: model:ir.actions.act_window,name:account.action_move_out_refund_type
@@ -704,33 +744,3 @@ msgstr "Número de control"
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_report_search
 msgid "Credit Notes"
 msgstr "Notas de Crédito"
-
-
-#. module: l10n_ve_invoice
-#. odoo-python
-#: code:addons/l10n_ve_invoice/models/account_move.py:0
-#, python-format
-msgid "An invoice cannot have a line with a price of zero"
-msgstr "Una factura no puede tener una linea con precio en cero"
-
-#. module: l10n_ve_invoice
-#. odoo-python
-#: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
-#, python-format
-msgid "There are no moves to show"
-msgstr "No se encontraron registros para mostrar"
-
-#. module: l10n_ve_invoice
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__declaration_unique_of_customs
-msgid "Declaration unique of customs"
-msgstr "Declaración Única de Aduana"
-
-#. module: l10n_ve_invoice
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__is_purchase_international
-msgid "Is International Purchase"
-msgstr "Es Compra Internacional"
-
-#. module: l10n_ve_invoice
-#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_account_move_filter_l10n_ve_invoice
-msgid "Number of Declaration Unique of Customs"
-msgstr "Declaración Única de Aduana"

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -40,6 +40,10 @@ class AccountMove(models.Model):
         compute="_compute_entry_in_period",
     )
 
+    tax_base_for_international_purchase = fields.Float(string='Tax Base for International Purchase', help='Tax base for international purchase to show in purchase book')
+    
+    tax_amount_for_international_purchase = fields.Float(string='Tax Amount for International Purchase', help='Tax amount for international purchase to show in purchase book')
+
     @api.depends("invoice_date", "state")
     def _compute_entry_in_period(self):
         """Computing that allows determining whether a debit or credit note is within the current fiscal period."""

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -16,7 +16,6 @@ class AccountMove(models.Model):
 
     correlative = fields.Char("Control Number", copy=False, help="Sequence control number")
     declaration_unique_of_customs = fields.Char('Declaration unique of customs', copy=False)
-    is_purchase_international = fields.Boolean(related='journal_id.is_purchase_international', string='Is International Purchase')
     invoice_reception_date = fields.Date(
         "Reception Date",
         help="Indicates when the invoice was received by the client/company",

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -8,6 +8,12 @@
                 <field name="is_contingency" invisible="1" />
                 <field name="entry_in_period" invisible="1" />
             </field>
+
+            <xpath expr="//field[@name='ref']" position="after">
+                <field name="tax_base_for_international_purchase" invisible="not is_purchase_international" required="is_purchase_international" readonly="state == 'posted'"/>
+                <field name="tax_amount_for_international_purchase" invisible="not is_purchase_international" required="is_purchase_international" readonly="state == 'posted'"/>
+            </xpath>
+
             <xpath expr="//header/button[@name='button_cancel'][2]" position="attributes">
                 <attribute name="invisible">not entry_in_period and (not id or state != 'draft' or move_type == 'entry')</attribute>
             </xpath>

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -208,6 +208,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(move)["tax_base_exempt_aliquot"]
                         for move in moves
+                        if not move.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -216,6 +217,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(move)["amount_exempt_aliquot"]
                         for move in moves
+                        if not move.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -224,6 +226,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(note)["tax_base_exempt_aliquot"] * -1
                         for note in credit_notes
+                        if not note.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -232,6 +235,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(note)["amount_exempt_aliquot"] * -1
                         for note in credit_notes
+                        if not note.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -243,6 +247,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(move)["tax_base_general_aliquot"]
                         for move in moves
+                        if not move.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -251,6 +256,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(move)["amount_general_aliquot"]
                         for move in moves
+                        if not move.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -259,6 +265,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(note)["tax_base_general_aliquot"] * -1
                         for note in credit_notes
+                        if not note.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -267,6 +274,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(note)["amount_general_aliquot"] * -1
                         for note in credit_notes
+                        if not note.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -278,6 +286,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(move)["tax_base_reduced_aliquot"]
                         for move in moves
+                        if not move.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -286,6 +295,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(move)["amount_reduced_aliquot"]
                         for move in moves
+                        if not move.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -294,6 +304,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(note)["tax_base_reduced_aliquot"] * -1
                         for note in credit_notes
+                        if not note.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -302,6 +313,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(note)["amount_reduced_aliquot"] * -1
                         for note in credit_notes
+                        if not note.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -313,6 +325,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(move)["tax_base_extend_aliquot"]
                         for move in moves
+                        if not move.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -321,6 +334,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(move)["amount_extend_aliquot"]
                         for move in moves
+                        if not move.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -329,6 +343,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(note)["tax_base_extend_aliquot"] * -1
                         for note in credit_notes
+                        if not note.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -337,6 +352,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                     [
                         self._determinate_amount_taxeds(note)["amount_extend_aliquot"] * -1
                         for note in credit_notes
+                        if not note.journal_id.is_purchase_international
                     ]
                 )
             )
@@ -1089,8 +1105,16 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                         )
 
         amount_import_international = 0.0
+        has_manual_international_amounts = (
+            move.journal_id.is_purchase_international
+            and (
+                move.tax_base_for_international_purchase
+                or move.tax_amount_for_international_purchase
+            )
+        )
         if move.journal_id.is_purchase_international:
-            amount_import_international += tax_result.get("international_tax_base_exempt_aliquot", 0.0)
+            if not has_manual_international_amounts:
+                amount_import_international += tax_result.get("international_tax_base_exempt_aliquot", 0.0)
             if not self.company_id.not_show_general_aliquot_purchase_international:
                 if move.tax_base_for_international_purchase:
                     old_base = tax_result.get('tax_base_general_aliquot_international', 0.0)
@@ -1109,6 +1133,13 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 
             if not self.company_id.not_show_extend_aliquot_purchase_international:
                 amount_import_international += tax_result.get("tax_base_extend_aliquot_international", 0.0) + tax_result.get("amount_extend_aliquot_international", 0.0)
+
+            if has_manual_international_amounts:
+                tax_result["tax_base_exempt_aliquot"] = 0.0
+                tax_result["amount_exempt_aliquot"] = 0.0
+                tax_result["international_tax_base_exempt_aliquot"] = 0.0
+                tax_result["international_amount_taxed"] = amount_import_international
+                tax_result["amount_taxed"] = amount_import_international
 
         tax_result['amount_import_international'] = amount_import_international
 

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -1092,6 +1092,16 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
         if move.journal_id.is_purchase_international:
             amount_import_international += tax_result.get("international_tax_base_exempt_aliquot", 0.0)
             if not self.company_id.not_show_general_aliquot_purchase_international:
+                if move.tax_base_for_international_purchase:
+                    old_base = tax_result.get('tax_base_general_aliquot_international', 0.0)
+                    tax_result['tax_base_general_aliquot_international'] = move.tax_base_for_international_purchase
+                    tax_result['international_amount_taxed'] += (move.tax_base_for_international_purchase - old_base) * (-1 if is_credit_note else 1)
+
+                if move.tax_amount_for_international_purchase:
+                    old_amount = tax_result.get('amount_general_aliquot_international', 0.0)
+                    tax_result['amount_general_aliquot_international'] = move.tax_amount_for_international_purchase
+                    tax_result['international_amount_taxed'] += (move.tax_amount_for_international_purchase - old_amount) * (-1 if is_credit_note else 1)
+
                 amount_import_international += tax_result.get("tax_base_general_aliquot_international", 0.0) + tax_result.get("amount_general_aliquot_international", 0.0)
             
             if not self.company_id.not_show_reduced_aliquot_purchase_international:
@@ -1665,7 +1675,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
 
         if international_fields:
             international_fields.insert(0,
-                {"name": "Número de Declaración Única de Aduana", "field": "declaration_unique_of_customs"}
+                {"name": "N° de Declaración Única de Aduana", "field": "declaration_unique_of_customs"}
             )
             international_fields.insert(1,
                 {"name": "Valor total de las importaciones definitivas", "field": "amount_import_international", "format": "number"}

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -1165,8 +1165,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             )
         )
         if move.journal_id.is_purchase_international:
-            if not has_manual_international_amounts:
-                amount_import_international += tax_result.get("international_tax_base_exempt_aliquot", 0.0)
+            amount_import_international += tax_result.get("international_tax_base_exempt_aliquot", 0.0)
             if not self.company_id.not_show_general_aliquot_purchase_international:
                 if move.tax_base_for_international_purchase:
                     old_base = tax_result.get('tax_base_general_aliquot_international', 0.0)
@@ -1187,9 +1186,6 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 amount_import_international += tax_result.get("tax_base_extend_aliquot_international", 0.0) + tax_result.get("amount_extend_aliquot_international", 0.0)
 
             if has_manual_international_amounts:
-                tax_result["tax_base_exempt_aliquot"] = 0.0
-                tax_result["amount_exempt_aliquot"] = 0.0
-                tax_result["international_tax_base_exempt_aliquot"] = 0.0
                 tax_result["international_amount_taxed"] = amount_import_international
                 tax_result["amount_taxed"] = amount_import_international
 

--- a/l10n_ve_tax/__manifest__.py
+++ b/l10n_ve_tax/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.19",
+    "version": "17.0.1.0.0",
     # any module necessary for this one to work correctly
     "depends": ["base", "account", "l10n_ve_base", "l10n_ve_rate"],
     "data": [

--- a/l10n_ve_tax/i18n/es_VE.po
+++ b/l10n_ve_tax/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20251118\n"
+"Project-Id-Version: Odoo Server 17.0+e-20250522\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-26 18:38+0000\n"
-"PO-Revision-Date: 2026-02-26 18:38+0000\n"
+"POT-Creation-Date: 2026-04-17 13:51+0000\n"
+"PO-Revision-Date: 2026-04-17 13:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,6 +23,14 @@ msgid ""
 "An International Purchase Journal is already enabled. Only one is allowed."
 msgstr ""
 "Ya se ha habilitado un Diario de Compras Internacional. Solo se permite uno."
+
+#. module: l10n_ve_tax
+#. odoo-python
+#: code:addons/l10n_ve_tax/models/account_journal.py:0
+#, python-format
+msgid "An International Sale Journal is already enabled. Only one is allowed."
+msgstr ""
+"Ya se ha habilitado un Diario de Ventas Internacional. Solo se permite uno."
 
 #. module: l10n_ve_tax
 #: model:ir.model,name:l10n_ve_tax.model_res_company
@@ -58,11 +66,6 @@ msgstr "Configuración Impuestos: Ventas/Compras"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Configuration: Accountant Books"
-msgstr "Configuración: Libros Contables"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Core Settings"
 msgstr "Configuración Principal"
 
@@ -73,8 +76,6 @@ msgstr "Deducibilidad"
 
 #. module: l10n_ve_tax
 #. odoo-javascript
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #, python-format
@@ -95,11 +96,6 @@ msgstr "Habilitar impuestos no deducibles"
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Enable discount column visibility on invoice lines"
 msgstr "Habilitar visibilidad de la columna de descuento en líneas de factura"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Exempt Aliquot"
-msgstr "Alícuota exenta"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__exent_aliquot_purchase
@@ -166,9 +162,9 @@ msgid "General Aliquot Sale"
 msgstr "Alícuota general ventas"
 
 #. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_international_purchase_in_book
-msgid "Hide international alicuotes"
-msgstr "Ocultar alícuotas internacionales"
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_move_line__international_purchase_exempt_product
+msgid "International Purchase Exempt Product"
+msgstr "Producto de importación exento"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_account_journal__is_purchase_international
@@ -176,9 +172,26 @@ msgid "International purchase"
 msgstr "Compra internacional"
 
 #. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_journal__is_sale_international
+msgid "International sale"
+msgstr "Venta internacional"
+
+#. module: l10n_ve_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_bank_statement_line__is_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_move__is_purchase_international
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_payment__is_purchase_international
+msgid "Is International Purchase"
+msgstr "Es Compra Internacional"
+
+#. module: l10n_ve_tax
 #: model:ir.model,name:l10n_ve_tax.model_account_journal
 msgid "Journal"
 msgstr "Diario"
+
+#. module: l10n_ve_tax
+#: model:ir.model,name:l10n_ve_tax.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento contable"
 
 #. module: l10n_ve_tax
 #: model:ir.model,name:l10n_ve_tax.model_account_move_line
@@ -205,7 +218,6 @@ msgstr "No Deducible Aliquota Reducida (Compra)"
 
 #. module: l10n_ve_tax
 #. odoo-python
-#: code:addons/l10n_ve_tax/models/account_tax.py:0
 #: code:addons/l10n_ve_tax/models/account_tax.py:0
 #, python-format
 msgid "No foreign currency configured in the company"
@@ -339,11 +351,6 @@ msgstr "Tasas de Impuestos de Ventas Internacionales"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Sales Book"
-msgstr "Libro de Ventas"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Sales Tax Rates"
 msgstr "Tasas de Impuestos de Ventas"
 
@@ -355,8 +362,6 @@ msgstr "Mostrar descuento en facturas"
 
 #. module: l10n_ve_tax
 #. odoo-javascript
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #, python-format
@@ -378,107 +383,22 @@ msgstr ""
 #. module: l10n_ve_tax
 #. odoo-javascript
 #: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #, python-format
 msgid "Total"
 msgstr ""
 
 #. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__unique_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__unique_tax
-msgid "Unique Tax"
-msgstr "Impuesto único"
-
-#. module: l10n_ve_tax
 #. odoo-javascript
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
 #, python-format
 msgid "Total to pay"
 msgstr "Total a pagar"
 
 #. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__exent_aliquot_purchase_international
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__exent_aliquot_purchase_international
-msgid "Exent Aliquot Purchase International"
-msgstr "Alícuota exenta compras internacionales"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__extend_aliquot_purchase_international
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__extend_aliquot_purchase_international
-msgid "Extend Aliquot Purchase International"
-msgstr "Alícuota extendida compras internacionales"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__general_aliquot_purchase_international
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__general_aliquot_purchase_international
-msgid "General Aliquot Purchase International"
-msgstr "Alícuota general compras internacionales"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_international_purchase_in_book
-msgid "Hide international alicuotes"
-msgstr "Ocultar alícuotas internacionales"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_journal__is_purchase_international
-msgid "International purchase"
-msgstr "Compra internacional"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_account_journal__is_sale_international
-msgid "International sale"
-msgstr "Venta internacional"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_international_purchase_in_book
-msgid "Not Show International Purchase In Book"
-msgstr "No mostrar compras internacionales en el libro"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_reduced_aliquot_purchase_international
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_reduced_aliquot_purchase_international
-msgid "Not Show Reduced Aliquot Purchase International"
-msgstr "No mostrar alícuota reducida compras internacionales"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Purchase Tax International Rates"
-msgstr "Tasas de Impuestos de Compras Internacionales"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__reduced_aliquot_purchase_international
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__reduced_aliquot_purchase_international
-msgid "Reduced Aliquot Purchase International"
-msgstr "Alícuota reducida compras internacionales"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_general_aliquot_purchase_international
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_general_aliquot_purchase_international
-msgid "Not Show General Aliquot Purchase International"
-msgstr "No mostrar alícuota general compras internacionales"
-
-#. module: l10n_ve_tax
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_extend_aliquot_purchase_international
-#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_extend_aliquot_purchase_international
-msgid "Not Show Extend Aliquot Purchase International"
-msgstr "No mostrar alícuota extendida compras internacionales"
-
-#. module: l10n_ve_tax
-#. odoo-python
-#: code:addons/l10n_ve_tax/models/account_journal.py:0
-#, python-format
-msgid ""
-"An International Purchase Journal is already enabled. Only one is allowed."
-msgstr ""
-"Ya se ha habilitado un Diario de Compras Internacional. Solo se permite uno."
-
-#. module: l10n_ve_tax
-#. odoo-python
-#: code:addons/l10n_ve_tax/models/account_journal.py:0
-#, python-format
-msgid "An International Sale Journal is already enabled. Only one is allowed."
-msgstr "Ya se ha habilitado un Diario de Ventas Internacional. Solo se permite uno."
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__unique_tax
+#: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__unique_tax
+msgid "Unique Tax"
+msgstr "Impuesto único"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__zero_aliquot_sale_international

--- a/l10n_ve_tax/models/__init__.py
+++ b/l10n_ve_tax/models/__init__.py
@@ -3,3 +3,4 @@ from . import res_company
 from . import res_config_settings
 from . import account_move_line
 from . import account_journal
+from . import account_move

--- a/l10n_ve_tax/models/account_move.py
+++ b/l10n_ve_tax/models/account_move.py
@@ -1,0 +1,22 @@
+from odoo import fields, models, api
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    is_purchase_international = fields.Boolean(
+        related="journal_id.is_purchase_international",
+        string="Is International Purchase",
+    )
+
+    @api.onchange("journal_id")
+    def _onchange_journal_id_reset_international_exempt(self):
+        """
+        Reset the international purchase exempt product field to False
+        when the journal is not an international purchase journal
+        """
+        for move in self:
+            if not move.journal_id.is_purchase_international:
+                move.invoice_line_ids.update(
+                    {"international_purchase_exempt_product": False}
+                )

--- a/l10n_ve_tax/models/account_move_line.py
+++ b/l10n_ve_tax/models/account_move_line.py
@@ -15,3 +15,29 @@ class AccountMoveLine(models.Model):
     config_deductible_tax = fields.Boolean(related='company_id.config_deductible_tax')
 
     not_deductible_tax = fields.Boolean(default=False)
+
+    international_purchase_exempt_product = fields.Boolean(
+        string="International Purchase Exempt Product"
+    )
+
+    @api.depends(
+        "product_id", "product_uom_id", "international_purchase_exempt_product"
+    )
+    def _compute_tax_ids(self):
+        """
+        We inherit this method to add the international purchase exempt product to the depends
+        """
+        super()._compute_tax_ids()
+
+    def _get_computed_taxes(self):
+        """
+        We inherit this method to return the international purchase exempt product when the
+        move line is an international purchase exempt product
+        """
+        res = super()._get_computed_taxes()
+        if (
+            self.international_purchase_exempt_product
+            and self.company_id.exent_aliquot_purchase_international
+        ):
+            res = self.company_id.exent_aliquot_purchase_international
+        return res

--- a/l10n_ve_tax/views/account_move.xml
+++ b/l10n_ve_tax/views/account_move.xml
@@ -12,6 +12,15 @@
                 <field name="not_deductible_tax" optional="hide" 
                 invisible="move_type not in ['in_invoice', 'in_refund'] or not config_deductible_tax"/>
             </xpath>
+            <xpath expr="//div[hasclass('oe_title')]/h1" position="after">
+                <field name="is_purchase_international" invisible="1"/>
+            </xpath>
+            <xpath expr="//page/field[@name='invoice_line_ids']/tree/field[@name='price_subtotal']"
+                position="after">
+                <field name="international_purchase_exempt_product" 
+                    column_invisible="parent.is_purchase_international == False" 
+                    optional="show"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Se implementa el campo 'international_purchase_exempt_product' en las líneas de factura para identificar manualmente productos exentos en compras internacionales. Al marcar este checklist, se sobreescribe la lógica de '_get_computed_taxes' para forzar la alícuota exenta de la compañía.

Cambios realizados:
- Centralización de 'is_purchase_international' en account.move (l10n_ve_tax), eliminando la definición redundante en l10n_ve_invoice.
- Implementación de 'onchange' en el diario para limpiar el checklist de exentos si se cambia a un diario que no sea de importación.
- Optimización del asistente de reportes contables en l10n_ve_invoice, corrigiendo el cálculo de 'amount_import_international' y el desglose de bases exentas internacionales.
- Actualización de vistas de factura para mostrar el nuevo campo condicionado al tipo de diario.
- Incremento de versiones de los módulos y actualización de archivos de traducción (es_VE.po).

References: https://binaural.odoo.com/odoo/action-341/68208