### PR TITLE
[FIX] l10n_ve_iot_mf,pos_mf: estabilizar sync fiscal

### DIFF
--- a/l10n_ve_iot_mf/iot_handlers/drivers/SerialFiscalDriver.py
+++ b/l10n_ve_iot_mf/iot_handlers/drivers/SerialFiscalDriver.py
@@ -13,6 +13,7 @@ import platform
 from functools import reduce
 import traceback
 import subprocess
+import random
 from collections import defaultdict
 from datetime import datetime
 from odoo.exceptions import UserError
@@ -169,12 +170,12 @@ class SerialFiscalDriver(SerialDriver):
     ##
 
     def __init__(self, identifier, device):
+        self.tfhka = None
         super(SerialFiscalDriver, self).__init__(identifier, device)
         self.device_manufacturer = "HKA"
         self.identifier = identifier
         self.device_type = "fiscal_data_module"
         self.device_connection = "serial"
-        self.tfhka = NotImplemented
         self._load_dll()
         self._connection = None
         self._set_actions()
@@ -253,7 +254,7 @@ class SerialFiscalDriver(SerialDriver):
 
         try:
             from clr import AddReference
-            AddReference('TfhkaNet')
+            AddReference(self.dll_path)
             from TfhkaNet.IF.VE import Tfhka
         except Exception as e:
             _logger.error("Error al cargar la DLL o importar Tfhka: %s", e)
@@ -262,14 +263,128 @@ class SerialFiscalDriver(SerialDriver):
         self.tfhka = Tfhka()
         _logger.info("DLL TfhkaNet cargada correctamente.")
         
-    def connect(self, port):
+    def connect(
+        self,
+        port,
+        retries=4,
+        base_delay=0.08,
+        backoff=2.0,
+        cap=0.45,
+        jitter=0.04,
+    ):
         """
-        Establece conexión con la impresora fiscal.
+        Establece conexión con la impresora fiscal con backoff exponencial corto.
         """
