### PR TITLE
[IMP]Se usa la precion de la moneda para los calculos de redondeo. 

### DIFF
--- a/l10n_ve_iot_mf/iot_handlers/drivers/SerialFiscalDriver.py
+++ b/l10n_ve_iot_mf/iot_handlers/drivers/SerialFiscalDriver.py
@@ -690,7 +690,7 @@ class SerialFiscalDriver(SerialDriver):
                 result = self.send_command(command)
                 
                 if not result and command not in ["101","199"]:
-                    msg.append("Fallo al enviar comando: %s",command)
+                    msg.append(f"Fallo al enviar comando: {command}")
                     self.send_command("199")
                     return {"valid": False, "message": msg}
 

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -5,9 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 import {
   formatFloat,
+  floatIsZero,
   roundDecimals as round_di,
   roundPrecision as round_pr,
-  floatIsZero,
 } from "@web/core/utils/numbers";
 import { _t } from "@web/core/l10n/translation";
 
@@ -171,7 +171,7 @@ patch(Order.prototype, {
       this.orderlines.reduce(function (sum, orderLine) {
         return sum + orderLine.get_display_foreign_price();
       }, 0),
-      4,
+      this.pos.dp["Foreign Product Price"],
     );
   },
   get_foreign_total_with_tax() {
@@ -182,12 +182,12 @@ patch(Order.prototype, {
       this.orderlines.reduce(function (sum, orderLine) {
         return sum + orderLine.get_foreign_price_without_tax();
       }, 0),
-      4,
+      this.pos.dp["Foreign Product Price"],
     );
   },
   get_foreign_total_discount() {
     const ignored_product_ids = this._get_ignored_product_ids_total_discount();
-    return round_pr(
+    return round_di(
       this.orderlines.reduce((sum, orderLine) => {
         if (!ignored_product_ids.includes(orderLine.product.id)) {
           sum +=
@@ -203,7 +203,7 @@ patch(Order.prototype, {
         }
         return sum;
       }, 0),
-      4,
+      this.pos.dp["Foreign Product Price"],
     );
   },
   get_foreign_total_tax() {
@@ -213,7 +213,7 @@ patch(Order.prototype, {
       // 2. Round that result
       // 3. Sum all those rounded amounts
       var groupTaxes = {};
-      this.orderlines.forEach(function(line) {
+      this.orderlines.forEach(function (line) {
         var taxDetails = line.get_foreign_tax_details();
         var taxIds = Object.keys(taxDetails);
         for (var t = 0; t < taxIds.length; t++) {
@@ -229,15 +229,15 @@ patch(Order.prototype, {
       var taxIds = Object.keys(groupTaxes);
       for (var j = 0; j < taxIds.length; j++) {
         var taxAmount = groupTaxes[taxIds[j]];
-        sum += round_pr(taxAmount, this.pos.currency.rounding);
+        sum += round_pr(taxAmount, this.pos.foreign_currency.rounding);
       }
       return sum;
     } else {
-      return round_di(
+      return round_pr(
         this.orderlines.reduce(function (sum, orderLine) {
           return sum + orderLine.get_foreign_tax();
         }, 0),
-        4,
+        this.pos.foreign_currency.rounding,
       );
     }
   },
@@ -245,7 +245,7 @@ patch(Order.prototype, {
     var details = {};
     var fulldetails = [];
 
-    this.orderlines.forEach(function(line) {
+    this.orderlines.forEach(function (line) {
       var ldetails = line.get_foreign_tax_details();
       for (var id in ldetails) {
         if (Object.hasOwnProperty.call(ldetails, id)) {

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -398,7 +398,7 @@ patch(Order.prototype, {
         }
         return sum;
       }, 0),
-      this.pos.dp["Foreign Product Price"],
+      this.pos.foreign_currency.rounding,
     );
   },
   get_foreign_change(paymentline) {
@@ -417,7 +417,7 @@ patch(Order.prototype, {
         }
       }
     }
-    return round_di(Math.max(0, change), this.pos.dp["Foreign Product Price"]);
+    return round_pr(Math.max(0, change), this.pos.foreign_currency.rounding);
   },
   get_foreign_due(paymentline) {
     if (!paymentline) {
@@ -436,7 +436,7 @@ patch(Order.prototype, {
         }
       }
     }
-    return round_di(due, this.pos.dp["Foreign Product Price"]);
+    return round_pr(due, this.pos.foreign_currency.rounding);
   },
 
   get_qty_products() {

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -135,7 +135,7 @@ patch(Order.prototype, {
       this.orderlines.reduce(function (sum, orderLine) {
         return sum + orderLine.get_display_foreign_price();
       }, 0),
-      this.pos.dp["Foreign Product Price"],
+      this.pos.foreign_currency.rounding,
     );
   },
   get_foreign_total_with_tax() {
@@ -146,7 +146,7 @@ patch(Order.prototype, {
       this.orderlines.reduce(function (sum, orderLine) {
         return sum + orderLine.get_foreign_price_without_tax();
       }, 0),
-      this.pos.dp["Foreign Product Price"],
+      this.pos.foreign_currency.rounding
     );
   },
   get_foreign_total_discount() {
@@ -167,7 +167,7 @@ patch(Order.prototype, {
         }
         return sum;
       }, 0),
-      this.pos.dp["Foreign Product Price"],
+      this.pos.foreign_currency.rounding,
     );
   },
   get_foreign_total_tax() {

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -5,9 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 import {
   formatFloat,
-  floatIsZero,
   roundDecimals as round_di,
   roundPrecision as round_pr,
+  floatIsZero,
 } from "@web/core/utils/numbers";
 import { _t } from "@web/core/l10n/translation";
 
@@ -38,7 +38,7 @@ patch(Order.prototype, {
   get init_conversion_rate() {
     //FIXME :Buscar una manera de esto sea por id y no por name
     if (this.pos.currency.name == "VEF") {
-      return this.pos.config.foreign_inverse_rate;
+      return round_di(this.pos.config.foreign_inverse_rate, this.pos.currency.decimal_places);
     }
     if (this.pos.currency.name == "USD") {
       return round_di(this.pos.config.foreign_rate, this.pos.foreign_currency.decimal_places);
@@ -65,42 +65,6 @@ patch(Order.prototype, {
 
     return this.init_conversion_rate;
   },
-
-  // get_orderlines() {
-  //   if (!this.cid || !this.pos.get_order()) {
-  //     return this.orderlines
-  //   }
-
-  //   if (this.cid != this.pos.get_order().cid) {
-  //     return this.orderlines;
-  //   }
-
-  //   if (this.orderlines.length < 1) {
-  //     this.lock_toggle_receipt_invoice = false
-  //     return this.orderlines
-  //   }
-
-  //   let line = this.orderlines[0]
-
-  //   if (!line.refunded_orderline_id) {
-  //     return this.orderlines
-  //   }
-
-  //   if (this.lock_toggle_receipt_invoice) {
-  //     return this.orderlines
-  //   }
-
-  //   this.pos.env.services.rpc({
-  //     model: 'pos.order.line',
-  //     method: 'search_read',
-  //     domain: [['id', '=', line.refunded_orderline_id]],
-  //   }).then((el) => {
-  //     this.to_receipt = el[0].to_receipt
-  //     this.lock_toggle_receipt_invoice = true
-  //   })
-
-  //   return this.orderlines;
-  // },
 
   reload_taxes() {
     this.orderlines.forEach((el) => {
@@ -434,7 +398,7 @@ patch(Order.prototype, {
         }
         return sum;
       }, 0),
-      this.pos.foreign_currency.rounding,
+      this.pos.dp["Foreign Product Price"],
     );
   },
   get_foreign_change(paymentline) {
@@ -453,7 +417,7 @@ patch(Order.prototype, {
         }
       }
     }
-    return round_pr(Math.max(0, change), this.pos.foreign_currency.rounding);
+    return round_di(Math.max(0, change), this.pos.dp["Foreign Product Price"]);
   },
   get_foreign_due(paymentline) {
     if (!paymentline) {
@@ -472,7 +436,7 @@ patch(Order.prototype, {
         }
       }
     }
-    return round_pr(due, this.pos.foreign_currency.rounding);
+    return round_di(due, this.pos.dp["Foreign Product Price"]);
   },
 
   get_qty_products() {

--- a/l10n_ve_pos/static/src/overrides/models/orderline_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/orderline_model.js
@@ -7,6 +7,8 @@ import {
   roundPrecision as round_pr,
   roundDecimals as round_di,
   floatIsZero,
+  roundDecimals as round_di,
+  roundPrecision as round_pr,
 } from "@web/core/utils/numbers";
 
 // New orders are now associated with the current table, if any.

--- a/l10n_ve_pos/static/src/overrides/models/orderline_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/orderline_model.js
@@ -4,8 +4,6 @@ import { Orderline } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 import {
   formatFloat,
-  roundPrecision as round_pr,
-  roundDecimals as round_di,
   floatIsZero,
   roundDecimals as round_di,
   roundPrecision as round_pr,

--- a/l10n_ve_pos/static/src/overrides/models/payment_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/payment_model.js
@@ -38,6 +38,7 @@ patch(Payment.prototype, {
 				return res;
 			}
 			this.foreign_amount = round_di(amount * this.pos.foreign_currency.rate, this.pos.dp["Foreign Product Price"]); 
+
 		}
 		return res;
 	},

--- a/l10n_ve_pos/static/src/overrides/models/payment_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/payment_model.js
@@ -37,7 +37,7 @@ patch(Payment.prototype, {
 				this.set_foreign_amount(this.order.get_foreign_due() + this.order.get_foreign_rounding_applied(), true);
 				return res;
 			}
-			this.foreign_amount = amount * this.pos.foreign_currency.rate; 
+			this.foreign_amount = round_di(amount * this.pos.foreign_currency.rate, this.pos.dp["Foreign Product Price"]); 
 		}
 		return res;
 	},
@@ -54,12 +54,12 @@ patch(Payment.prototype, {
 			if (this.pos.currency.name == "USD") {
 				if (this.payment_method.is_foreign_currency) {
 					this.set_amount(
-						this.foreign_amount * this.pos.foreign_currency.inverse_rate,
+						this.foreign_amount * 1 / this.pos.foreign_currency.inverse_rate,
 					);
 					return;
 				}
 				this.set_amount(
-					this.foreign_amount * this.order.init_conversion_rate,
+					this.foreign_amount * 1 / this.order.init_conversion_rate,
 					true,
 				);
 			}

--- a/l10n_ve_pos/static/src/overrides/models/pos_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/pos_model.js
@@ -93,7 +93,7 @@ patch(PosStore.prototype, {
       if (company.country && company.country.code === "IN") {
         let total_tax_amount = 0.0;
         for (const [i, tax_factor] of incl_tax_amounts.percent_taxes) {
-          const tax_amount = round_di(base_amount * tax_factor / (100 + percent_amount), 4);
+          const tax_amount = round_pr(base_amount * tax_factor / (100 + percent_amount), currency_rounding);
           total_tax_amount += tax_amount;
           cached_tax_amounts[i] = tax_amount;
           fixed_amount += tax_amount;
@@ -173,7 +173,7 @@ patch(PosStore.prototype, {
       });
     }
 
-    var total_excluded = round_di(
+    var total_excluded = round_pr(
       recompute_base(base, incl_tax_amounts),
       currency_rounding
     );
@@ -206,10 +206,10 @@ patch(PosStore.prototype, {
         var tax_amount = self._compute_all(tax, tax_base_amount, quantity, true);
       }
 
-      tax_amount = round_di(tax_amount, 4);
-      var factorized_tax_amount = round_di(
+      tax_amount = round_pr(tax_amount, currency_rounding);
+      var factorized_tax_amount = round_pr(
         tax_amount * tax.sum_repartition_factor,
-        4
+        currency_rounding
       );
 
       if (tax.price_include && total_included_checkpoints[i] === undefined) {
@@ -220,7 +220,7 @@ patch(PosStore.prototype, {
         id: tax.id,
         name: tax.name,
         amount: sign * factorized_tax_amount,
-        base: sign * round_di(tax_base_amount, 4),
+        base: sign * round_pr(tax_base_amount, currency_rounding),
       });
 
       if (tax.include_base_amount) {
@@ -235,8 +235,8 @@ patch(PosStore.prototype, {
     });
     return {
       taxes: taxes_vals,
-      total_excluded: sign * round_di(total_excluded, 4),
-      total_included: sign * round_di(total_included, 4),
+      total_excluded: sign * total_excluded,
+      total_included: sign * total_included,
     };
   },
 

--- a/l10n_ve_pos/static/src/overrides/screens/payment_line/payment_line.js
+++ b/l10n_ve_pos/static/src/overrides/screens/payment_line/payment_line.js
@@ -8,11 +8,18 @@ patch(PaymentScreenPaymentLines.prototype, {
   formatLineAmount(paymentline) {
     let amount = this.env.utils.formatCurrency(paymentline.get_amount(), true)
     let foreign_amount = this.env.utils.formatForeignCurrency(paymentline.get_foreign_amount())
+    if (paymentline.selected) {
+      if (paymentline.payment_method.is_foreign_currency) {
+        return foreign_amount
+      } else {
+        return amount
+      }
+    }
     if (paymentline.payment_method.is_foreign_currency) {
       return foreign_amount + " / " + amount
     } else {
-      return amount
+      return foreign_amount + " / " + amount
+
     }
-    
   }
 })

--- a/l10n_ve_pos_igtf/static/src/app/overrides/models/order_model.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/models/order_model.js
@@ -4,9 +4,9 @@ import { Order, Payment } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 import {
   formatFloat,
+  floatIsZero,
   roundDecimals as round_di,
   roundPrecision as round_pr,
-  floatIsZero,
 } from "@web/core/utils/numbers";
 
 // New orders are now associated with the current table, if any.
@@ -113,21 +113,17 @@ patch(Order.prototype, {
           return true;
         });
 
-        if (payment_without_change.length > 0) {
-          payment_without_change.forEach((payment) => {
-            if (!payment.include_igtf) {
-              payment.set_igtf_amount(
-                igtf_amount / payment_without_change.length,
-              );
-              payment.set_foreign_igtf_amount(
-                foreign_igtf_amount / payment_without_change.length,
-              );
-              return;
-            }
-            // payment.set_igtf_amount(igtf_amount / payment_without_change.length)
-            // payment.set_foreign_igtf_amount(foreign_igtf_amount / payment_without_change.length)
-          });
-        }
+        let total_payment_amount = payment_without_change.reduce((acc, p) => acc + p.amount, 0);
+        payment_without_change.forEach((payment) => {
+          let factor = total_payment_amount ? (payment.amount / total_payment_amount) : 0;
+          if (!payment.include_igtf) {
+            payment.set_igtf_amount(igtf_amount * factor);
+            payment.set_foreign_igtf_amount(foreign_igtf_amount * factor);
+            return;
+          }
+          payment.set_igtf_amount(igtf_amount * factor);
+          payment.set_foreign_igtf_amount(foreign_igtf_amount * factor);
+        });
         return;
       }
 
@@ -151,9 +147,9 @@ patch(Order.prototype, {
       }
 
       if (!is_change) {
-        payment.set_igtf_amount(this.compute_igtf_amount(amount_to_pay));
+        payment.set_igtf_amount(this.compute_igtf_amount(amount_to_pay, false));
         payment.set_foreign_igtf_amount(
-          this.compute_igtf_amount(foreign_amount_to_pay),
+          this.compute_igtf_amount(foreign_amount_to_pay, true),
         );
 
         igtf_amount += payment.igtf_amount;
@@ -170,8 +166,8 @@ patch(Order.prototype, {
     ) {
       bi_igtf = this.get_total_without_igtf();
       foreign_bi_igtf = this.get_foreign_total_without_igtf();
-      igtf_amount = this.compute_igtf_amount(bi_igtf);
-      foreign_igtf_amount = this.compute_igtf_amount(foreign_bi_igtf);
+      igtf_amount = this.compute_igtf_amount(bi_igtf, false);
+      foreign_igtf_amount = this.compute_igtf_amount(foreign_bi_igtf, true);
 
       let payment_without_change = paymentlines.filter((payment) => {
         if (!bi_payments.includes(payment.cid)) {
@@ -193,38 +189,36 @@ patch(Order.prototype, {
       });
 
       if (payment_without_change.length > 0) {
+        let remaining_taxable_base = bi_igtf;
         payment_without_change.forEach((payment) => {
+          let allocatable_amount = Math.min(payment.amount, remaining_taxable_base);
+          if (allocatable_amount < 0) {
+            allocatable_amount = 0;
+          }
+          remaining_taxable_base = Math.max(0, remaining_taxable_base - allocatable_amount);
+
           if (!payment.include_igtf) {
             return;
           }
-          // payment.set_igtf_amount(igtf_amount / payment_without_change.length)
-          // payment.set_foreign_igtf_amount(foreign_igtf_amount / payment_without_change.length)
+
+          let ratio = payment.amount ? (allocatable_amount / payment.amount) : 0;
+          payment.set_igtf_amount(this.compute_igtf_amount(allocatable_amount, false));
+          payment.set_foreign_igtf_amount(this.compute_igtf_amount(payment.get_foreign_amount() * ratio, true));
         });
       }
     }
 
-    if (igtf_payment_methods.length > 0) {
-      let amount_sum = 0;
-      let foreign_amount_sum = 0;
-      let igtf_amount_sum = 0;
-      let foreign_igtf_amount_sum = 0;
 
-      for (let payments of igtf_payment_methods) {
-        amount_sum += payments.amount;
-        foreign_amount_sum += payments.foreign_amount;
-        igtf_amount_sum += payments.igtf_amount;
-        foreign_igtf_amount_sum += payments.foreign_igtf_amount;
-      }
-      this.bi_igtf = amount_sum;
-      this.foreign_bi_igtf = foreign_amount_sum;
-      this.igtf_amount = igtf_amount_sum;
-      this.foreign_igtf_amount = foreign_igtf_amount_sum;
-    }
+
+    this.bi_igtf = bi_igtf;
+    this.foreign_bi_igtf = foreign_bi_igtf;
+    this.igtf_amount = igtf_amount;
+    this.foreign_igtf_amount = foreign_igtf_amount;
     return this.igtf_amount;
   },
-  compute_igtf_amount(amount) {
-    var rounding = this.pos.currency.rounding;
-    return amount * (this.pos.config.igtf_percentage / 100);
+  compute_igtf_amount(amount, use_foreign_rounding = false) {
+    var rounding = use_foreign_rounding ? this.pos.foreign_currency.rounding : this.pos.currency.rounding;
+    return round_pr(amount * (this.pos.config.igtf_percentage / 100), rounding);
   },
 
   get_bi_igtf() {
@@ -281,7 +275,7 @@ patch(Order.prototype, {
   },
   get_max_total_with_igtf() {
     const result =
-      this.compute_igtf_amount(super.get_foreign_total_with_tax()) +
+      this.compute_igtf_amount(super.get_foreign_total_with_tax(), true) +
       this.props.order.get_foreign_rounding_applied();
     return result;
   },
@@ -302,8 +296,11 @@ patch(Order.prototype, {
       is_change = this.get_due() > 0;
     }
 
+    var rounding = this.pos.currency.rounding;
     if (
-      !payment_method.apply_igtf || this.get_due() <= this.get_igtf_amount() || is_change
+      !payment_method.apply_igtf ||
+      round_pr(this.get_due(), rounding) <= round_pr(this.get_igtf_amount(), rounding) ||
+      is_change
     ) {
       let res = super.add_paymentline(...arguments);
       this.update_igtf();

--- a/l10n_ve_pos_igtf/static/src/app/overrides/models/order_model.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/models/order_model.js
@@ -113,22 +113,26 @@ patch(Order.prototype, {
           return true;
         });
 
-        let total_payment_amount = payment_without_change.reduce((acc, p) => acc + p.amount, 0);
-        payment_without_change.forEach((payment) => {
-          let factor = total_payment_amount ? (payment.amount / total_payment_amount) : 0;
-          if (!payment.include_igtf) {
-            payment.set_igtf_amount(igtf_amount * factor);
-            payment.set_foreign_igtf_amount(foreign_igtf_amount * factor);
-            return;
-          }
-          payment.set_igtf_amount(igtf_amount * factor);
-          payment.set_foreign_igtf_amount(foreign_igtf_amount * factor);
-        });
+        if (payment_without_change.length > 0) {
+          payment_without_change.forEach((payment) => {
+            if (!payment.include_igtf) {
+              payment.set_igtf_amount(
+                igtf_amount / payment_without_change.length,
+              );
+              payment.set_foreign_igtf_amount(
+                foreign_igtf_amount / payment_without_change.length,
+              );
+              return;
+            }
+            // payment.set_igtf_amount(igtf_amount / payment_without_change.length)
+            // payment.set_foreign_igtf_amount(foreign_igtf_amount / payment_without_change.length)
+          });
+        }
         return;
       }
 
-      bi_igtf += payment.amount;
-      foreign_bi_igtf += payment.get_foreign_amount();
+      bi_igtf += round_pr(payment.amount, rounding);
+      foreign_bi_igtf += round_pr(payment.get_foreign_amount(), rounding);
       repeat_same_method.push(payment.payment_method.id);
       bi_payments.push(payment.cid);
 
@@ -147,9 +151,9 @@ patch(Order.prototype, {
       }
 
       if (!is_change) {
-        payment.set_igtf_amount(this.compute_igtf_amount(amount_to_pay, false));
+        payment.set_igtf_amount(this.compute_igtf_amount(amount_to_pay));
         payment.set_foreign_igtf_amount(
-          this.compute_igtf_amount(foreign_amount_to_pay, true),
+          this.compute_igtf_amount(foreign_amount_to_pay),
         );
 
         igtf_amount += payment.igtf_amount;
@@ -166,8 +170,8 @@ patch(Order.prototype, {
     ) {
       bi_igtf = this.get_total_without_igtf();
       foreign_bi_igtf = this.get_foreign_total_without_igtf();
-      igtf_amount = this.compute_igtf_amount(bi_igtf, false);
-      foreign_igtf_amount = this.compute_igtf_amount(foreign_bi_igtf, true);
+      igtf_amount = this.compute_igtf_amount(bi_igtf);
+      foreign_igtf_amount = this.compute_igtf_amount(foreign_bi_igtf);
 
       let payment_without_change = paymentlines.filter((payment) => {
         if (!bi_payments.includes(payment.cid)) {
@@ -189,33 +193,36 @@ patch(Order.prototype, {
       });
 
       if (payment_without_change.length > 0) {
-        let remaining_taxable_base = bi_igtf;
         payment_without_change.forEach((payment) => {
-          let allocatable_amount = Math.min(payment.amount, remaining_taxable_base);
-          if (allocatable_amount < 0) {
-            allocatable_amount = 0;
-          }
-          remaining_taxable_base = Math.max(0, remaining_taxable_base - allocatable_amount);
-
           if (!payment.include_igtf) {
             return;
           }
-
-          let ratio = payment.amount ? (allocatable_amount / payment.amount) : 0;
-          payment.set_igtf_amount(this.compute_igtf_amount(allocatable_amount, false));
-          payment.set_foreign_igtf_amount(this.compute_igtf_amount(payment.get_foreign_amount() * ratio, true));
+          // payment.set_igtf_amount(igtf_amount / payment_without_change.length)
+          // payment.set_foreign_igtf_amount(foreign_igtf_amount / payment_without_change.length)
         });
       }
     }
 
+    if (igtf_payment_methods.length > 0) {
+      let amount_sum = 0;
+      let foreign_amount_sum = 0;
+      let igtf_amount_sum = 0;
+      let foreign_igtf_amount_sum = 0;
 
-
-    this.bi_igtf = bi_igtf;
-    this.foreign_bi_igtf = foreign_bi_igtf;
-    this.igtf_amount = igtf_amount;
-    this.foreign_igtf_amount = foreign_igtf_amount;
+      for (let payments of igtf_payment_methods) {
+        amount_sum += payments.amount;
+        foreign_amount_sum += payments.foreign_amount;
+        igtf_amount_sum += payments.igtf_amount;
+        foreign_igtf_amount_sum += payments.foreign_igtf_amount;
+      }
+      this.bi_igtf = amount_sum;
+      this.foreign_bi_igtf = foreign_amount_sum;
+      this.igtf_amount = igtf_amount_sum;
+      this.foreign_igtf_amount = foreign_igtf_amount_sum;
+    }
     return this.igtf_amount;
   },
+
   compute_igtf_amount(amount, use_foreign_rounding = false) {
     var rounding = use_foreign_rounding ? this.pos.foreign_currency.rounding : this.pos.currency.rounding;
     return round_pr(amount * (this.pos.config.igtf_percentage / 100), rounding);

--- a/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_status.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_status.js
@@ -5,6 +5,7 @@ import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { patch } from "@web/core/utils/patch";
 import {
   roundPrecision as round_pr,
+  roundDecimals as round_di,
 } from "@web/core/utils/numbers";
 
 
@@ -58,7 +59,7 @@ patch(PaymentScreenStatus.prototype, {
   },
   get suggestedIgtf() {
     var rounding = this.pos.currency.rounding;
-    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), 4);
+    var result = round_di(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), 4);
     return this.env.utils.formatCurrency(result);
   },
   get foreignTotalDueTextWithIGTF() {
@@ -81,7 +82,7 @@ patch(PaymentScreenStatus.prototype, {
   },
   get totalDueTextWithIGTFDisplay() {
     var rounding = this.pos.currency.rounding;
-    var result = round_pr(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), 4);
+    var result = round_di(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), rounding);
     return this.env.utils.formatCurrency(
       (this.props.order.get_total_with_tax() + result)
     );


### PR DESCRIPTION
Se hacen mejoras en los calculos de redondeo,ya no se usa 4 como valor
quemado.
Segun sea el caso de usara la precision decimal de la moneda,de la
moneda foranea o del precio/precio alterno segun sea necesario.

references: https://binaural.odoo.com/odoo/helpdesk.ticket/10725