### PR TITLE
FIX #12681:  l10n_ve_invoice

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/models/ir_sequence.py
+++ b/l10n_ve_invoice/models/ir_sequence.py
@@ -8,6 +8,10 @@ class IrSequence(models.Model):
 
     code = fields.Char(copy=False)
 
+    _UNIQUE_CODE_BY_COMPANY = {
+        "invoice.correlative",
+    }
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -23,7 +27,8 @@ class IrSequence(models.Model):
         """"Checks if a sequence with the given code already exists for the specified company."""
         seq_code = vals.get("code", self.code)
         company_id = vals.get("company_id", self.company_id.id)
-        # Realiza la validacion solo si se proporciona un company_id y un seq_code
+        if seq_code and seq_code not in self._UNIQUE_CODE_BY_COMPANY:
+            return
         if company_id and seq_code:
             domain = [
                 ("code", "=", seq_code), 

--- a/l10n_ve_invoice/tests/test_account_move.py
+++ b/l10n_ve_invoice/tests/test_account_move.py
@@ -264,7 +264,7 @@ class TestAccountMove(TransactionCase):
             ],
             move_type="out_refund",
             invoice_date=invoice_date,
-            journal=self.purchase_journal,
+            journal=self.sales_journal,
         )
         move.state = 'posted'
 

--- a/l10n_ve_invoice/tests/test_accounting_reports.py
+++ b/l10n_ve_invoice/tests/test_accounting_reports.py
@@ -243,6 +243,8 @@ class TestAccountingReports(TransactionCase):
             "correlative": "CTRL-001",
             "declaration_unique_of_customs": False,
             "tax_totals": {},
+            "tax_base_for_international_purchase": 0.0,
+            "tax_amount_for_international_purchase": 0.0,
         }
         data.update(vals)
         return SimpleNamespace(**data)

--- a/l10n_ve_invoice/tests/test_ir_sequence.py
+++ b/l10n_ve_invoice/tests/test_ir_sequence.py
@@ -15,21 +15,13 @@ class TestIrSequence(TransactionCase):
         )
 
     def test_01_duplicate_sequence_code_same_company_raises_on_create(self):
-        self.env["ir.sequence"].create(
-            {
-                "name": "Primary Sequence",
-                "code": "test.sequence.same.company",
-                "padding": 4,
-                "number_next_actual": 1,
-                "company_id": self.company.id,
-            }
-        )
-
+        # La secuencia 'invoice.correlative' ya existe por la instalación del módulo.
+        # Intentar crear otra con el mismo código debe fallar.
         with self.assertRaises(ValidationError):
             self.env["ir.sequence"].create(
                 {
                     "name": "Duplicated Sequence",
-                    "code": "test.sequence.same.company",
+                    "code": "invoice.correlative",
                     "padding": 4,
                     "number_next_actual": 1,
                     "company_id": self.company.id,
@@ -61,15 +53,7 @@ class TestIrSequence(TransactionCase):
         self.assertEqual(sequence.company_id, self.other_company)
 
     def test_03_write_duplicate_sequence_code_same_company_raises(self):
-        existing_sequence = self.env["ir.sequence"].create(
-            {
-                "name": "Existing Sequence",
-                "code": "test.sequence.write.origin",
-                "padding": 4,
-                "number_next_actual": 1,
-                "company_id": self.company.id,
-            }
-        )
+        # Intentar cambiar el código de una secuencia a 'invoice.correlative' (que ya existe)
         sequence_to_update = self.env["ir.sequence"].create(
             {
                 "name": "Sequence To Update",
@@ -81,7 +65,7 @@ class TestIrSequence(TransactionCase):
         )
 
         with self.assertRaises(ValidationError):
-            sequence_to_update.write({"code": existing_sequence.code})
+            sequence_to_update.write({"code": "invoice.correlative"})
 
     def test_04_write_same_code_without_duplicates_is_allowed(self):
         sequence = self.env["ir.sequence"].create(
@@ -97,3 +81,29 @@ class TestIrSequence(TransactionCase):
         sequence.write({"name": "Single Sequence Updated"})
 
         self.assertEqual(sequence.name, "Single Sequence Updated")
+
+    def test_05_duplicate_generic_sequence_code_is_allowed(self):
+        """Test that duplicate codes are allowed if they are NOT 'invoice.correlative'."""
+        code = "test.sequence.duplicate.allowed"
+        self.env["ir.sequence"].create(
+            {
+                "name": "First Sequence",
+                "code": code,
+                "padding": 4,
+                "number_next_actual": 1,
+                "company_id": self.company.id,
+            }
+        )
+
+        # This should NOT raise ValidationError now
+        second_sequence = self.env["ir.sequence"].create(
+            {
+                "name": "Second Sequence",
+                "code": code,
+                "padding": 4,
+                "number_next_actual": 1,
+                "company_id": self.company.id,
+            }
+        )
+        self.assertTrue(second_sequence)
+        self.assertEqual(second_sequence.code, code)


### PR DESCRIPTION
Problema:
La validación en `ir.sequence` no permitía tener más de una secuencia activa con el mismo `code` por compañía. Al crear/guardar una caja de PdV, Odoo crea secuencias (p. ej. `pos.order` / `pos.order.line`) que comparten el mismo `code`; la regla global las bloqueaba, impidiendo crear la caja.

Solución:
Restringir la validación para que aplique únicamente a `code = invoice.correlative`, que es el caso fiscal donde sí debe existir una sola secuencia por compañía, sin afectar las secuencias del PdV.

link: https://binaural.odoo.com/odoo/action-390/12681 ticket de triaje-atc [x]