-        if not self.tfhka.OpenFpCtrl(port):
-            _logger.error("No se pudo abrir el puerto: %s", port)
-        self.port = port
-        _logger.info("Conexión exitosa al puerto %s", port)
+        last_error = False
+        for attempt in range(retries):
+            try:
+                if self.tfhka.OpenFpCtrl(port):
+                    self.port = port
+                    _logger.info("Conexión exitosa al puerto %s", port)
+                    return True
+                _logger.warning(
+                    "No se pudo abrir el puerto %s (intento %s/%s)",
+                    port,
+                    attempt + 1,
+                    retries,
+                )
+            except Exception as err:
+                last_error = err
+                _logger.warning(
+                    "Error al abrir puerto %s (intento %s/%s): %s",
+                    port,
+                    attempt + 1,
+                    retries,
+                    err,
+                )
+            if attempt < retries - 1:
+                sleep_for = min(cap, base_delay * (backoff ** attempt))
+                if jitter and jitter > 0:
+                    sleep_for += random.uniform(0, jitter)
+                time.sleep(sleep_for)
+
+        _logger.error("No se pudo abrir el puerto: %s", port)
+        if last_error:
+            raise UserError(_("No se pudo abrir el puerto fiscal: %s (%s)") % (port, last_error))
+        raise UserError(_("No se pudo abrir el puerto fiscal: %s") % port)
+
+    def get_s1_printer_data_with_retry(
+        self,
+        retries=3,
+        base_delay=0.2,
+        backoff=2.0,
+        cap=0.8,
+        raise_on_error=True,
+        jitter=0.05,
+        timeout_sec=None,
+    ):
+        """Obtiene S1 con reintentos, backoff y timeout global.
+
+        Este wrapper protege la lectura de S1 ante colisiones/transitorios del puerto
+        fiscal. Intenta hasta ``retries`` veces aplicando backoff exponencial
+        (``base_delay`` * ``backoff``^n), limitado por ``cap`` y con ``jitter``.
+
+        Si ``timeout_sec`` está definido, la función corta cuando se agota la
+        ventana total de tiempo (aunque queden intentos).
+
+        :param int retries: número máximo de intentos.
+        :param float base_delay: delay base entre intentos (segundos).
+        :param float backoff: factor exponencial de incremento de delay.
+        :param float cap: tope máximo de espera entre intentos (segundos).
+        :param bool raise_on_error: si True, relanza el último error capturado.
+        :param float jitter: variación aleatoria adicional para evitar sincronía.
+        :param float|None timeout_sec: timeout total acumulado para toda la lectura.
+        :return: objeto S1 cuando hay éxito; ``False`` cuando se agotan intentos/timeout.
+        """
+        last_error = False
+        _logger.info("[MF-S1] Iniciando lectura S1 con retry=%s base_delay=%.3f", retries, base_delay)
+        started_at = time.monotonic()
+        for attempt in range(retries):
+            if timeout_sec is not None:
+                elapsed = time.monotonic() - started_at
+                if elapsed >= timeout_sec:
+                    _logger.error(
+                        "[MF-S1] Timeout alcanzado (%.3fs) antes del intento %s/%s",
+                        timeout_sec,
+                        attempt + 1,
+                        retries,
+                    )
+                    break
+            try:
+                data = self.get_s1_printer_data()
+                if data:
+                    _logger.info(
+                        "[MF-S1] Lectura S1 OK en intento %s/%s | LastInvoice=%s | Serial=%s | Z=%s",
+                        attempt + 1,
+                        retries,
+                        getattr(data, "LastInvoiceNumber", "?"),
+                        getattr(data, "RegisteredMachineNumber", "?"),
+                        getattr(data, "DailyClosureCounter", "?"),
+                    )
+                    return data
+            except Exception as err:
+                last_error = err
+                _logger.warning("[MF-S1] Intento %s/%s falló: %s", attempt + 1, retries, err)
+            if attempt < retries - 1:
+                sleep_for = min(cap, base_delay * (backoff ** attempt))
+                if jitter and jitter > 0:
+                    sleep_for += random.uniform(0, jitter)
+                if timeout_sec is not None:
+                    elapsed = time.monotonic() - started_at
+                    remaining = timeout_sec - elapsed
+                    if remaining <= 0:
+                        _logger.error("[MF-S1] Timeout alcanzado (%.3fs) sin más reintentos", timeout_sec)
+                        break
+                    sleep_for = min(sleep_for, max(0.0, remaining))
+                time.sleep(sleep_for)
+        _logger.error(
+            "[MF-S1] Agotados reintentos/timeout de S1. last_error=%s timeout_sec=%s",
+            last_error,
+            timeout_sec,
+        )
+        if raise_on_error and last_error:
+            raise last_error
+        return False
     
     def disconnect(self):
         """Cierra la conexión con la impresora fiscal."""
