### PR TITLE
[FIX] l10n_ve_pos, l10n_ve_pos_igtf: Corrige IGTF en PoS con doble moneda

### DIFF
--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -131,27 +131,27 @@ patch(Order.prototype, {
   },
   /* ---- Payment Status --- */
   get_foreign_subtotal() {
-    return round_di(
+    return round_pr(
       this.orderlines.reduce(function (sum, orderLine) {
         return sum + orderLine.get_display_foreign_price();
       }, 0),
-      this.pos.foreign_currency.rounding,
+      this.pos.foreign_currency.rounding || 0.01,
     );
   },
   get_foreign_total_with_tax() {
     return this.get_foreign_total_without_tax() + this.get_foreign_total_tax();
   },
   get_foreign_total_without_tax() {
-    return round_di(
+    return round_pr(
       this.orderlines.reduce(function (sum, orderLine) {
         return sum + orderLine.get_foreign_price_without_tax();
       }, 0),
-      this.pos.foreign_currency.rounding
+      this.pos.foreign_currency.rounding,
     );
   },
   get_foreign_total_discount() {
     const ignored_product_ids = this._get_ignored_product_ids_total_discount();
-    return round_di(
+    return round_pr(
       this.orderlines.reduce((sum, orderLine) => {
         if (!ignored_product_ids.includes(orderLine.product.id)) {
           sum +=
@@ -167,7 +167,7 @@ patch(Order.prototype, {
         }
         return sum;
       }, 0),
-      this.pos.foreign_currency.rounding,
+      this.pos.foreign_currency.rounding || 0.01,
     );
   },
   get_foreign_total_tax() {
@@ -324,7 +324,8 @@ patch(Order.prototype, {
       if (!only_cash || (only_cash && last_line_is_cash)) {
         var rounding_method = this.pos.cash_rounding[0].rounding_method;
         var remaining =
-          this.get_foreign_total_with_tax() - this.get_total_paid();
+this.get_foreign_total_with_tax() -
+            this.get_foreign_total_paid();
         var sign = this.get_foreign_total_with_tax() > 0 ? 1.0 : -1.0;
         if (
           ((this.get_foreign_total_with_tax() < 0 && remaining > 0) ||
@@ -391,22 +392,23 @@ patch(Order.prototype, {
   },
 
   get_foreign_total_paid() {
-    return round_di(
+    const result = round_pr(
       this.paymentlines.reduce(function (sum, paymentLine) {
         if (paymentLine.is_done()) {
           sum += paymentLine.get_foreign_amount();
         }
         return sum;
       }, 0),
-      this.pos.foreign_currency.rounding,
+      this.pos.foreign_currency.rounding || 0.01,
     );
+    return result;
   },
   get_foreign_change(paymentline) {
     if (!paymentline) {
       var change =
-        this.get_foreign_total_paid() -
-        this.get_foreign_total_with_tax() -
-        this.get_rounding_applied();
+this.get_foreign_total_paid() -
+            this.get_foreign_total_with_tax() -
+            this.get_foreign_rounding_applied();
     } else {
       change = -this.get_foreign_total_with_tax();
       var lines = this.paymentlines;
@@ -419,12 +421,12 @@ patch(Order.prototype, {
     }
     return round_pr(Math.max(0, change), this.pos.foreign_currency.rounding);
   },
-  get_foreign_due(paymentline) {
+get_foreign_due(paymentline) {
     if (!paymentline) {
       var due =
-        this.get_foreign_total_with_tax() -
-        this.get_foreign_total_paid() +
-        this.get_rounding_applied();
+this.get_foreign_total_with_tax() -
+            this.get_foreign_total_paid() +
+            this.get_foreign_rounding_applied();
     } else {
       due = this.get_foreign_total_with_tax();
       var lines = this.paymentlines;

--- a/l10n_ve_pos/static/src/overrides/models/orderline_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/orderline_model.js
@@ -112,6 +112,7 @@ patch(Orderline.prototype, {
       qty,
       this.pos.foreign_currency.rounding,
     );
+
     all_taxes.taxes.forEach(function (tax) {
       taxtotal += tax.amount;
       taxdetail[tax.id] = {

--- a/l10n_ve_pos/static/src/overrides/screens/payment_status/payment_status.js
+++ b/l10n_ve_pos/static/src/overrides/screens/payment_status/payment_status.js
@@ -8,7 +8,7 @@ patch(PaymentScreenStatus.prototype, {
 
     if (igtf_payment_methods.length > 0) {
       return this.env.utils.formatForeignCurrency(
-        this.props.order.get_foreign_total_with_tax() + this.props.order.get_foreign_rounding_applied() + this.props.order.get_foreign_igtf_amount()
+        this.props.order.get_foreign_total_with_tax() + this.props.order.get_foreign_rounding_applied()
       );
     } else {
       return this.env.utils.formatForeignCurrency(

--- a/l10n_ve_pos_igtf/__manifest__.py
+++ b/l10n_ve_pos_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.0.0.2",
+    "version": "17.0.1.0.0",
     "depends": [
         "base",
         "l10n_ve_pos",

--- a/l10n_ve_pos_igtf/models/pos_payment.py
+++ b/l10n_ve_pos_igtf/models/pos_payment.py
@@ -57,10 +57,9 @@ class PosPayment(models.Model):
                 payment.payment_date,
             )
             amount_igtf = payment.igtf_amount
-                
+
             if payment.include_igtf:
                 if not (amounts["amount"] - amount_igtf == 0):
-                    amount_without_igtf = payment.foreign_amount - payment.foreign_igtf_amount
                     add_credit_line_vals = pos_session._credit_amounts(
                         {
                             "account_id": accounting_partner.with_company(
@@ -68,7 +67,6 @@ class PosPayment(models.Model):
                             ).property_account_receivable_id.id,
                             "partner_id": accounting_partner.id,
                             "move_id": payment_move.id,
-                            
                         },
                         amounts["amount"] - amount_igtf,
                         amounts["amount_converted"] - amount_igtf,
@@ -79,7 +77,6 @@ class PosPayment(models.Model):
                         "account_id": self.env.company.customer_account_igtf_id.id,
                         "partner_id": accounting_partner.id,
                         "move_id": payment_move.id,
-                        
                     },
                     amount_igtf,
                     amount_igtf,
@@ -89,10 +86,9 @@ class PosPayment(models.Model):
                     {
                         "account_id": accounting_partner.with_company(
                             order.company_id
-                        ).property_account_receivable_id.id,  # The field being company dependant, we need to make sure the right value is received.
+                        ).property_account_receivable_id.id,
                         "partner_id": accounting_partner.id,
                         "move_id": payment_move.id,
-                       
                     },
                     amounts["amount"],
                     amounts["amount_converted"],
@@ -115,19 +111,34 @@ class PosPayment(models.Model):
                     "partner_id": accounting_partner.id
                     if is_split_transaction and is_reverse
                     else False,
-                    
                 },
                 amounts["amount"],
                 amounts["amount_converted"],
             )
 
             if add_credit_line_vals:
-                self.env["account.move.line"].with_context(check_move_validity=False).create(
+                receivable_line = self.env["account.move.line"].with_context(check_move_validity=False).create(
                     [add_credit_line_vals]
                 )
+                receivable_line.not_foreign_recalculate = True
+                receivable_line.foreign_credit = abs(payment.foreign_amount - payment.foreign_igtf_amount)
 
-            self.env["account.move.line"].with_context(check_move_validity=False).create(
+            other_lines = self.env["account.move.line"].with_context(check_move_validity=False).create(
                 [credit_line_vals, debit_line_vals]
             )
+            igtf_or_receivable_line = other_lines[0]
+            debit_line = other_lines[1]
+
+            # Setear Bs correctos en la línea de débito (CUENTA POR COBRAR POS)
+            debit_line.not_foreign_recalculate = True
+            debit_line.foreign_debit = abs(payment.foreign_amount)
+
+            # Setear Bs correctos en crédito IGTF o cuenta por cobrar (pago sin IGTF split)
+            igtf_or_receivable_line.not_foreign_recalculate = True
+            if payment.include_igtf:
+                igtf_or_receivable_line.foreign_credit = abs(payment.foreign_igtf_amount)
+            else:
+                igtf_or_receivable_line.foreign_credit = abs(payment.foreign_amount)
+
             payment_move._post()
         return result

--- a/l10n_ve_pos_igtf/static/src/app/overrides/models/order_model.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/models/order_model.js
@@ -132,7 +132,7 @@ patch(Order.prototype, {
       }
 
       bi_igtf += round_pr(payment.amount, rounding);
-      foreign_bi_igtf += round_pr(payment.get_foreign_amount(), rounding);
+      foreign_bi_igtf += round_pr(payment.get_foreign_amount(), this.pos.foreign_currency.rounding);
       repeat_same_method.push(payment.payment_method.id);
       bi_payments.push(payment.cid);
 
@@ -153,7 +153,7 @@ patch(Order.prototype, {
       if (!is_change) {
         payment.set_igtf_amount(this.compute_igtf_amount(amount_to_pay));
         payment.set_foreign_igtf_amount(
-          this.compute_igtf_amount(foreign_amount_to_pay),
+          this.compute_igtf_amount(foreign_amount_to_pay, true),
         );
 
         igtf_amount += payment.igtf_amount;
@@ -218,6 +218,10 @@ patch(Order.prototype, {
       this.bi_igtf = amount_sum;
       this.foreign_bi_igtf = foreign_amount_sum;
       this.igtf_amount = igtf_amount_sum;
+
+      // Usamos el IGTF acumulado por pago (no el de la base total del pedido).
+      // Para pago parcial: 153,24 Bs (3% de $10 pagado).
+      // Para pago total: 529,71 Bs (3% de 17.657,06 Bs, calculado en el loop).
       this.foreign_igtf_amount = foreign_igtf_amount_sum;
     }
     return this.igtf_amount;
@@ -304,6 +308,15 @@ patch(Order.prototype, {
     }
 
     var rounding = this.pos.currency.rounding;
+    // Capturar ANTES de super.add_paymentline() porque después get_due() = 0
+    const due_before = round_pr(this.get_due(), rounding);
+    const igtf_before = round_pr(this.get_igtf_amount(), rounding);
+    // Contar pagos no-IGTF existentes ANTES de añadir el nuevo.
+    // Solo el primero (EFECTIVO BS) debe pre-fillarse con el monto IGTF.
+    const non_igtf_count_before = this.get_paymentlines().filter(
+      (p) => !p.payment_method.apply_igtf
+    ).length;
+
     if (
       !payment_method.apply_igtf ||
       round_pr(this.get_due(), rounding) <= round_pr(this.get_igtf_amount(), rounding) ||
@@ -311,12 +324,28 @@ patch(Order.prototype, {
     ) {
       let res = super.add_paymentline(...arguments);
       this.update_igtf();
+      if (
+        res &&
+        !payment_method.apply_igtf &&
+        !is_change &&
+        this.get_paymentlines().some((p) => p.payment_method.apply_igtf)
+      ) {
+        // Odoo base pre-fill amount = get_due() (antes de añadir = $24,87).
+        // EFECTIVO BS solo cubre el IGTF ($0,30). Corregimos usando due_before.
+        // Solo lo hacemos para el PRIMER pago no-IGTF.
+        if (due_before >= igtf_before && non_igtf_count_before === 0) {
+          res.set_amount(this.get_igtf_amount());
+          // Asignación directa para evitar que el setter dispare reconversiones locas
+          res.foreign_amount = this.get_foreign_igtf_amount();
+        }
+      }
       return res;
     }
     let res_igtf = this.add_paymentline_without_igtf(...arguments);
     this.update_igtf();
     return res_igtf;
   },
+
 
   add_paymentline_without_igtf(payment_method) {
     this.assert_editable();

--- a/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_screen.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_screen.js
@@ -6,10 +6,11 @@ import { patch } from "@web/core/utils/patch";
 // New orders are now associated with the current table, if any.
 patch(PaymentScreen.prototype, {
 
-  addNewPaymentLine(paymentMethod) {
+addNewPaymentLine(paymentMethod) {
     let res = super.addNewPaymentLine(...arguments);
-      this.pos.get_order().update_igtf()
-     
+    // update_igtf() already called inside Order.add_paymentline()
+    // No need to call it again — double invocation causes incorrect
+    // last_igtf_amount comparisons and unnecessary recalculation.
     this.render();
     return res
   },

--- a/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_status.js
+++ b/l10n_ve_pos_igtf/static/src/app/overrides/screens/payment_status.js
@@ -58,13 +58,12 @@ patch(PaymentScreenStatus.prototype, {
     return this.env.utils.formatCurrency(igtfAmount, 'Product Price');
   },
   get suggestedIgtf() {
-    var rounding = this.pos.currency.rounding;
-    var result = round_di(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), 4);
-    return this.env.utils.formatCurrency(result);
+    return this.env.utils.formatCurrency(this.props.order.get_igtf_amount());
   },
   get foreignTotalDueTextWithIGTF() {
     return this.env.utils.formatForeignCurrency(
-      (this.props.order.get_foreign_total_with_tax() * ((this.pos.config.igtf_percentage / 100) + 1)) + this.props.order.get_foreign_rounding_applied()
+      this.props.order.get_foreign_total_with_tax() +
+        this.props.order.get_foreign_rounding_applied(),
     );
   },
   get totalDueTextWithIGTF() {
@@ -81,10 +80,8 @@ patch(PaymentScreenStatus.prototype, {
     }
   },
   get totalDueTextWithIGTFDisplay() {
-    var rounding = this.pos.currency.rounding;
-    var result = round_di(this.props.order.get_total_with_tax() * (this.pos.config.igtf_percentage / 100), rounding);
     return this.env.utils.formatCurrency(
-      (this.props.order.get_total_with_tax() + result)
+      this.props.order.get_total_with_tax()
     );
   },
   get totalDueText() {


### PR DESCRIPTION
- round_di() reemplazado por round_pr() con fallback || 0.01 en get_foreign_subtotal, get_foreign_total_without_tax, get_foreign_total_discount y get_foreign_total_paid: round_di recibía un factor monetario (0.01) como si fueran decimal places, redondeando a entero y generando un adeudado alterno fantasma al pagar parcialmente con IGTF.

- get_foreign_due() y get_foreign_change() usaban get_rounding_applied() (moneda compañía) en cálculos de moneda foránea. Corregido a get_foreign_rounding_applied().

- get_foreign_rounding_applied() restaba get_total_paid() (compañía) de get_foreign_total_with_tax() (foránea). Corregido a get_foreign_total_paid().

- update_igtf(): compute_igtf_amount() ahora recibe use_foreign_rounding para montos en moneda foránea. foreign_bi_igtf usa foreign_currency.rounding en vez de currency.rounding.

- add_paymentline(): al añadir un método no-IGTF existiendo ya un pago IGTF, solo el primer pago no-IGTF recibe el monto del IGTF como pre-fill. Se capturan due_before, igtf_before y non_igtf_count_before antes de super.add_paymentline() para evitar valores inválidos.

- payment_screen: removida llamada duplicada a update_igtf() en addNewPaymentLine (ya se ejecuta dentro de add_paymentline).

- PaymentScreenStatus: corregida doble suma de IGTF en displays totalDueTextWithIGTFDisplay, foreignTotalDueTextWithIGTF, foreignTotalDueText y suggestedIgtf.

- pos_payment.py: líneas de account.move.line creadas con not_foreign_recalculate=True y foreign_credit/foreign_debit explícitos para que el backoffice refleje los mismos montos en moneda foránea calculados en el PoS, evitando que Odoo los recalcule incorrectamente.

References: https://binaural.odoo.com/odoo/helpdesk.ticket/13027