### PR TITLE
FIX #12678 l10n_ve_pos corregir error round_pr en POS

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.9",
+    "version": "17.0.0.0.10",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/static/src/overrides/models/orderline_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/orderline_model.js
@@ -4,6 +4,7 @@ import { Orderline } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 import {
   formatFloat,
+  roundPrecision as round_pr,
   roundDecimals as round_di,
   floatIsZero,
 } from "@web/core/utils/numbers";


### PR DESCRIPTION
Body: PROBLEMA: Al hacer clic en un producto en el POS se generaba un error JavaScript ReferenceError: round_pr is not defined, rompiendo el ciclo de Owl y bloqueando la pantalla de productos.

SOLUCION: Se agregó el import faltante de roundPrecision como round_pr en el override de Orderline para que los cálculos de precios en moneda extranjera no fallen.

LINK: https://binaural.odoo.com/odoo/action-390/12681

ticket [x]