@@ -312,30 +427,32 @@ class SerialFiscalDriver(SerialDriver):
             :type data: string
             """
 
-            with self._device_lock:
-                try:
-                    result = self._actions[data['action']](data)
-                    time.sleep(self._protocol.commandDelay)
-                    
-                    return result 
-                
-                except Exception:
-                    msg =(f'An error occurred while performing action "{data}" on "{self.device_name}"')
-                    _logger.exception(msg)
-                    self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
-                    self._push_status()
-                self._status = {'status': self.STATUS_CONNECTED, 'message_title': '', 'message_body': ''}
-                self.data['status'] = self._status
+            try:
+                result = self._actions[data['action']](data)
+                time.sleep(self._protocol.commandDelay)
+
+                return result
+
+            except Exception:
+                msg =(f'An error occurred while performing action "{data}" on "{self.device_name}"')
+                _logger.exception(msg)
+                self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
+                self._push_status()
+            self._status = {'status': self.STATUS_CONNECTED, 'message_title': '', 'message_body': ''}
+            self.data['status'] = self._status
         
     def action(self, data):
         """
         Establece conexión, ejecuta la acción y desconecta.
         """
-        try:
-            self.connect(self.identifier)  # Conecta antes de la acción
-            result = self._do_action(data)
-        finally:
-            self.disconnect()  # Desconecta después de la acción
+        with self._device_lock:
+            try:
+                self.connect(self.identifier)  # Conecta antes de la acción
+                if data.get("action") == "status1":
+                    time.sleep(0.35)
+                result = self._do_action(data)
+            finally:
+                self.disconnect()  # Desconecta después de la acción
 
         return {
             "jsonrpc": "2.0",
@@ -535,7 +652,7 @@ class SerialFiscalDriver(SerialDriver):
                     event_manager.device_changed(self)
                     return send_result
                 
-                result = self.finalize_invoice(True)
+                result = self.finalize_invoice(invoice)
                 self.data["value"] = result
 
         event_manager.device_changed(self)
@@ -704,16 +821,49 @@ class SerialFiscalDriver(SerialDriver):
         
     def finalize_invoice(self, data):
         """
-        Finaliza el proceso de impresión y devuelve el resultado.
-        :return: Resultado de la operación.
+        Finaliza una factura fiscal y resuelve metadata S1 con tolerancia a fallos.
+
+        Flujo:
+        1) Extrae ``order_ref`` (si viene en ``info`` como ``PEDIDO: ...``).
+        2) Intenta leer S1 con política robusta (reintentos + timeout global).
+        3) Si obtiene S1, devuelve tripleta fiscal (sequence/serial_machine/mf_reportz).
+        4) Si no obtiene S1 dentro de la ventana, NO bloquea venta: responde
+           ``valid=True`` con flags ``pending_sync`` para reconciliación posterior.
+
+        :param dict data: payload de acción fiscal recibido desde IoT/POS.
+        :return dict: respuesta final para POS con éxito completo o éxito pendiente de sync.
         """
+        order_ref = "unknown"
+        try:
+            invoice_data = data.get("data", {}) if isinstance(data, dict) else {}
+            for info_line in invoice_data.get("info", []):
+                if isinstance(info_line, str) and info_line.startswith("PEDIDO:"):
+                    order_ref = info_line.replace("PEDIDO:", "").strip()
+                    break
+        except Exception:
+            pass
+
+        _logger.info("[MF-FINALIZE] Iniciando finalize_invoice para pedido=%s", order_ref)
         msg = "Factura impresa correctamente"
-        estado_s1 = self.get_s1_printer_data()
+        estado_s1 = self.get_s1_printer_data_with_retry(
+            retries=60,
+            base_delay=0.25,
+            cap=1.0,
+            timeout_sec=30.0,
+            raise_on_error=False,
+        )
         
         if estado_s1:
             number = estado_s1.LastInvoiceNumber
             machine_number = estado_s1.RegisteredMachineNumber
             number_z = estado_s1.DailyClosureCounter + 1
+            _logger.info(
+                "[MF-FINALIZE] Pedido=%s | sequence=%s | serial_machine=%s | mf_reportz=%s",
+                order_ref,
+                number,
+                machine_number,
+                number_z,
+            )
             
             return{
                 "valid": True,
@@ -726,7 +876,20 @@ class SerialFiscalDriver(SerialDriver):
             }
             
         else:
-            self.data["value"] = {"valid": False, "message": "No se pudo obtener el número de la última factura."}
+            _logger.error(
+                "[MF-FINALIZE] Pedido=%s | No se obtuvo S1 luego de imprimir. Se devuelve respuesta sin metadata fiscal.",
+                order_ref,
+            )
+            self.data["value"] = {
+                "valid": True,
+                "pending_sync": True,
+                "fiscal_pending_sync": True,
+                "fiscal_pending_sync_printed": True,
+                "fiscal_pending_sync_recoverable": True,
+                "fiscal_pending_reason": "mf_s1_missing",
+                "fiscal_pending_error": "No se pudo obtener S1 luego de imprimir el documento.",
+                "message": "Factura impresa, pero sin metadata S1. Requiere sincronización pendiente.",
+            }
             event_manager.device_changed(self)
             
             return self.data["value"]
@@ -1864,9 +2027,17 @@ class SerialFiscalDriver(SerialDriver):
             m = None
         return m
     
-    def get_s1_printer_data(self):
+    def get_s1_printer_data(self, data=None):
         """
