### PR TITLE
FEAT#70274 Add dependency filter partner in invoice

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -14,6 +14,7 @@
         "l10n_ve_accountant",
         "l10n_ve_contact",
         "l10n_ve_tax",
+        "l10n_ve_filter_partner",
         "od_journal_sequence",
         "account_debit_note",
     ],

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 class AccountMove(models.Model):
     _name = "account.move"
-    _inherit = "account.move"
+    _inherit = ["account.move", "filter.partner.mixin"]
 
     correlative = fields.Char("Control Number", copy=False, help="Sequence control number")
     declaration_unique_of_customs = fields.Char('Declaration unique of customs', copy=False)


### PR DESCRIPTION
Se agrega dependencia de Filter Partner en l10n_ve_invoice por error presentado al momento de abrir facturas de clientes, ya que existe campo relacionado con filter partner, pero no se podia acceder al mismo por que no estaba en las dependencias del modulo.

Tarea: https://binaural.odoo.com/odoo/project.task/70274