### PR TITLE
Error tasa banco central de venezuela en configuracion

### DIFF
--- a/l10n_ve_currency_rate_live/__manifest__.py
+++ b/l10n_ve_currency_rate_live/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.1.0.4",
+    "version": "17.0.1.0.5",
     "depends": ["l10n_ve_rate", "currency_rate_live"],
     "data": [
         "data/cron_data.xml",

--- a/l10n_ve_currency_rate_live/__manifest__.py
+++ b/l10n_ve_currency_rate_live/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.1.0.5",
+    "version": "17.0.1.0.6",
     "depends": ["l10n_ve_rate", "currency_rate_live"],
     "data": [
         "data/cron_data.xml",

--- a/l10n_ve_currency_rate_live/models/res_company.py
+++ b/l10n_ve_currency_rate_live/models/res_company.py
@@ -18,41 +18,79 @@ class ResCompany(models.Model):
     can_update_habil_days = fields.Boolean(default=True)
 
     @api.model
-    def _parse_bcv_data(self, availible_currencies):
-        companies = self.env["res.company"].search([])
-        for company in companies:
-            can_update_habil_days = company.can_update_habil_days
-            current_date = fields.Date.context_today(company)
+    def _parse_bcv_data(self, available_currencies):
+        """
+        Parses currency rates from the BCV (Central Bank of Venezuela) website.
+        This method is called by Odoo's multi-company currency update engine.
+        
+        :param available_currencies: List of currencies currently active in the system.
+        :return: A dictionary mapping currency codes to their exchange rates and dates,
+                 or an empty dict if the update is not applicable or fails.
+        """
+        # Always return a dictionary to prevent the calling method from crashing
+        result = {}
+        try:
+            # We use the current company in the context
+            current_date = fields.Date.context_today(self)
+            
+            # Check if today is a business day (Monday=1, Sunday=7)
             day = current_date.isoweekday()
             is_habil_day = day <= 5
-            invalid_update_in_habil_day = not is_habil_day and can_update_habil_days
-            if invalid_update_in_habil_day:
-                return
-            usd_rate_bcv = company.get_usd_rate_of_the_day_bcv()
-            is_valid_update_date = str(usd_rate_bcv[1]) == str(current_date)
-            if not is_valid_update_date:
-                return
-            return {"USD": (1, usd_rate_bcv[1]), "VEF": usd_rate_bcv}
+            
+            # Condition to skip update if it's a weekend and the company restricts it
+            if not is_habil_day and self.can_update_habil_days:
+                _logger.info("BCV Update: Skipping update because it is not a business day.")
+                return result
+
+            usd_rate_data = self.get_usd_rate_of_the_day_bcv()
+            rate_value = usd_rate_data[0]
+            rate_date = usd_rate_data[1]
+
+            # Validate that we actually got a date and it matches today (or the expected date)
+            if not rate_date or str(rate_date) != str(current_date):
+                _logger.warning("BCV Update: The rate date found (%s) does not match today (%s).", rate_date, current_date)
+                return result
+
+            # result dictionary structure: { 'CURRENCY_CODE': (factor, date), ... }
+            # Note: Odoo expects (1.0, date) for the base currency of the provider.
+            result = {
+                "USD": (1.0, rate_date),
+                "VEF": (rate_value, rate_date) 
+            }
+        except Exception as e:
+            _logger.error("BCV Update: Critical error parsing data: %s", e)
+            
+        return result
     
     @api.model
     def get_usd_rate_of_the_day_bcv(self):
-        """This function return the rate of the day by the BCV website
-
-        Raises:
-            UserError: Error to connect with BCV, please check your internet connection or try again later
-
-        Return:
-            tuple (float: rate of the day, date: date of the rate)
+        """
+        Performs web scraping on the BCV website to retrieve the official USD exchange rate.
+        
+        :return: A tuple containing (float: rate value, date: date of the rate).
+                 Returns (1.0, False) in case of connection or parsing errors.
         """
         disable_warnings(InsecureRequestWarning)
         URL = "https://www.bcv.org.ve/"
         current_date = fields.Date.context_today(self)
 
-        try:
-            html_content = requests.get(URL, verify=False, timeout=30)
-            soup = BeautifulSoup(html_content.text, "html.parser")
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
 
+        try:
+            # Using a 30-second timeout to prevent the process from hanging indefinitely
+            response = requests.get(URL, verify=False, timeout=30, headers=headers)
+            response.raise_for_status() # Ensure we got a 200 OK status
+            
+            soup = BeautifulSoup(response.text, "html.parser")
+
+            # Extracting the USD value from the specific HTML ID used by BCV
             usd_container = soup.find(id="dolar")
+            if not usd_container:
+                _logger.error("BCV Update: No se encontró el contenedor 'dolar' en la web del BCV.")
+                return (1.0, False)
+
             usd_value = (
                 usd_container.text.replace("\n", "")
                 .replace("USD", "")
@@ -60,9 +98,12 @@ class ResCompany(models.Model):
                 .strip()
             )
             return (float(usd_value), current_date)
+        except requests.exceptions.RequestException as e:
+            _logger.error("BCV Update: Connection error to BCV website: %s", e)
+            return (1.0, False)
         except Exception as e:
-            _logger.error(e)
-            return (1, False)
+            _logger.error("BCV Update: Unexpected error during scraping: %s", e)
+            return (1.0, False)
 
     @api.depends('country_id')
     def _compute_currency_provider(self):

--- a/l10n_ve_currency_rate_live/views/res_config_settings.xml
+++ b/l10n_ve_currency_rate_live/views/res_config_settings.xml
@@ -23,5 +23,16 @@
                 </xpath>
             </field>
         </record>
+
+        <record id="res_config_settings_view_form_inherit_rates" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.rates</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//setting[@id='update_exchange_rates']" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                </xpath>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/l10n_ve_currency_rate_live/views/res_config_settings.xml
+++ b/l10n_ve_currency_rate_live/views/res_config_settings.xml
@@ -5,19 +5,21 @@
             <field name="model">res.config.settings</field>
             <field name="inherit_id" ref="l10n_ve_rate.res_config_settings_l10n_ve_rate" />
             <field name="arch" type="xml">
-                <xpath expr="//block[@name='l10n_ve_rate_block']" position="inside">
-                    <separator string="Exchange Rate Synchronization" />
-                    <div id="l10n_ve_currency_rate_live_div" class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="can_update_habil_days" readonly="False"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="can_update_habil_days" string="Only update in habil days"/>
-                            <div class="text-muted">
-                                <span class="o_text-muted">Only update in habil days</span>
+                <xpath expr="//block[@name='l10n_ve_rate_block']" position="after">
+                    <block >
+                        <separator string="Exchange Rate Synchronization" />
+                        <div id="l10n_ve_currency_rate_live_div" class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="can_update_habil_days" readonly="False"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="can_update_habil_days" string="Only update in habil days"/>
+                                <div class="text-muted">
+                                    <span class="o_text-muted">Only update in habil days</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    </block>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
[FIX] l10n_ve_currency_rate_live: Error tasa banco central de venezuela en configuracion

- Se corrije Vista de configuracion, la misma no se mostraba

- Se agregan validaciones de sguirdad a codigo del parceo de la pagina de BCV, el mismo no manejaba excepciones para los casos en fallos de conexion, o errores en el formato devuelvo, de la misma forma cuando estos errores sucedian retornaba False lo que en ocaciones puede interrunpir el funcionamiento del crom y obligar al usuario a tener q reestablecerlo manualmente.

References:
- Ticket: https://binaural.odoo.com/odoo/action-389/12904
- Tarea:
- PR:
- Otros: