### PR TITLE
[FIX] l10n_ve_igtf: f-string con comillas anidadas rompe en Python 3.11

### DIFF
--- a/l10n_ve_igtf/wizard/accounting_reports.py
+++ b/l10n_ve_igtf/wizard/accounting_reports.py
@@ -99,7 +99,7 @@ class WizardAccountingReports(models.TransientModel):
         multiplier = -1 if move.move_type == "out_refund" else 1
         bi_igtf = move.foreign_bi_igtf if not self.currency_system else move.bi_igtf
         is_igtf = bool(move.alter_bi_igtf > 0)
-        igtf = (move.tax_totals["igtf"]["foreign_igtf_amount"]) if is_igtf else 0
+        igtf = (move.tax_totals['igtf']["foreign_igtf_amount"]) if is_igtf else 0
         # fields |= {"bi_igtf": bi_igtf,}
         if fields:
             fields |= {"igtf": igtf * multiplier,}
@@ -132,8 +132,8 @@ class WizardAccountingReports(models.TransientModel):
         multiplier = -1 if move.move_type == "in_refund" else 1
         bi_igtf = move.foreign_bi_igtf if not self.currency_system else move.bi_igtf
         is_igtf = bool(move.alter_bi_igtf > 0)
-        _logger.info(f"TAX TOTALS IGTF:{move.tax_totals["igtf"]}")
-        igtf =  (move.tax_totals["igtf"]["foreign_igtf_amount"]) if is_igtf else 0
+        _logger.info(f"TAX TOTALS IGTF:{move.tax_totals['igtf']}")
+        igtf =  (move.tax_totals['igtf']["foreign_igtf_amount"]) if is_igtf else 0
         # fields |= {"bi_igtf": bi_igtf,}
         if fields:
             fields |= {"igtf": igtf * multiplier,}


### PR DESCRIPTION
En `l10n_ve_igtf/wizard/accounting_reports.py:135` el f-string usa comillas dobles tanto para el delimitador como dentro del subscript:

    _logger.info(f"TAX TOTALS IGTF:{move.tax_totals[\"igtf\"]}")

Esto sólo es válido a partir de Python 3.12 (PEP 701). En 3.11 levanta `SyntaxError: f-string: unmatched '['` y impide que el módulo cargue.

El fix es cambiar las comillas internas a simples. comportamiento idéntico, compatible con 3.11 y 3.12+:

    _logger.info(f"TAX TOTALS IGTF:{move.tax_totals['igtf']}")