### PR TITLE
fix(l10n_ve_pos):corrige total del reporte de ventas POS #12906

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.10",
+    "version": "17.0.0.0.11",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/report/report_saledetails.py
+++ b/l10n_ve_pos/report/report_saledetails.py
@@ -145,18 +145,18 @@ class ReportSaleDetails(models.AbstractModel):
             )
             payments = []
             for payment in self.env.cr.dictfetchall():
-                total = payment.get("total") or 0.0
-                f_total = payment.get("f_total") or 0.0
+                payment_total = payment.get("total") or 0.0
+                payment_f_total = payment.get("f_total") or 0.0
                 try:
-                    total = float(total)
+                    payment_total = float(payment_total)
                 except (TypeError, ValueError):
-                    total = 0.0
+                    payment_total = 0.0
                 try:
-                    f_total = float(f_total)
+                    payment_f_total = float(payment_f_total)
                 except (TypeError, ValueError):
-                    f_total = 0.0
-                payment["total"] = total
-                payment["f_total"] = f_total
+                    payment_f_total = 0.0
+                payment["total"] = payment_total
+                payment["f_total"] = payment_f_total
                 payments.append(payment)
         else:
             payments = []


### PR DESCRIPTION
-Ajustar error en cálculo de total de ventas de caja que toma monto del último método de pago del resumen, en lugar del total sumado de todos los métodos de pago
- Evita sobrescribir los acumulados generales al iterar métodos de pago. Usa variables locales por método (payment_total y payment_f_total). Corrige Total y Total Alterno para que reflejen la suma de todos los métodos de pago. -
- https://binaural.odoo.com/odoo/my-tickets/12906