### PR TITLE
[FEAT] l10n_ve_stock_account: permitir edición de guía de despacho en traslados entre almacenes

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "19.0.1.1.4",
+    "version": "19.0.2.0.0",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -101,6 +101,11 @@ class StockPicking(models.Model):
         tracking=True,
         store=True,
         compute="_compute_is_dispatch_guide",
+        inverse="_inverse_is_dispatch_guide",
+    )
+    is_transfer_between_warehouses = fields.Boolean(
+        compute="_compute_is_transfer_between_warehouses",
+        store=True,
     )
     partner_required = fields.Boolean(compute='_compute_partner_required', store=True)
     
@@ -1051,6 +1056,33 @@ class StockPicking(models.Model):
                 )
             ):
                 picking.is_dispatch_guide = True
+
+    def _inverse_is_dispatch_guide(self):
+        """Permite editar manualmente is_dispatch_guide para traslados entre almacenes."""
+        for picking in self:
+            transfer_between_warehouses_reason = self.env.ref(
+                "l10n_ve_stock_account.transfer_reason_transfer_between_warehouses",
+                raise_if_not_found=False,
+            )
+            if (
+                picking.operation_code == "internal"
+                and picking.transfer_reason_id == transfer_between_warehouses_reason
+            ):
+                continue
+            # Para otros casos, no permitir cambios manuales
+            # El compute se encarga de establecer el valor correcto
+
+    @api.depends("transfer_reason_id")
+    def _compute_is_transfer_between_warehouses(self):
+        transfer_between_warehouses_reason = self.env.ref(
+            "l10n_ve_stock_account.transfer_reason_transfer_between_warehouses",
+            raise_if_not_found=False,
+        )
+        for picking in self:
+            picking.is_transfer_between_warehouses = (
+                transfer_between_warehouses_reason
+                and picking.transfer_reason_id == transfer_between_warehouses_reason
+            )
 
     @api.depends(
         "is_donation", "is_dispatch_guide", "operation_code", "location_dest_id"

--- a/l10n_ve_stock_account/views/stock_picking_views.xml
+++ b/l10n_ve_stock_account/views/stock_picking_views.xml
@@ -49,7 +49,7 @@
                 <field
                     name="is_dispatch_guide"
                     invisible="operation_code != 'internal' and operation_code != 'outgoing'"
-                    readonly="operation_code != 'internal' or not is_transfer_between_warehouses"  />
+                    readonly="operation_code != 'internal' or not is_transfer_between_warehouses or state == 'done'"  />
                 <field name="is_consignment_readonly" invisible="1"/>
                 <field 
                     name="transfer_reason_id"

--- a/l10n_ve_stock_account/views/stock_picking_views.xml
+++ b/l10n_ve_stock_account/views/stock_picking_views.xml
@@ -45,10 +45,11 @@
             </xpath>
             <xpath expr="//field[@name='origin']" position="after">
                 <field name="is_consignment" invisible="1" />
-                <field 
+                <field name="is_transfer_between_warehouses" invisible="1" />
+                <field
                     name="is_dispatch_guide"
                     invisible="operation_code != 'internal' and operation_code != 'outgoing'"
-                    readonly="1" />
+                    readonly="operation_code != 'internal' or not is_transfer_between_warehouses"  />
                 <field name="is_consignment_readonly" invisible="1"/>
                 <field 
                     name="transfer_reason_id"


### PR DESCRIPTION
- Se agrega el campo 'is_transfer_between_warehouses' para identificar traslados internos específicos.
- Se implementa un método inverse en 'is_dispatch_guide' para permitir su edición manual cuando se trata de traslados entre almacenes.
- Se ajusta la vista de picking para habilitar la edición del campo bajo la condición mencionada.
- Se incrementa la versión del módulo a 19.0.2.0.0.

References:
- Ticket: https://www.binauraldev.com/odoo/helpdesk/58/tickets/13129