### PR TITLE
 Generación errónea de asientos automáticos de Diferencial Cambiario sin origen identificado

### DIFF
--- a/l10n_ve_accountant/models/__init__.py
+++ b/l10n_ve_accountant/models/__init__.py
@@ -10,5 +10,5 @@ from . import account_payment_term
 from . import tax_unit
 from . import res_currency
 from . import fields
-
+from . import bank_rec_widget
 # from . import account_journal # ESTA HERENCIA NO SE IMPORTARÁ PORQUE ESTÁ GENERANDO ERROR, AL SOLUCIONAR, VOLVER A AGREGAR EN EN IMPORT

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -742,8 +742,8 @@ class AccountMove(models.Model):
         """
         for move in self:
             move.foreign_taxable_income = False
-            if move.is_invoice() and move.invoice_line_ids:
-                move.foreign_taxable_income = move.tax_totals["foreign_amount_untaxed"]
+            if move.is_invoice() and move.invoice_line_ids and isinstance(move.tax_totals, dict):
+                move.foreign_taxable_income = move.tax_totals.get("foreign_amount_untaxed", 0.0)
 
     @api.depends("tax_totals")
     def _compute_foreign_total_billed(self):

--- a/l10n_ve_accountant/models/bank_rec_widget.py
+++ b/l10n_ve_accountant/models/bank_rec_widget.py
@@ -1,0 +1,51 @@
+from odoo import models, api, Command
+from odoo.tools import float_round, float_is_zero
+
+class BankRecWidget(models.Model):
+    _inherit = 'bank.rec.widget'
+    
+    def _action_validate(self):
+        """
+        Extends the validation process to handle rounding discrepancies 
+        between the bank statement line and the selected payments/invoices.
+        It ensures the move is perfectly balanced before calling the 
+        standard Odoo validation logic.
+            The main idea is:
+            1. Round all lines to the currency precision immediately.
+            2. Calculate the total balance after rounding.
+            3. If there's a discrepancy, adjust the bank (liquidity) line to absorb it.
+            4. Then call the original validation method, which will now work with perfectly rounded values.
+            This way, we avoid any issues with Odoo's internal checks that expect a balanced move.
+        """
+        self.ensure_one()
+        # Use the currency of the company to define rounding precision
+        #STEP 0: Get the company currency for rounding purposes
+        company_currency = self.st_line_id.company_id.currency_id
+
+        # STEP 1: "Clean" all lines. Convert 377.495 into 377.50 immediately.
+        # This matches your loop in the long code where you rounded every 'v'.
+        for line in self.line_ids:
+            line.balance = float_round(line.balance, precision_rounding=company_currency.rounding)
+            if line.currency_id == company_currency:
+                line.amount_currency = line.balance
+
+        # STEP 2: Calculate the real discrepancy after rounding
+        total_balance = sum(line.balance for line in self.line_ids if line.flag != 'exchange_diff')
+
+        # STEP 3: Force the bank (liquidity) line to absorb the difference
+        if not float_is_zero(total_balance, precision_rounding=company_currency.rounding):
+            liquidity_line = self.line_ids.filtered(lambda l: l.flag == 'liquidity')
+            if liquidity_line:
+                # If bank was 1000.0 but payments sum 1000.01, this sets bank to 1000.01
+                liquidity_line.balance = float_round(
+                    liquidity_line.balance - total_balance, 
+                    precision_rounding=company_currency.rounding
+                )
+                if liquidity_line.currency_id == company_currency:
+                    liquidity_line.amount_currency = liquidity_line.balance
+
+        # STEP 4: Call the original Odoo function. 
+        return super(BankRecWidget, self)._action_validate()
+
+    
+    


### PR DESCRIPTION
[FIX] l10nve_accountant: Generación errónea de asientos automáticos de Diferencial Cambiario sin origen identificado

Criterio:
- En la version 17 del sistema los montos redondeados en los asientos se eliminaron para garantizar que exista la mayor cantidad de numeros para que al momento de realizar conversiones entre monedas diferentes no  se generen diferenciales por perdida o ganancia por errores de redondeo, esto es a nivel de base de datos y de cache, a nivel visual de igual forma se respeta la precisiones decimales configuradas.

Como consecuencia cuando se calcula un monto de bolivares a dolares o biceversa el sistema en la UI redondea el monto(hacia arriba simpre) pero a nivel de base de datos los montos se mantienen sin redondeo: EJ : 450.7999999 = 450.80 en base de datos permanecen la mayoria de los digitos lo q garantiza q la conversion en reversa genere el mismo monto y existan errores.

Al realizar esto se detecto que al momento de realizar la consilicacion cuando un monto en base de datos en menor a su valor redondeado ingresado en el estracto bancario(EJ:  450.7999999$ = 450.80$  ) el sistema trata de cerrar la conciliacion generando esa diferencia por 0.01$ en un asiento de diferencial cambiario por perdida o ganancia.

Para prevenir esto se ajusto la diferencia al momento de validar un estracto bancario (conciliar) ya que en dicho momento es donde se ajustan los montos para conciliar.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/12989
- Tarea:
- PR:
- Otros: