### PR TITLE
[FIX] l10n_ve_payment_extension: Agregando simulacion de crear retenciones

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.28",
+    "version": "17.0.0.0.29",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -11,6 +11,11 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
+class SimulationSuccess(Exception):
+    """Exception raised to rollback simulation savepoints when dry-run succeeds."""
+    pass
+
+
 class AccountRetention(models.Model):
     _name = "account.retention"
     _inherit = ["mail.thread", "mail.activity.mixin"]
@@ -484,6 +489,16 @@ class AccountRetention(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        if not self.env.context.get("simulation"):
+            try:
+                with self.env.cr.savepoint():
+                    self.with_context(simulation=True).create(vals_list)
+                    raise SimulationSuccess()
+            except SimulationSuccess:
+                pass
+            except Exception as e:
+                raise e
+
         res = super().create(vals_list)
         res._set_sequence()
         return res
@@ -659,6 +674,16 @@ class AccountRetention(models.Model):
             self.payment_ids.action_draft()
 
     def action_post(self):
+        if not self.env.context.get("simulation"):
+            try:
+                with self.env.cr.savepoint():
+                    self.with_context(simulation=True).action_post()
+                    raise SimulationSuccess()
+            except SimulationSuccess:
+                pass
+            except Exception as e:
+                raise e
+
         today = datetime.now()
         self._create_payments_from_retention_lines()
         for retention in self:
@@ -742,14 +767,20 @@ class AccountRetention(models.Model):
     def _set_sequence(self):
         for retention in self.filtered(lambda r: not r.number):
             sequence_number = ""
-            if retention.type_retention == "iva":
-                sequence_number = retention.get_sequence_iva_retention().next_by_id()
-            elif retention.type_retention == "islr":
-                sequence_number = retention.get_sequence_islr_retention().next_by_id()
+            if self.env.context.get("simulation"):
+                if retention.type_retention == "iva":
+                    sequence_number = "99999999"
+                else:
+                    sequence_number = "99999"
             else:
-                sequence_number = (
-                    retention.get_sequence_municipal_retention().next_by_id()
-                )
+                if retention.type_retention == "iva":
+                    sequence_number = retention.get_sequence_iva_retention().next_by_id()
+                elif retention.type_retention == "islr":
+                    sequence_number = retention.get_sequence_islr_retention().next_by_id()
+                else:
+                    sequence_number = (
+                        retention.get_sequence_municipal_retention().next_by_id()
+                    )
             correlative = f"{retention.date_accounting.year}{retention.date_accounting.month:02d}{sequence_number}"
             retention.name = correlative
             retention.number = correlative

--- a/l10n_ve_payment_extension/views/account_retention_iva.xml
+++ b/l10n_ve_payment_extension/views/account_retention_iva.xml
@@ -36,7 +36,7 @@
                                 invisible="not type"
                                 readonly="state in ['emitted', 'cancel']" />
                             <field name="date_accounting" select="1"
-                                readonly="state in ['emitted', 'cancel']" />
+                                readonly="state in ['emitted', 'cancel']" required='0' />
                             <field name="number" force_save="1"
                                 readonly="type == 'in_invoice' or state in ['emitted', 'cancel']"
                                 required="type == 'out_invoice'"/>


### PR DESCRIPTION
- Agregando simulación de prueba para la creación y publicación de retenciones.
- Agregando el campo 'date_accounting' como requerido en el xml de retenciones de IVA.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13120