### PR TITLE
Sobreposición de texto en impresión de Comprobante de Retención de IVA o ISLR por números extendidos

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.28",
+    "version": "17.0.0.0.29",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/report/retention_voucher_templates.xml
+++ b/l10n_ve_payment_extension/report/retention_voucher_templates.xml
@@ -116,33 +116,19 @@
         </div>
 
         <style>
-        .ret-table { width:100%; table-layout:fixed; border-collapse:separate; border-spacing:0; box-sizing:border-box; font-family:sans-serif; -webkit-print-color-adjust:exact; -webkit-font-smoothing:antialiased; }
-        .ret-table col { box-sizing:border-box; }
-        .ret-table th, .ret-table td { border:none !important; padding:4px 6px; vertical-align:middle; font-size:10px; }
-        .ret-left { text-align:left; }
-        .ret-num { text-align:right; }
-        .no-wrap { white-space:nowrap; }
-        .ret-num span { display:inline-block; }
-        .sep-cell { padding:0; }
+            .ret-table { width:100%; table-layout:auto; border-collapse:separate; border-spacing:0; box-sizing:border-box; font-family:sans-serif; -webkit-print-color-adjust:exact; -webkit-font-smoothing:antialiased; }
+            .ret-table col { box-sizing:border-box; }
+            .ret-table th, .ret-table td { border:none !important; padding:4px 6px; vertical-align:middle; font-size:10px; }
+            .ret-left { text-align:left; }
+            .ret-num { text-align:right; }
+            .no-wrap { white-space:nowrap; }
+            .ret-num span { display:inline-block; }
+            .sep-cell { padding:0; }
         </style>
 
         <table class="ret-table" role="presentation" aria-hidden="true">
             <colgroup>
-                <col style="width:60px"/>   <!-- 1 Fecha Factura -->
-                <col style="width:60px"/>   <!-- 2 Número de Factura -->
-                <col style="width:70px"/>   <!-- 3 Nro de Control Factura -->
-                <col style="width:70px"/>   <!-- 4 Nota de Débito -->
-                <col style="width:70px"/>   <!-- 5 Nota de Crédito -->
-                <col style="width:80px"/>   <!-- 6 Tipo de Transacción -->
-                <col style="width:90px"/>   <!-- 7 Factura afectada -->
-                <col style="width:110px"/>  <!-- 8 Total Compras Incluyendo el IVA -->
-                <col style="width:100px"/>  <!-- 9 Compras sin derecho a Crédito IVA -->
-                <col style="width:100px"/>  <!-- 10 Base Imponible -->
-                <col style="width:60px"/>   <!-- 11 % Alic -->
-                <col style="width:60px"/>   <!-- 12 % Ret -->
-                <col style="width:90px"/>   <!-- 13 Impuesto IVA -->
-                <col style="width:110px"/>  <!-- 14 IVA Retenido -->
-            </colgroup>
+                <col style="width: 7%"/>   <col style="width: 11%"/>  <col style="width: 11%"/>  <col style="width: 6%"/>   <col style="width: 6%"/>   <col style="width: 7%"/>   <col style="width: 7%"/>   <col style="width: 9%"/>   <col style="width: 8%"/>   <col style="width: 9%"/>   <col style="width: 4%"/>   <col style="width: 4%"/>   <col style="width: 8%"/>   <col style="width: 10%"/>  </colgroup>
 
             <thead style="font-size:12px;">
                 <tr>
@@ -183,13 +169,14 @@
                     <tr>
                         <!-- 1 Fecha Factura -->
                         <td class="ret-left">
+
                             <t t-if="line.move_id.invoice_date"><span t-esc="line.move_id.invoice_date.strftime('%d/%m/%Y')"/></t><t t-else="">--</t>
                         </td>
 
                         <!-- 2 Número de Factura -->
                         <td class="ret-num">
                             <t t-if="line.move_id.move_type in ['out_invoice','out_contingence','in_invoice'] and not line.move_id.journal_id.is_debit">
-                                <span t-esc="line.move_id.name"/>
+                                <span t-esc="line.move_id.name"/> 
                             </t>
                             <t t-else="">--</t>
                         </td>
@@ -525,7 +512,7 @@
 
         <!-- Tabla de retenciones -->
         <style>
-            .ret-table { width:100%; table-layout:fixed; border-collapse:separate; border-spacing:0; box-sizing:border-box; font-family:sans-serif; -webkit-print-color-adjust:exact; -webkit-font-smoothing:antialiased; }
+            .ret-table { width:100%; table-layout:auto; border-collapse:separate; border-spacing:0; box-sizing:border-box; font-family:sans-serif; -webkit-print-color-adjust:exact; -webkit-font-smoothing:antialiased; }
             .ret-table col { box-sizing:border-box; }
             .ret-table th, .ret-table td { border:none !important; padding:4px 6px; vertical-align:middle; font-size:10px; }
             .ret-left { text-align:left; }
@@ -542,17 +529,7 @@
 
         <table class="ret-table" role="presentation" aria-hidden="true">
             <colgroup>
-                <col style="width:60px"/>   <!-- TD -->
-                <col style="width:60px"/>   <!-- Fact Nro -->
-                <col style="width:70px"/>   <!-- Nro de Control -->
-                <col style="width:70px"/>   <!-- Fecha -->
-                <col style="width:260px"/>  <!-- Concepto -->
-                <col style="width:90px"/>   <!-- Total Factura -->
-                <col style="width:90px"/>   <!-- Base de Retención -->
-                <col style="width:70px"/>   <!-- Tarifa Ret -->
-                <col style="width:80px"/>   <!-- Sustraendo -->
-                <col style="width:110px"/>  <!-- Imp Retenido -->
-            </colgroup>
+                <col style="width: 7%"/>   <col style="width: 11%"/>  <col style="width: 11%"/>  <col style="width: 6%"/>   <col style="width: 6%"/>   <col style="width: 7%"/>   <col style="width: 7%"/>   <col style="width: 9%"/>   <col style="width: 8%"/>   <col style="width: 9%"/>   <col style="width: 4%"/>   <col style="width: 4%"/>   <col style="width: 8%"/>   <col style="width: 10%"/>  </colgroup>
 
             <thead>
                 <tr>


### PR DESCRIPTION
[FIX] l10n_ve_payment_extension(s):Sobreposición de texto en impresión de Comprobante de Retención de IVA o ISLR por números extendidos

- Se Ajustan los stylos en las tablas templates del comprobante de retenciones de IVA e ISLR

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-390/13123
- Tarea:
- PR:
- Otros: