### PR TITLE
[FIX] l10n_ve_invoice_loyalty: evitar import de tests

### DIFF
--- a/l10n_ve_invoice_loyalty/__init__.py
+++ b/l10n_ve_invoice_loyalty/__init__.py
@@ -1,2 +1,1 @@
 from . import models
-from . import tests


### PR DESCRIPTION
## Summary
- Elimina `from . import tests` de `l10n_ve_invoice_loyalty/__init__.py`
- Evita que Odoo cargue `odoo.tests` durante el arranque normal del addon
- Previene el mismo error de despliegue en Odoo.sh si ese modulo se carga en staging

## Cambios
| Archivo | Cambio |
|------|--------|
| `l10n_ve_invoice_loyalty/__init__.py` | Se elimina el import de `tests` en carga normal |

## Validacion
- Se detecto el mismo antipatron al revisar los `__init__.py` de addons
- Se confirmo que el modulo no debe importar tests desde negocio

## Referencias
- Ticket: none
- Tarea: none