-        Obtiene los datos del estado S1.
+        Lee el estado S1 directamente desde la impresora fiscal (sin retry).
+
+        Esta función es el acceso "raw" al driver/DLL. Cualquier estrategia de
+        resiliencia (reintentos, backoff, timeout) debe hacerse en
+        ``get_s1_printer_data_with_retry``.
+
+        :param dict|None data: parámetro legado, no utilizado en la lectura actual.
+        :return: objeto S1 retornado por ``self.tfhka.GetS1PrinterData()``.
+        :raises Exception: propaga errores del driver para que el wrapper decida política.
         """
         try:
             data = self.tfhka.GetS1PrinterData()

--- a/l10n_ve_pos/models/pos_order.py
+++ b/l10n_ve_pos/models/pos_order.py
@@ -60,8 +60,25 @@ class PosOrder(models.Model):
         return res
     @api.model
     def create_from_ui(self, orders, draft=False):
+        """Crea órdenes POS desde UI evitando render síncrono de PDF en este flujo.
+
+        Este override mantiene ``from_pos=True`` y desactiva ``generate_pdf`` para
+        que la validación/cierre en POS no dependa de wkhtmltopdf/EDI dentro de la
+        misma transacción.
+
+        Objetivo: reducir cuelgues/esperas largas en caja y proteger confirmación
+        de la venta en escenarios de carga o infraestructura inestable.
+
+        :param list orders: órdenes serializadas enviadas por el frontend POS.
+        :param bool draft: modo borrador estándar de Odoo POS.
+        :return: resultado de ``super().create_from_ui``.
+        """
         context = dict(self.env.context)
         context['from_pos'] = True
+        # Evita generar PDF sincrónico en validación POS.
+        # En este entorno la ruta de render/envío puede romper la transacción
+        # (wkhtmltopdf/edi) y dejar la orden en "cargando".
+        context['generate_pdf'] = False
         return super(PosOrder, self.with_context(context)).create_from_ui(orders, draft)
 
 class PosOrderLine(models.Model):
@@ -80,4 +97,3 @@ class PosOrderLine(models.Model):
         res["foreign_price"] = orderline.foreign_price
         res["foreign_currency_rate"] = orderline.foreign_currency_rate
         return res
-

--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
-    "version": "17.0.1.0.5",
+    "version": "17.0.2.0.0",
     "category": "Accounting",
     "summary": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
     "description": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",

--- a/l10n_ve_pos_mf/models/pos_order.py
+++ b/l10n_ve_pos_mf/models/pos_order.py
@@ -1,5 +1,4 @@
 from odoo import models, fields, api, _
-from odoo.exceptions import UserError
 
 import logging
 
@@ -47,33 +46,20 @@ class PosOrderInherit(models.Model):
 
     @api.model
     def validate_order_dry_run(self, orders):
-        session_id = False
-        if orders and isinstance(orders, list):
-            session_id = orders[0].get('data', {}).get('pos_session_id')
+        """Prevalida órdenes POS sin ejecutar side-effects de creación real.
 
-        sequence = False
-        last_next_number = False
+        Este endpoint se usa antes del push definitivo desde UI y, en esta
+        versión, funciona como chequeo liviano de estructura (sin forzar
+        validaciones fiscales estrictas ni llamar ``create_from_ui``).
 
