### PR TITLE
FIX #11946 l10n_ve_sale avoid picking singleton on reconfirm

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "17.0.1.1.21",
+    "version": "17.0.1.1.22",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -456,24 +456,35 @@ class SaleOrder(models.Model):
         res = super().action_confirm()
         product_limit = self.env.company.limit_product_qty_out
         for sale in self:
-            picking = sale.picking_ids
             if product_limit > 0:
-                picking_moves = picking.move_ids_without_package
-                picking_vals = picking.read(['location_dest_id', 'location_id', 'move_type', 'picking_type_id']) 
-                picking_vals = {
-                    key: (value[0] if isinstance(value, tuple) else value)
-                    for key, value in picking_vals[0].items()
-                }
-                picking_vals['origin'] = picking.origin
-                picking_vals['partner_id'] = picking.partner_id.id
-                picking_vals['user_id'] = picking.user_id.id
-                
-                list_pickings_moves = [picking_moves[i:i + product_limit] for i in range(0, len(picking_moves), product_limit)]
-                picking.move_ids_without_package = list_pickings_moves[0]
-                
-                for list_moves in list_pickings_moves[1:]:
-                    picking_vals["move_ids_without_package"] = list_moves
-                    new_picking = self.env['stock.picking'].create(picking_vals)
+                for picking in sale.picking_ids:
+                    picking_moves = picking.move_ids_without_package
+                    if not picking_moves:
+                        continue
+
+                    list_pickings_moves = [
+                        picking_moves[i : i + product_limit]
+                        for i in range(0, len(picking_moves), product_limit)
+                    ]
+                    if len(list_pickings_moves) <= 1:
+                        continue
+
+                    picking_vals = picking.read(
+                        ["location_dest_id", "location_id", "move_type", "picking_type_id"]
+                    )
+                    picking_vals = {
+                        key: (value[0] if isinstance(value, tuple) else value)
+                        for key, value in picking_vals[0].items()
+                    }
+                    picking_vals["origin"] = picking.origin
+                    picking_vals["partner_id"] = picking.partner_id.id
+                    picking_vals["user_id"] = picking.user_id.id
+
+                    picking.move_ids_without_package = list_pickings_moves[0]
+
+                    for list_moves in list_pickings_moves[1:]:
+                        picking_vals["move_ids_without_package"] = list_moves
+                        self.env["stock.picking"].create(picking_vals)
                 
 
                 

--- a/l10n_ve_sale/tests/test_sale_order.py
+++ b/l10n_ve_sale/tests/test_sale_order.py
@@ -226,3 +226,79 @@ class TestSaleOrderInvoice(TransactionCase):
             order.action_confirm()
             order._create_invoices()
         _logger.info("test_02_error_generate_invoice_from_sale_order --- successfully (%s)",e.exception,)
+
+    def test_03_reconfirm_sale_order_with_pickings(self):
+        """Test reconfirming a sale order after it was confirmed, cancelled and set to draft.
+        This flow was causing a singleton error in stock.picking.
+        """
+        # Create a storable product
+        product_storable = self.env["product.product"].create({
+            "name": "Producto Almacenable",
+            "type": "product",
+            "invoice_policy": "order",
+            "list_price": 50,
+            "taxes_id": [(6, 0, [self.tax_iva16.id])],
+            "barcode": "ST12345",
+        })
+        
+        # Give some stock
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.company.id)], limit=1)
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': product_storable.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'inventory_quantity': 10,
+        }).action_apply_inventory()
+
+        rate = 5.0
+        # Create order with 2 lines of 1 unit each to trigger split picking logic
+        order = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+            "manually_set_rate": True,
+            "foreign_rate": rate,
+            "foreign_inverse_rate": 1 / rate,
+            "order_line": [
+                (0, 0, {
+                    "product_id": product_storable.id,
+                    "product_uom_qty": 1,
+                    "price_unit": 100,
+                    "tax_id": [(6, 0, [self.tax_iva16.id])],
+                    "name": "Line 1",
+                }),
+                (0, 0, {
+                    "product_id": product_storable.id,
+                    "product_uom_qty": 1,
+                    "price_unit": 100,
+                    "tax_id": [(6, 0, [self.tax_iva16.id])],
+                    "name": "Line 2",
+                })
+            ]
+        })
+
+        # Seteamos el límite de pickings para que se dividan
+        self.company.write({'limit_product_qty_out': 1})
+
+        # 1. Confirm the order
+        order.action_confirm()
+        self.assertEqual(order.state, 'sale')
+        self.assertTrue(len(order.picking_ids) > 1, "Should have created multiple pickings due to limit_product_qty_out=1")
+        
+        # 2. Cancel related pickings to allow SO cancellation
+        for picking in order.picking_ids:
+            picking.move_ids.write({'state': 'cancel'})
+            picking.write({'state': 'cancel'})
+        
+        # 3. Cancel the order
+        order.action_cancel()
+        if order.state != 'cancel':
+            order.write({'state': 'cancel'})
+            
+        self.assertEqual(order.state, 'cancel')
+        
+        # 4. Set back to draft
+        order.action_draft()
+        self.assertEqual(order.state, 'draft')
+        
+        # 5. Confirm again (This validates the fix for the singleton error)
+        order.action_confirm()
+        self.assertEqual(order.state, 'sale')
+        _logger.info("test_03_reconfirm_sale_order_with_pickings --- successfully")


### PR DESCRIPTION
PROBLEMA: Al reconfirmar una orden de venta que fue confirmada, cancelada y restablecida a borrador, podían existir múltiples transferencias asociadas y el módulo asumía un solo picking, provocando un error de singleton y bloqueando la confirmación.

SOLUCION: Se ajustó la lógica de particionado de movimientos para iterar por cada picking de la orden y evitar accesos tipo singleton cuando existen múltiples transferencias; además se omite el procesamiento cuando no aplica.

LINK: https://binaural.odoo.com/odoo/action-390/11946

ticket [x]