### PR TITLE
-Realizar Corrección de nombre en ficha de Contacto (Socio 1042)

### DIFF
--- a/l10n_ve_contact/__manifest__.py
+++ b/l10n_ve_contact/__manifest__.py
@@ -4,10 +4,13 @@
        Módulo para información de contactos de Venezuela
     """,
     "license": "LGPL-3",
+    "description": """
+       Módulo para información de contactos de Venezuela
+    """,
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Contacts/Contacts",
-    "version": "17.0.0.0.5",
+    "version": "17.0.0.0.6",
     "depends": ["base", "contacts", "l10n_ve_rate", "l10n_ve_location"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_ve_contact/i18n/es_VE.po
+++ b/l10n_ve_contact/i18n/es_VE.po
@@ -277,3 +277,19 @@ msgid ""
 "You cannot modify the name of a contact with associated transactions."
 msgstr ""
 "No puedes modificar el nombre de un contacto con transacciones asociadas."
+
+#. module: l10n_ve_contact
+#: model:ir.model.fields,field_description:l10n_ve_contact.field_res_company__validate_partner_name_immutable
+#: model:ir.model.fields,field_description:l10n_ve_contact.field_res_config_settings__validate_partner_name_immutable
+#: model_terms:ir.ui.view,arch_db:l10n_ve_contact.res_config_settings_l10n_ve_contact
+msgid "Prevent renaming contacts with transactions"
+msgstr "Evitar el cambio de nombre de los contactos con transacciones"
+
+#. module: l10n_ve_contact
+#: model_terms:ir.ui.view,arch_db:l10n_ve_contact.res_config_settings_l10n_ve_contact
+msgid ""
+"<span class=\"o_text-muted\">When enabled, partner name changes are blocked "
+"if related sales, purchases, invoices, or journal items exist.</span>"
+msgstr ""
+"<span class=\"o_text-muted\">Cuando está habilitado, se bloquean los cambios de nombre de los contactos "
+"si existen ventas, compras, facturas o asientos contables relacionados.</span>"

--- a/l10n_ve_contact/models/res_company.py
+++ b/l10n_ve_contact/models/res_company.py
@@ -17,6 +17,11 @@ class ResCompany(models.Model):
         default = False,
         string='Validate user creation general',
     )
+
+    validate_partner_name_immutable = fields.Boolean(
+        default=True,
+        string="Prevent renaming contacts with transactions",
+    )
     
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_ve_contact/models/res_config_settings.py
+++ b/l10n_ve_contact/models/res_config_settings.py
@@ -12,4 +12,9 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.validate_user_creation_general',
         readonly=False
     )
+
+    validate_partner_name_immutable = fields.Boolean(
+        related="company_id.validate_partner_name_immutable",
+        readonly=False,
+    )
     

--- a/l10n_ve_contact/models/res_partner.py
+++ b/l10n_ve_contact/models/res_partner.py
@@ -67,6 +67,9 @@ class ResPartner(models.Model):
 
     @api.constrains("name")
     def _check_name_immutable(self):
+        if not self.env.company.validate_partner_name_immutable:
+            return
+
         model_checks = {
             "sale.order": [("partner_id", "=", "id")],
             "purchase.order": [("partner_id", "=", "id")],

--- a/l10n_ve_contact/views/res_config_settings.xml
+++ b/l10n_ve_contact/views/res_config_settings.xml
@@ -28,6 +28,17 @@
                             </div>
                         </div>
                     </div>
+                    <div id="l10n_ve_contact_div_validate_partner_name_immutable" class="col-6 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="validate_partner_name_immutable" readonly="False"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="validate_partner_name_immutable" string="Prevent renaming contacts with transactions"/>
+                            <div class="text-muted">
+                                <span class="o_text-muted">When enabled, partner name changes are blocked if related sales, purchases, invoices, or journal items exist.</span>
+                            </div>
+                        </div>
+                    </div>
                 </block>
             </xpath>
         </field>


### PR DESCRIPTION
feat: agregar configuración por compañía para permitir/deshabilitar edición de nombre con transacciones relacionadas

Se agrega un campo de configuración por compañía.
Valor por defecto: True para mantener el comportamiento actual. Permite deshabilitar la validación para clientes que no la requieran. 
-https://binaural.odoo.com/odoo/my-tickets/12576