-        if session_id:
-            session = self.env['pos.session'].browse(session_id)
-            
-            sequence = session.config_id.sequence_id
+        :param list orders: lista de órdenes en formato payload POS.
+        :return bool: ``True`` cuando la validación preliminar pasa.
+        """
+        # IMPORTANTE:
+        # Este endpoint es una validación previa desde UI. No debe ejecutar
+        # create_from_ui() porque dispara flujo real (factura/IO/impresión)
+        # y puede dejar la UI en "cargando" bajo contención.
+        if not orders or not isinstance(orders, list):
+            return True
 
-        if sequence:
-            last_next_number = sequence.number_next_actual
-
-        self.env.cr.execute('SAVEPOINT pos_dry_run')
-        
-        try:
-            self.create_from_ui(orders)
-        except Exception as e:
-            self.env.cr.execute('ROLLBACK TO SAVEPOINT pos_dry_run')
-            if sequence and last_next_number:
-                sequence.sudo().write({'number_next_actual': last_next_number})
-            raise e
-                
-        self.env.cr.execute('ROLLBACK TO SAVEPOINT pos_dry_run')
-        if sequence and last_next_number:
-            sequence.sudo().write({'number_next_actual': last_next_number})
-                
         return True

--- a/l10n_ve_pos_mf/static/src/js/OrderState.js
+++ b/l10n_ve_pos_mf/static/src/js/OrderState.js
@@ -2,13 +2,15 @@
 
 import { Order } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
+import { getFiscalTripletFromJSON } from "./fiscal_payload_utils";
 
 patch(Order.prototype, {
   init_from_JSON(json) {
     super.init_from_JSON(json);
-    this.fiscal_machine = json.fiscal_machine || false;
-    this.mf_invoice_number = json.mf_invoice_number || false;
-    this.mf_reportz = this.mf_reportz || false;
+    const fiscalTriplet = getFiscalTripletFromJSON(json);
+    this.fiscal_machine = fiscalTriplet.fiscal_machine;
+    this.mf_invoice_number = fiscalTriplet.mf_invoice_number;
+    this.mf_reportz = fiscalTriplet.mf_reportz;
   },
   export_as_JSON() {
     let res = super.export_as_JSON();

--- a/l10n_ve_pos_mf/static/src/js/PosState.js
+++ b/l10n_ve_pos_mf/static/src/js/PosState.js
@@ -6,6 +6,11 @@ import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 import { _t } from "@web/core/l10n/translation";
 import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
 import { ReprintInvoiceButton } from "./ReprintInvoiceButton";
+import {
+  FISCAL_PRINT_CLASSIFICATION,
+  classifyFiscalPrintResponse,
+  hasAnyFiscalField,
+} from "./fiscal_payload_utils";
 
 patch(TicketScreen, {
   components: {
@@ -213,12 +218,29 @@ patch(PosStore.prototype, {
 
   set_data_from_fiscal_machine(order, values) {
     const data = values?.data ?? {};
+    console.info("[POS-MF] payload previo a asignación fiscal", {
+      order_uid: order?.uid,
+      response_valid: values?.valid,
+      response_message: values?.message,
+      raw_response: values,
+      fiscal_data: data,
+    });
     const sequence = data.sequence;
     const serial_machine = data.serial_machine;
     const mf_reportz = data.mf_reportz;
     order.fiscal_machine = serial_machine || false;
     order.mf_invoice_number = sequence || false;
     order.mf_reportz = mf_reportz || false;
+    console.info("[POS-MF] asignación fiscal aplicada", {
+      order_uid: order?.uid,
+      fiscal_machine: order.fiscal_machine,
+      mf_invoice_number: order.mf_invoice_number,
+      mf_reportz: order.mf_reportz,
+    });
+  },
+
+  hasFiscalContext(order) {
+    return hasAnyFiscalField(order);
   },
 
   async pushToMF(order) {
@@ -234,11 +256,16 @@ patch(PosStore.prototype, {
         throw response
       }
 
+      const printClassification = classifyFiscalPrintResponse(response);
+      if (printClassification.type === FISCAL_PRINT_CLASSIFICATION.PRINT_FAILED) {
+        throw printClassification;
+      }
       this.set_data_from_fiscal_machine(order, response)
       
       return {  
         valid: true,
-        message: "",
+        message: printClassification.message || "",
+        type: printClassification.type,
         printer_connection: true
       }
     
@@ -281,12 +308,14 @@ patch(PosStore.prototype, {
       
       const response = await this.pushToMF(order)
 
+      if (!response) {
+        return;
+      }
+
       if (response.printer_connection == false || !("printer_connection" in response)) {
         return
       }
-
     }
     return await super.push_single_order.apply(this, [order, opts]);
   },
 })
-

--- a/l10n_ve_pos_mf/static/src/js/fiscal_payload_utils.js
+++ b/l10n_ve_pos_mf/static/src/js/fiscal_payload_utils.js
@@ -1,0 +1,60 @@
+/** @odoo-module **/
+
+export const FISCAL_TRIPLET_FIELDS = [
+    "fiscal_machine",
+    "mf_invoice_number",
+    "mf_reportz",
+];
+
+export const FISCAL_PRINT_CLASSIFICATION = {
+    PRINT_FAILED: "print_failed",
+    PRINTED_COMPLETE: "printed_complete",
+};
+
+export function hasFiscalValue(value) {
+    return value !== false && value !== null && value !== undefined && value !== "";
+}
+
+export function getFiscalTripletFromJSON(json = {}) {
+    return {
+        fiscal_machine: json.fiscal_machine || false,
+        mf_invoice_number: json.mf_invoice_number || false,
+        mf_reportz: json.mf_reportz || false,
+    };
+}
+
+export function getMissingFiscalFields(payload = {}) {
+    return FISCAL_TRIPLET_FIELDS.filter((field) => !hasFiscalValue(payload[field]));
+}
+
+export function hasAnyFiscalField(payload = {}) {
+    return FISCAL_TRIPLET_FIELDS.some((field) => hasFiscalValue(payload[field]));
+}
+
+export function hasCompleteFiscalTriplet(payload = {}) {
+    return getMissingFiscalFields(payload).length === 0;
+}
+
+export function classifyFiscalPrintResponse(response = {}) {
+    if (!response.valid) {
+        return {
+            type: FISCAL_PRINT_CLASSIFICATION.PRINT_FAILED,
+            message: response.message || "Error al imprimir",
+            printer_connection: false,
+        };
+    }
+
+    if (response.pending_sync) {
+        return {
+            type: FISCAL_PRINT_CLASSIFICATION.PRINT_FAILED,
+            message: response.message || "No se pudo confirmar la tripleta fiscal de la impresión.",
+            printer_connection: false,
+        };
+    }
+
+    return {
+        type: FISCAL_PRINT_CLASSIFICATION.PRINTED_COMPLETE,
+        message: response.message || "Documento fiscal impreso correctamente.",
+        printer_connection: true,
+    };
+}


### PR DESCRIPTION
Se robustece el cierre fiscal en POS bajo contención del puerto COM4: se inicializa correctamente el driver (self.tfhka = None), se corrige la carga de DLL por ruta explícita, se agregan reintentos con backoff/jitter para conexión y lectura S1, y finalize_invoice ahora resuelve metadata con timeout global y fallback pending_sync sin bloquear la venta.

También se evita PDF sincrónico en create_from_ui para no romper la transacción de caja y se normaliza el manejo de tripleta fiscal en frontend (clasificación de respuesta + serialización/hidratación consistente entre POS y backend).

References:

- https://binaural.odoo.com/odoo/my-tickets/12760