### PR TITLE
FIX #12687: l10n_ve_contact

### DIFF
--- a/l10n_ve_contact/__manifest__.py
+++ b/l10n_ve_contact/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Contacts/Contacts",
-    "version": "17.0.0.0.5",
+    "version": "17.0.0.0.6",
     "depends": ["base", "contacts", "l10n_ve_rate", "l10n_ve_location"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_ve_contact/models/res_partner.py
+++ b/l10n_ve_contact/models/res_partner.py
@@ -121,12 +121,18 @@ class ResPartner(models.Model):
             if existing_partner:
                 raise ValidationError(error_message)
 
-    def check_duplicate_email(self, email, company_id=None):
+    def check_duplicate_email(self, email, company_id=None, parent_id=False):
         if email:
             domain = [
                 ("email", "=", email),
                 ("id", "!=", self.id if self else False),
             ]
+
+            if parent_id:
+                domain.extend([
+                    ("id", "!=", parent_id),
+                    ("parent_id", "!=", parent_id)
+                ])
 
             if self.env.company.validate_user_creation_by_company:
                 domain.extend(
@@ -176,7 +182,7 @@ class ResPartner(models.Model):
             if "vat" and "prefix_vat" in vals:
                 self.check_duplicate_vat(vals.get("prefix_vat"), vals.get("vat"))
             if "email" in vals:
-                self.check_duplicate_email(vals.get("email"))
+                self.check_duplicate_email(vals.get("email"), parent_id=vals.get("parent_id"))
         return super(ResPartner, self).create(vals_list)
 
     def write(self, vals):
@@ -186,7 +192,8 @@ class ResPartner(models.Model):
                 record.check_duplicate_vat(vals.get("prefix_vat"), vals.get("vat"))
         if "email" in vals:
             for record in self:
-                record.check_duplicate_email(vals.get("email"))
+                actual_parent_id = vals.get("parent_id", record.parent_id.id)
+                record.check_duplicate_email(vals.get("email"), parent_id=actual_parent_id)
         return res
 
     def _check_vat(self):

--- a/l10n_ve_contact/tests/test_l1on_ve_contact.py
+++ b/l10n_ve_contact/tests/test_l1on_ve_contact.py
@@ -18,6 +18,15 @@ class TestResPartner(TransactionCase):
             "country_id": self.env.ref("base.ve").id,
         })
 
+        self.partner_company = self.env["res.partner"].create({
+            "name": "Empresa Principal, C.A.",
+            "is_company": True,
+            "prefix_vat": "J",
+            "vat": "312345678",
+            "email": "contacto@empresatest.com",
+            "country_id": self.env.ref("base.ve").id,
+        })
+
     def test_duplicate_vat(self):
         with self.assertRaises(ValidationError):
             self.env["res.partner"].create({
@@ -28,15 +37,71 @@ class TestResPartner(TransactionCase):
                 "country_id": self.env.ref("base.ve").id,
             })
 
-    def test_duplicate_email(self):
+    def test_duplicate_email_unrelated_partners(self):
+        """Validar que dos contactos independientes NO puedan tener el mismo correo"""
         with self.assertRaises(ValidationError):
             self.env["res.partner"].create({
-                "name": "Other",
+                "name": "Cliente Ajeno",
                 "prefix_vat": "V",
                 "vat": "12345678",
-                "email": "test@example.com",
+                "email": "contacto@empresatest.com",
                 "country_id": self.env.ref("base.ve").id,
             })
+
+    def test_child_contact_same_email_on_create(self):
+        """Validar que un contacto HIJO SÍ se pueda CREAR con el mismo correo de su padre"""
+        child_partner = self.env["res.partner"].create({
+            "name": "María Pérez (Contacto Hijo)",
+            "is_company": False,
+            "parent_id": self.partner_company.id,
+            "email": "contacto@empresatest.com",  # Mismo correo de la casa matriz
+            "country_id": self.env.ref("base.ve").id,
+        })
+        self.assertEqual(child_partner.email, self.partner_company.email)
+
+    def test_child_contact_same_email_on_write(self):
+        """Validar que a un contacto existente se le pueda asignar el correo de su padre mediante WRITE"""
+        child_partner = self.env["res.partner"].create({
+            "name": "Juan Blonco",
+            "is_company": False,
+            "parent_id": self.partner_company.id,
+            "email": "juan@example.com",
+            "country_id": self.env.ref("base.ve").id,
+        })
+        
+        child_partner.write({
+            "email": "contacto@empresatest.com"
+        })
+        self.assertEqual(child_partner.email, self.partner_company.email)
+
+    def test_write_parent_id_and_email_simultaneously(self):
+        """Validar que si asociamos un padre y cambiamos el email en el mismo WRITE, no falle"""
+        independent_partner = self.env["res.partner"].create({
+            "name": "Socio Externo",
+            "email": "externo@example.com",
+        })
+
+        independent_partner.write({
+            "parent_id": self.partner_company.id,
+            "email": "contacto@empresatest.com",
+        })
+        self.assertEqual(independent_partner.parent_id.id, self.partner_company.id)
+
+    def test_write_only_email_no_parent(self):
+        """Validar que actualizar únicamente el email de un contacto sin padre 
+        no cause errores (no pete) con la lógica del record.parent_id.id"""
+        
+        independent_partner = self.env["res.partner"].create({
+            "name": "Persona Natural",
+            "email": "correo.inicial@example.com",
+            "country_id": self.env.ref("base.ve").id,
+        })
+        
+        independent_partner.write({
+            "email": "correo.nuevo.limpio@example.com"
+        })
+        
+        self.assertEqual(independent_partner.email, "correo.nuevo.limpio@example.com")
 
     def test_check_vat_invalid_characters(self):
         self.partner.vat = "12A34"


### PR DESCRIPTION
Problema:

El sistema arroja un error injustificado de tipo ValidationError por correo duplicado cuando se intenta crear o editar un contacto hijo que comparte el mismo correo electrónico de su compañía matriz.

Solución:

-Se modifica la función check_duplicate_email para aceptar y excluir del dominio de búsqueda al parent_id y a sus contactos vinculados. -Se ajustan los métodos create y write para extraer y pasar el parent_id al check_duplicate_email. -Se agregan pruebas unitarias.

Tarea (Link): https://binaural.odoo.com/odoo/my-tickets/12687

Tarea de proyecto []
Ticket de soporte [x]