### PR TITLE
[FIX] l10n_ve_pos: corregir error de referencia en reporte de órdenes

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.9",
+    "version": "17.0.1.0.0",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/static/src/overrides/models/orderline_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/orderline_model.js
@@ -5,6 +5,7 @@ import { patch } from "@web/core/utils/patch";
 import {
   formatFloat,
   roundDecimals as round_di,
+  roundPrecision as round_pr,
   floatIsZero,
 } from "@web/core/utils/numbers";
 


### PR DESCRIPTION
Se agrega la importación faltante de 'round_pr' en el modelo de línea de pedido del POS. Este error de referencia impedía el correcto funcionamiento del cálculo de precios en moneda extranjera, lo que generaba errores al procesar órdenes y visualizar reportes.

References: https://binaural.odoo.com/odoo/helpdesk/89/tickets/12593