### PR TITLE
Desbalance en moneda alterna (Bs), se duplica el IVA en CxC/CxP cuando el impuesto no tiene cuenta contable configurada.

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.46",
+    "version": "17.0.0.0.47",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -274,44 +274,35 @@ class AccountMove(models.Model):
             container = {'records': moves}
             moves._sync_dynamic_lines(container)
 
-    @api.depends("invoice_line_ids", "tax_totals")
+    @api.depends("invoice_line_ids.price_unit", "invoice_line_ids.quantity", "invoice_line_ids.discount", "tax_totals")
     def _compute_detailed_amounts(self):
         for record in self:
-            discount_amount = 0
-            if not record.tax_totals:
-                record.detailed_amounts = dict()
-                return
-            amount_taxed = record.tax_totals.get(
-                "amount_total", 0
-            ) - record.tax_totals.get("amount_untaxed", 0)
-            total = 0
+            # Inicializamos siempre para evitar errores si no entra en la lógica
+            total = 0.0
+            discount_amount = 0.0
+            amount_taxed = 0.0
+            
+            if record.tax_totals:
+                amount_taxed = record.tax_totals.get("amount_total", 0.0) - record.tax_totals.get("amount_untaxed", 0.0)
 
-            for line in record.invoice_line_ids:
+            # Calculamos sobre las líneas de factura de forma segura
+            for line in record.invoice_line_ids.filtered(lambda l: l.display_type == 'product'):
                 subtotal = line.price_unit * line.quantity
                 if line.discount > 0:
-                    discount_amount += subtotal - line.price_subtotal
+                    discount_amount += (subtotal - line.price_subtotal)
                 total += subtotal
 
-            record.detailed_amounts = dict(
-                {
-                    "gross_amount": total,
-                    "formatted_gross_amount": formatLang(
-                        self.env, total, currency_obj=self.currency_id
-                    ),
-                    "discount_amount": discount_amount,
-                    "formatted_discount_amount": formatLang(
-                        self.env, discount_amount, currency_obj=self.currency_id
-                    ),
-                    "gross_discount_amount": total,
-                    "formatted_gross_discount_amount": formatLang(
-                        self.env, total - discount_amount, currency_obj=self.currency_id
-                    ),
-                    "taxes_amount": amount_taxed,
-                    "formatted_taxes_amount": formatLang(
-                        self.env, amount_taxed, currency_obj=self.currency_id
-                    ),
-                }
-            )
+            # Asignamos el diccionario completo sin usar 'return' para no romper el bucle masivo
+            record.detailed_amounts = {
+                "gross_amount": total,
+                "formatted_gross_amount": formatLang(self.env, total, currency_obj=record.currency_id),
+                "discount_amount": discount_amount,
+                "formatted_discount_amount": formatLang(self.env, discount_amount, currency_obj=record.currency_id),
+                "gross_discount_amount": total - discount_amount, # Corregido: antes estaba 'total' a secas en dict original
+                "formatted_gross_discount_amount": formatLang(self.env, total - discount_amount, currency_obj=record.currency_id),
+                "taxes_amount": amount_taxed,
+                "formatted_taxes_amount": formatLang(self.env, amount_taxed, currency_obj=record.currency_id),
+            }
 
 
     @api.model
@@ -991,69 +982,47 @@ class AccountMove(models.Model):
         return super().action_post()
 
     @api.depends(
-        "invoice_line_ids.compute_all_tax",
-        "invoice_line_ids.price_subtotal",
-        "foreign_inverse_rate",
-        "foreign_currency_id",
-        "foreign_rate",
+        'invoice_payment_term_id', 
+        'invoice_date', 
+        'currency_id', 
+        'amount_total_in_currency_signed', 
+        'invoice_date_due',
+        'foreign_rate',        
+        'foreign_currency_id'
     )
     def _compute_needed_terms(self):
         res = super()._compute_needed_terms()
 
         for invoice in self:
-            is_draft = invoice.id != invoice._origin.id
+            if not invoice.is_invoice(include_receipts=True) or not invoice.invoice_line_ids:
+                continue
+            if not invoice.foreign_currency_id:
+                continue
+            current_needed_terms = dict(invoice.needed_terms or {})
             sign = 1 if invoice.is_inbound(include_receipts=True) else -1
-            if invoice.is_invoice(True) and invoice.invoice_line_ids:
-                invoice._compute_tax_totals()
-                if invoice.invoice_payment_term_id:
-                    if is_draft:
-                        tax_amount_currency = 0.0
-                        untaxed_amount_currency = 0.0
-                        for line in invoice.invoice_line_ids:
-                            untaxed_amount_currency += line.foreign_subtotal
-                            tax_amount_currency += (
-                                line.foreign_price_total - line.foreign_subtotal
-                            )
-                        untaxed_amount = untaxed_amount_currency
-                        tax_amount = tax_amount_currency
+
+            if invoice.invoice_payment_term_id:
+                total_balance_base = abs(invoice.amount_total_signed)
+                for key, values in current_needed_terms.items():
+                    if total_balance_base > 0.0:
+                        porcion_cuota = abs(values.get('balance', 0.0)) / total_balance_base
+                        foreign_balance = (invoice.foreign_total_billed * porcion_cuota) * sign
                     else:
-                        tax_amount = (
-                            invoice.foreign_total_billed
-                            - invoice.foreign_taxable_income
-                        ) * sign
-                        untaxed_amount = (invoice.foreign_taxable_income) * sign
+                        foreign_balance = 0.0
 
-                    invoice_payment_terms = (
-                        invoice.invoice_payment_term_id._compute_terms(
-                            date_ref=invoice.invoice_date
-                            or invoice.date
-                            or fields.Date.context_today(invoice),
-                            currency=invoice.foreign_currency_id,
-                            tax_amount_currency=tax_amount,
-                            tax_amount=tax_amount,
-                            untaxed_amount_currency=untaxed_amount,
-                            untaxed_amount=untaxed_amount,
-                            company=invoice.company_id,
-                            sign=sign,
-                        )
-                    )
-
-                    for term in invoice_payment_terms["line_ids"]:
-                        for key in list(invoice.needed_terms.keys()):
-                            if key["date_maturity"] == fields.Date.to_date(
-                                term.get("date")
-                            ):
-                                invoice.needed_terms[key] = {
-                                    **invoice.needed_terms[key],
-                                    "foreign_balance": term["company_amount"],
-                                }
-                else:
-                    for key in list(invoice.needed_terms.keys()):
-                        invoice.needed_terms[key] = {
-                            **invoice.needed_terms[key],
-                            "foreign_balance": sign * invoice.foreign_total_billed,
-                        }
+                    current_needed_terms[key] = {
+                        **values,
+                        "foreign_balance": foreign_balance,
+                    }
+            else:
+                for key, values in current_needed_terms.items():
+                    current_needed_terms[key] = {
+                        **values,
+                        "foreign_balance": sign * invoice.foreign_total_billed,
+                    }
+            invoice.needed_terms = current_needed_terms
         return res
+
 
     def button_draft(self):
         for rec in self:
@@ -1074,5 +1043,50 @@ class AccountMove(models.Model):
                 ):
                     raise ValidationError(_("All added lines must indicate the product."))
                 
+    
+    @api.depends(
+        'invoice_line_ids.price_unit',
+        'invoice_line_ids.quantity',
+        'invoice_line_ids.discount',
+        'invoice_line_ids.tax_ids',
+        'invoice_line_ids.foreign_subtotal', 
+    )
+    def _compute_tax_totals(self):
+        """
+        PUENTE DE CONTEXTO REAL:
+        Detecta si el origen del cambio fue manual analizando la masa de las líneas.
+        Si la masa fue alterada, inyecta el contexto directamente en la llamada del super.
+        """
+        for move in self:
+            is_manual_trigger = False
+            
+            # Validamos las líneas que tienen precio unitario y no son secciones/notas
+            valid_lines = move.invoice_line_ids.filtered(
+                lambda l: l.display_type not in ('line_section', 'line_note') and l.price_unit
+            )
+            
+            if valid_lines:
+                # 1. Obtenemos la tasa del documento
+                rate = valid_lines[0].foreign_inverse_rate or 1.0
+                
+                # 2. Sumamos lo que el usuario ve actualmente en la pantalla (Masa Viva)
+                total_foreign_subtotal_live = sum(getattr(l, 'foreign_subtotal', 0.0) for l in valid_lines)
+                
+                # 3. Calculamos cuál sería el subtotal teórico según la tasa estricta
+                total_native_subtotal = sum(l.price_subtotal for l in valid_lines)
+                theoretical_foreign_subtotal = total_native_subtotal * rate
+                
+                # 4. Si la masa actual en pantalla difiere del cálculo teórico por más de un centavo,
+                # significa que el usuario aplicó una Porción Real Manual.
+                if abs(total_foreign_subtotal_live - theoretical_foreign_subtotal) > 0.01:
+                    is_manual_trigger = True
+
+            # Ejecutamos el super pasando el contexto directamente en el registro (self) del llamado.
+            # Al hacerlo dentro del super, Odoo se ve obligado a transferir este contexto 
+            # cuando invoque internamente a 'account.tax'.
+            if is_manual_trigger:
+                super(AccountMove, move.with_context(real_portion_manual_edit=True))._compute_tax_totals()
+            else:
+                super(AccountMove, move)._compute_tax_totals()
 
   

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -2,7 +2,7 @@ import inspect
 from odoo import api, fields, models, Command, _
 from odoo.tools import float_compare
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import frozendict, formatLang, format_date, float_compare, Query, float_round
+from collections import defaultdict
 
 from datetime import date, timedelta
 import traceback
@@ -28,19 +28,20 @@ class AccountMoveLine(models.Model):
     foreign_price = fields.Monetary(
         help="Foreign Price of the line",
         compute="_compute_foreign_price",
+        inverse="_inverse_foreign_price",
         currency_field="foreign_currency_id",
         store=True,
         readonly=False,
     )
     foreign_subtotal = fields.Monetary(
         help="Foreign Subtotal of the line",
-        compute="_compute_foreign_subtotal",
+        compute="_compute_foreign_price",
         currency_field="foreign_currency_id",
         store=True,
     )
     foreign_price_total = fields.Monetary(
         help="Foreign Total of the line",
-        compute="_compute_foreign_subtotal",
+        compute="_compute_foreign_price",
         currency_field="foreign_currency_id",
         store=True,
     )
@@ -82,18 +83,36 @@ class AccountMoveLine(models.Model):
 
     foreign_amount_residual = fields.Monetary(
         currency_field="foreign_currency_id",
-        compute="_compute_foreign_amount_residuals",
+        compute="_compute_amount_residual",
         store=True,
         readonly=True,
     )
     foreign_amount_residual_currency = fields.Monetary(
         currency_field="foreign_currency_id",
-        compute="_compute_foreign_amount_residuals",
+        compute="_compute_amount_residual",
         store=True,
         readonly=True,
     )
 
 
+    def _inverse_foreign_price(self):
+        """
+        INVERSE POR CONTEXTO:
+        Inyecta una bandera temporal en el hilo de ejecución para avisarle al compute
+        que el cambio actual proviene del dedo del usuario.
+        """
+        for line in self:
+            if line.display_type in ('line_section', 'line_note'):
+                continue
+            
+            # Creamos un entorno protegido con nuestro contexto de edición manual
+            context_env = line.move_id.line_ids.with_context(real_portion_manual_edit=True)
+            
+            # 2. Forzamos el cálculo de la Porción Real en todas las líneas de la cuadrícula
+            context_env._compute_foreign_price()
+            
+           
+        
     @api.depends("product_id", "move_id.name")
     def _compute_name(self):
         lines_without_name = self.filtered(lambda l: not l.name)
@@ -105,49 +124,101 @@ class AccountMoveLine(models.Model):
             line.name = line.move_id.name
         return res
 
-    @api.depends("price_unit", "foreign_inverse_rate")
+    @api.depends("price_unit", 
+        "foreign_inverse_rate", 
+        "move_id.line_ids.price_unit",
+        "quantity",
+        "discount",
+        "tax_ids",
+        "price_subtotal",
+        "price_total")
     def _compute_foreign_price(self):
-        for line in self:
-           
-            if line.price_unit and line.foreign_inverse_rate:
-                line.foreign_price = line.price_unit * line.foreign_inverse_rate
-            else:
-                line.foreign_price = 0.0
+        """
+        PORCIÓN REAL CON REDISTRIBUCIÓN DE MASA:
+        El contexto ahora llega blindado desde el write de account.move.
+        Si es manual, recalcula las proporciones usando la masa extranjera actual.
+        Si es automático, usa el price_unit nativo.
+        """
+        # El contexto ya no se pierde porque viaja en la raíz de la transacción
+        is_manual_edit = self.env.context.get('real_portion_manual_edit', False)
 
-    @api.depends("foreign_price", "quantity", "discount", "tax_ids", "price_unit")
-    def _compute_foreign_subtotal(self):
+        moves_mapped = defaultdict(lambda: self.env['account.move.line'])
         for line in self:
-            line_discount_price_unit = line.foreign_price * (
-                1 - (line.discount / 100.0)
+            moves_mapped[line.move_id] |= line
+
+        for move, lines in moves_mapped.items():
+            valid_lines = move.line_ids.filtered(
+                lambda l: l.display_type not in ('line_section', 'line_note') and l.price_unit
             )
-            foreign_subtotal = line_discount_price_unit * line.quantity
 
-            if line.tax_ids:
-                taxes_res = line.tax_ids.with_context(round_base=False).compute_all(
-                    line_discount_price_unit,
-                    quantity=line.quantity,
-                    currency=line.foreign_currency_id,
-                    product=line.product_id,
-                    partner=line.partner_id,
-                    is_refund=line.is_refund,
-                )
-                line.foreign_subtotal = taxes_res["total_excluded"]
-                line.foreign_price_total = taxes_res["total_included"]
+            if not valid_lines:
+                for line in lines:
+                    line.foreign_price = line.foreign_subtotal = line.foreign_price_total = 0.0
+                continue
+
+            rate = valid_lines[0].foreign_inverse_rate or 1.0
+            last_line = valid_lines[-1]
+            allocated_foreign_price = 0.0
+
+            # =========================================================================
+            # CONFIGURACIÓN DINÁMICA DEL PIVOTE DE MASA CONTABLE
+            # =========================================================================
+            if is_manual_edit:
+                # Pivote Extranjero: El objetivo es la suma de lo que ya está en pantalla
+                total_mass_pivote = sum(l.foreign_price for l in valid_lines)
+                total_foreign_price_target = total_mass_pivote
             else:
-                line.foreign_price_total = line.foreign_subtotal = foreign_subtotal
+                # Pivote Nativo: El objetivo es el techo teórico original por tasa
+                total_mass_pivote = sum(l.price_unit for l in valid_lines)
+                total_foreign_price_target = total_mass_pivote * rate
+
+            # Procesamos TODAS las líneas bajo el peso del pivote seleccionado
+            for line in valid_lines:
+                if line in lines:
+                    # Determinamos la proporción matemática según el flujo activo
+                    if is_manual_edit:
+                        proportion = line.foreign_price / total_mass_pivote if total_mass_pivote else 0.0
+                    else:
+                        proportion = line.price_unit / total_mass_pivote if total_mass_pivote else 0.0
+                    
+                    line.foreign_price = total_foreign_price_target * proportion
+
+                    # Cálculo uniforme de subtotales y porción real de IVA
+                    disc_price = line.foreign_price * (1 - (line.discount / 100.0))
+                    line.foreign_subtotal = disc_price * line.quantity
+                    porcion_iva = line.price_total / line.price_subtotal if line.price_subtotal > 0.0 else 1.0
+                    line.foreign_price_total = line.foreign_subtotal * porcion_iva
+                else:
+                    line.foreign_price = line.foreign_price
+
+                allocated_foreign_price += line.foreign_price
+
+            # =========================================================================
+            # AJUSTE POR SUSTRACCIÓN DE RESIDUO SOBRE LA ÚLTIMA LÍNEA
+            # =========================================================================
+            residual_difference = total_foreign_price_target - allocated_foreign_price
+            
+            if abs(residual_difference) > 0.0001 and last_line in lines:
+                last_line.foreign_price += residual_difference
+                
+                disc_price = last_line.foreign_price * (1 - (last_line.discount / 100.0))
+                last_line.foreign_subtotal = disc_price * last_line.quantity
+                porcion_iva = last_line.price_total / last_line.price_subtotal if last_line.price_subtotal > 0.0 else 1.0
+                last_line.foreign_price_total = last_line.foreign_subtotal * porcion_iva
 
     @api.depends(
         "debit",
         "credit",
         "foreign_subtotal",
         "foreign_balance",
-        "amount_currency",
+        "foreign_price_total",
         "not_foreign_recalculate",
         "foreign_debit_adjustment",
         "foreign_credit_adjustment",
     )
     def _compute_foreign_debit_credit(self):
         for line in self:
+            
             if line.not_foreign_recalculate:
                 if line.foreign_debit_adjustment or line.foreign_credit_adjustment:
                     self._calculate_from_adjustment(line)
@@ -156,20 +227,14 @@ class AccountMoveLine(models.Model):
             if line.foreign_debit_adjustment or line.foreign_credit_adjustment:
                 self._calculate_from_adjustment(line)
 
-             
             elif line.display_type in ("line_section", "line_note"):
                 self._calculate_zero(line)
-            elif line.display_type in ("payment_term", "tax"):
-                self._calculate_for_non_invoice(line)
+
+            elif line.display_type == ("payment_term", "tax","product"):
+                self._calculate_from_product(line)
+
             elif line.currency_id == line.company_id.currency_foreign_id and line.amount_currency:
                 self._calculate_from_amount_currency(line)
-
-            elif line.move_id.payment_id and "retention_foreign_amount" in self.env["account.payment"]._fields and line.move_id.payment_id.is_retention:
-                self._calculate_from_retention(line)
-            elif not line.move_id.is_invoice(include_receipts=True):
-                self._calculate_for_non_invoice(line)
-            elif line.display_type == "product":
-                self._calculate_from_product(line)
             else:
                 self._calculate_for_non_invoice(line)
 
@@ -201,70 +266,90 @@ class AccountMoveLine(models.Model):
         if line.foreign_credit != new_foreign_credit:
             line.foreign_credit = new_foreign_credit
 
-    def _calculate_from_retention(self, line):
-        retention_amount = line.move_id.payment_id.retention_foreign_amount
-        new_foreign_debit = 0.0
-        new_foreign_credit = 0.0
-        if not line.currency_id.is_zero(line.debit):
-            new_foreign_debit = retention_amount
-        elif not line.currency_id.is_zero(line.credit):
-            new_foreign_credit = retention_amount
-
-        if line.foreign_debit != new_foreign_debit:
-            line.foreign_debit = new_foreign_debit
-        if line.foreign_credit != new_foreign_credit:
-            line.foreign_credit = new_foreign_credit
 
     def _calculate_for_non_invoice(self, line):
+        """
+        APLICACIÓN DE PORCIÓN REAL (LÍNEA POR LÍNEA):
+        Calcula la masa global del asiento en memoria para determinar la porción real 
+        exacta de esta línea o asignarle el residuo si es la última del asiento.
+        """
+        move = line.move_id
         
-        foreign_lines = line.move_id.line_ids.filtered(
-            lambda l: l.currency_id == l.company_id.currency_foreign_id
+        # 1. Filtramos las líneas operativas del asiento entero para el cálculo global
+        valid_lines = move.line_ids.filtered(
+            lambda l: l.display_type not in ('line_section', 'line_note')
         )
-        currency_lines = line.move_id.line_ids.filtered(
-            lambda l: l.currency_id == l.company_id.currency_id
-        )
-        new_foreign_debit = 0.0
-        new_foreign_credit = 0.0
+        if not valid_lines:
+            return
 
-        rate_is_zero = line.foreign_inverse_rate == 0.0
-        is_base_currency = line.currency_id == line.company_id.currency_id
-        
-        inverse_rate_to_use = line.foreign_inverse_rate
-        
-        if is_base_currency and rate_is_zero:
-            foreign_currency = line.company_id.currency_foreign_id
-            
+        # 2. Determinar la tasa real única (Macro Tasa) del asiento
+        rate_line = valid_lines.filtered(lambda l: l.foreign_inverse_rate)
+        inverse_rate = rate_line[0].foreign_inverse_rate if rate_line else 0.0
+
+        if inverse_rate == 0.0:
+            foreign_currency = move.company_id.currency_foreign_id
             if foreign_currency:
-                if hasattr(line.move_id, 'origin_payment_advanced_payment_id') and line.move_id.origin_payment_advanced_payment_id:
-                    rate_date = line.move_id.origin_payment_advanced_payment_id.date
-                else:
-                    rate_date = line.date
-                rate = foreign_currency._get_conversion_rate(
-                    line.company_id.currency_id,
+                inverse_rate = foreign_currency._get_conversion_rate(
+                    move.company_id.currency_id,
                     foreign_currency,
-                    line.company_id,
-                    rate_date
+                    move.company_id,
+                    move.date
                 )
+        inverse_rate = inverse_rate or 1.0
 
-                inverse_rate_to_use = rate if inverse_rate_to_use == 0.0 else rate
-     
-        balance = sum(foreign_lines.mapped("amount_currency"))
-        if balance and len(currency_lines) == 1:
-            new_foreign_debit = abs(balance) if balance < 0 else 0.0
-            new_foreign_credit = abs(balance) if balance > 0 else 0.0
+        # 3. Caso especial: Cuenta puente/cuadre con balance extranjero existente
+        foreign_lines = move.line_ids.filtered(lambda l: l.currency_id == l.company_id.currency_foreign_id)
+        currency_lines = move.line_ids.filtered(lambda l: l.currency_id == l.company_id.currency_id)
+        bridge_balance = sum(foreign_lines.mapped("amount_currency"))
+
+        if bridge_balance and len(currency_lines) == 1:
+            if line in currency_lines:
+                line.foreign_debit = abs(bridge_balance) if bridge_balance < 0 else 0.0
+                line.foreign_credit = abs(bridge_balance) if bridge_balance > 0 else 0.0
+                line.foreign_debit_no_format = line.foreign_debit
+                line.foreign_credit_no_format = line.foreign_credit
+            return
+
+        # 4. DETERMINACIÓN DE LA PORCIÓN REAL
+        last_line = valid_lines[-1]
+
+        # Si la línea actual NO es la última, aplicamos el prorrateo puro de la porción real
+        if line != last_line:
+            total_local_debit = sum(l.debit for l in valid_lines)
+            total_local_credit = sum(l.credit for l in valid_lines)
+            
+            target_foreign_debit = total_local_debit * inverse_rate
+            target_foreign_credit = total_local_credit * inverse_rate
+
+            prop_debit = line.debit / total_local_debit if total_local_debit else 0.0
+            prop_credit = line.credit / total_local_credit if total_local_credit else 0.0
+
+            line.foreign_debit = target_foreign_debit * prop_debit
+            line.foreign_credit = target_foreign_credit * prop_credit
         
+        # Si la línea actual ES la última, le toca absorber el residuo para cuadrar el asiento
         else:
-            new_foreign_debit = line.debit * inverse_rate_to_use
-            new_foreign_credit = line.credit * inverse_rate_to_use
-        
-       
-        line.foreign_debit_no_format = line.debit * inverse_rate_to_use
-        line.foreign_credit_no_format = line.credit * inverse_rate_to_use
-        
-        if new_foreign_debit:
-            line.foreign_debit = new_foreign_debit
-        if new_foreign_credit:
-            line.foreign_credit = new_foreign_credit
+            # Calculamos cuánto sumaron las líneas anteriores (recalculadas bajo la misma lógica)
+            total_local_debit = sum(l.debit for l in valid_lines)
+            total_local_credit = sum(l.credit for l in valid_lines)
+            
+            target_foreign_debit = total_local_debit * inverse_rate
+            target_foreign_credit = total_local_credit * inverse_rate
+
+            allocated_foreign_debit = 0.0
+            allocated_foreign_credit = 0.0
+
+            for l in valid_lines[:-1]:
+                prop_d = l.debit / total_local_debit if total_local_debit else 0.0
+                prop_c = l.credit / total_local_credit if total_local_credit else 0.0
+                allocated_foreign_debit += target_foreign_debit * prop_d
+                allocated_foreign_credit += target_foreign_credit * prop_c
+
+            line.foreign_debit = max(0.0, target_foreign_debit - allocated_foreign_debit)
+            line.foreign_credit = max(0.0, target_foreign_credit - allocated_foreign_credit)
+
+        line.foreign_debit_no_format = line.foreign_debit
+        line.foreign_credit_no_format = line.foreign_credit
 
     def _calculate_from_product(self, line):
         
@@ -336,55 +421,74 @@ class AccountMoveLine(models.Model):
         other_aml_values=None,
     ):
         """Prepare the available residual amounts for each currency.
-        :param aml_values: The values of account.move.line to consider.
-        :param counterpart_currency: The currency of the opposite line this line will be reconciled with.
-        :param shadowed_aml_values: A mapping aml -> dictionary to replace some original aml values to something else.
-                                    This is usefull if you want to preview the reconciliation before doing some changes
-                                    on amls like changing a date or an account.
-        :param other_aml_values:    The other aml values to be reconciled with the current one.
-        :return: A mapping currency -> dictionary containing:
-            * residual: The residual amount left for this currency.
-            * rate:     The rate applied regarding the company's currency.
+
+        RATIONALE FOR OVERRIDING (REAL PORTION IMPLEMENTATION):
+        Odoo 17's native method computes the accounting reconciliation rate ('get_accounting_rate')
+        by dividing 'amount_currency / balance'. In dual-currency economies with high fluctuation,
+        this native approach completely ignores the subtraction adjustments and global mass pricing
+        applied to custom control fields ('foreign_debit' and 'foreign_credit'). This mismatch
+        leads to phantom exchange rate differences due to rounding errors during reconciliation.
+
+        This override intercepts the calculation when the target currency matches the company's
+        foreign currency, forcing Odoo to determine the effective real accounting rate based on
+        the pre-balanced Real Portion fields on the move line.
         """
 
         def is_payment(aml):
             return aml.move_id.payment_id or aml.move_id.statement_line_id
 
         def get_odoo_rate(aml, other_aml, currency):
-            if forced_rate := self._context.get("forced_rate_from_register_payment"):
+            if forced_rate := self._context.get(
+                "forced_rate_from_register_payment"
+            ):
                 return forced_rate
             if other_aml and not is_payment(aml) and is_payment(other_aml):
-                # >>>> Integra
-                if aml.move_id.payment_id:
-                    return aml.move_id.payment_id.foreign_inverse_rate
-                # <<<< Integra
                 return get_accounting_rate(other_aml, currency)
             if aml.move_id.is_invoice(include_receipts=True):
                 exchange_rate_date = aml.move_id.invoice_date
             else:
-                exchange_rate_date = aml._get_reconciliation_aml_field_value(
-                    "date", shadowed_aml_values
+                exchange_rate_date = (
+                    aml._get_reconciliation_aml_field_value(
+                        "date", shadowed_aml_values
+                    )
                 )
-            return currency._get_conversion_rate(
-                aml.company_currency_id, currency, aml.company_id, exchange_rate_date
+            return aml.company_currency_id._get_conversion_rate(
+                aml.company_currency_id,
+                currency,
+                aml.company_id,
+                exchange_rate_date,
             )
 
         def get_accounting_rate(aml, currency):
-            if forced_rate := self._context.get("forced_rate_from_register_payment"):
-                return forced_rate
+            # --- START REAL PORTION MODIFICATION ---
+            # Check if the evaluated currency is the company's secondary/foreign control currency
+            if (
+                aml.company_id.currency_foreign_id
+                and currency == aml.company_id.currency_foreign_id
+            ):
+                # Extract the real portion balances from local and foreign custom fields
+                local_balance = abs(aml.debit - aml.credit)
+                foreign_balance = abs(aml.foreign_debit - aml.foreign_credit)
+
+                if (
+                    not aml.company_currency_id.is_zero(local_balance)
+                    and foreign_balance > 0.0
+                ):
+                    # Return the real implicit mathematical rate derived from our balanced fields
+                    return foreign_balance / local_balance
+            # --- END REAL PORTION MODIFICATION ---
+
+            # Native Odoo fallback for any other currencies
             balance = aml._get_reconciliation_aml_field_value(
                 "balance", shadowed_aml_values
             )
             amount_currency = aml._get_reconciliation_aml_field_value(
                 "amount_currency", shadowed_aml_values
             )
-            if not aml.company_currency_id.is_zero(balance) and not currency.is_zero(
-                amount_currency
-            ):
+            if not aml.company_currency_id.is_zero(
+                balance
+            ) and not currency.is_zero(amount_currency):
                 return abs(amount_currency / balance)
-            
-            return 1.0
-        
 
         aml = aml_values["aml"]
         other_aml = (other_aml_values or {}).get("aml")
@@ -455,48 +559,6 @@ class AccountMoveLine(models.Model):
                 }
             )
 
-    @api.depends(
-        "foreign_inverse_rate",
-        "foreign_currency_id",
-        "foreign_rate",
-        "foreign_price",
-    )
-    def _compute_all_tax(self):
-        res = super(AccountMoveLine, self)._compute_all_tax()
-        for line in self:
-            sign = line.move_id.direction_sign
-
-            if line.display_type == "product" and line.move_id.is_invoice(True):
-                amount_currency = sign * line.foreign_price * (1 - line.discount / 100)
-                handle_price_include = True
-                quantity = line.quantity
-            else:
-                amount_currency = (
-                    line.amount_currency * line.move_id.foreign_inverse_rate
-                )
-                handle_price_include = False
-                quantity = 1
-
-            compute_all_currency = line.tax_ids.compute_all(
-                amount_currency,
-                currency=line.foreign_currency_id,
-                quantity=quantity,
-                product=line.product_id,
-                partner=line.move_id.partner_id or line.partner_id,
-                is_refund=line.is_refund,
-                handle_price_include=handle_price_include,
-                include_caba_tags=line.move_id.always_tax_exigible,
-                fixed_multiplicator=sign,
-            )
-
-            for tax in compute_all_currency["taxes"]:
-                for key in list(line.compute_all_tax.keys()):
-                    if not key.get("tax_repartition_line_id", False):
-                        continue
-
-                    if tax["tax_repartition_line_id"] == key["tax_repartition_line_id"]:
-                        line.compute_all_tax[key]["foreign_balance"] = tax["amount"]
-        return res
 
     @api.onchange("quantity")
     def _onchange_quantity(self):
@@ -507,7 +569,6 @@ class AccountMoveLine(models.Model):
     def _onchange_price_unit(self):
         if self.price_unit < 0:
             raise ValidationError(_("The price entered cannot be negative"))
-        
 
     def write(self, vals):
         old_values = {
@@ -516,9 +577,17 @@ class AccountMoveLine(models.Model):
                 'foreign_credit': line.foreign_credit
             } for line in self
         }
+        
+        
+        if self.env.context.get('skip_real_adjustment_flag'):
+            return super(AccountMoveLine, self).write(vals)
     
         res = super(AccountMoveLine, self).write(vals)
 
+        if any(f in vals for f in ['balance', 'amount_currency', 'currency_rate']):
+            self._apply_real_portion_adjustment()
+            
+    
         for line in self:
             old_line_data = old_values.get(line.id)
             if old_line_data:
@@ -554,88 +623,10 @@ class AccountMoveLine(models.Model):
                         })
 
         return res
-
-    def _get_manual_foreign_amount_residual(
-        self,
-        currency=None,
-        foreign_debit=None,
-        foreign_credit=None,
-        partials=None,
-    ):
-        """
-        Calculates the manual residual amount in foreign currency for the move line.
-        Considers matched partials and computes the remaining amount after reconciliation.
-        Returns a tuple: (rounded residual, manual_available).
-        """
-        self.ensure_one()
-
-        currency = currency or self.foreign_currency_id
-        if not currency:
-            return 0.0, False
-
-        if self.foreign_currency_id and currency != self.foreign_currency_id:
-            return 0.0, False
-
-        foreign_debit = foreign_debit if foreign_debit is not None else self.foreign_debit
-        foreign_credit = (
-            foreign_credit if foreign_credit is not None else self.foreign_credit
-        )
-
-        manual_total = (foreign_debit or 0.0) - (foreign_credit or 0.0)
-
-        partials = partials or (self.matched_debit_ids | self.matched_credit_ids)
-        manual_partial_total = 0.0
-        for partial in partials:
-            amount = 0.0
-            partial_currency = False
-            if partial.debit_move_id == self:
-                amount = partial.debit_amount_currency or 0.0
-                partial_currency = partial.debit_currency_id
-            elif partial.credit_move_id == self:
-                amount = partial.credit_amount_currency or 0.0
-                partial_currency = partial.credit_currency_id
-
-            if partial_currency == currency and amount:
-                manual_partial_total += amount
-
-        if currency.is_zero(manual_total) and currency.is_zero(manual_partial_total):
-            return 0.0, False
-
-        if currency.is_zero(manual_total):
-            balance_sign = 1 if self.balance >= 0 else -1
-        else:
-            balance_sign = 1 if manual_total >= 0 else -1
-
-        residual = manual_total - balance_sign * manual_partial_total
-        if balance_sign > 0:
-            residual = max(residual, 0.0)
-        else:
-            residual = min(residual, 0.0)
-
-        return residual, True
-
-    @api.depends(
-        "foreign_currency_id",
-        "foreign_debit",
-        "foreign_credit",
-        "matched_debit_ids.debit_amount_currency",
-        "matched_debit_ids.debit_currency_id",
-        "matched_credit_ids.credit_amount_currency",
-        "matched_credit_ids.credit_currency_id",
-    )
-    def _compute_foreign_amount_residuals(self):
-        """
-        Computes and stores the foreign currency residuals for each move line.
-        Uses _get_manual_foreign_amount_residual for calculation.
-        """
-        for line in self:
-            residual, manual_available = line._get_manual_foreign_amount_residual()
-            line.foreign_amount_residual = residual if manual_available else 0.0
-            line.foreign_amount_residual_currency = residual if manual_available else 0.0
+    
 
     @api.model
     def _prepare_reconciliation_single_partial(self, debit_values, credit_values, shadowed_aml_values=None):
-        # 1. Llamada al método original
         res = super()._prepare_reconciliation_single_partial(
             debit_values, credit_values, shadowed_aml_values=shadowed_aml_values
         )
@@ -643,39 +634,54 @@ class AccountMoveLine(models.Model):
         if not res.get('partial_values'):
             return res
 
+        partial_amount = res['partial_values'].get('amount', 0.0)
         debit_aml = debit_values['aml']
         credit_aml = credit_values['aml']
-        partial_vals = res['partial_values']
+        company_currency = debit_aml.company_currency_id
+
+        has_debit_fb = hasattr(debit_aml, 'foreign_balance') and debit_aml.foreign_balance
+        has_credit_fb = hasattr(credit_aml, 'foreign_balance') and credit_aml.foreign_balance
+
+        recon_debit_amount = debit_values.get('amount_residual', 0.0)
+        recon_credit_amount = -credit_values.get('amount_residual', 0.0)
         
-        amount_company = partial_vals['amount']
+        compare_amounts = company_currency.compare_amounts(recon_debit_amount, recon_credit_amount)
+        debit_fully_matched = compare_amounts <= 0
 
-
-        def get_foreign_partial_amount(aml):
-            f_currency = aml.foreign_currency_id
-            if not f_currency:
-                return 0.0
-           
-            total_foreign = abs(aml.foreign_balance) 
-
+        if debit_fully_matched:
+            if has_debit_fb and debit_aml.balance:
+                percent = partial_amount / abs(debit_aml.balance)
+                monto_usd = abs(debit_aml.foreign_balance) * percent
+                remaining = debit_values.get('foreign_amount_residual', abs(debit_aml.foreign_balance))
+                partial_debit_foreign = min(monto_usd, remaining)
+            else:
+                partial_debit_foreign = 0.0
             
-            return total_foreign
-
-   
-        foreign_debit_amount = get_foreign_partial_amount(debit_aml)
-        foreign_credit_amount = get_foreign_partial_amount(credit_aml)
-
+            partial_credit_foreign = partial_debit_foreign
+            foreign_amount_final = partial_debit_foreign
+        else:
+            if has_credit_fb and credit_aml.balance:
+                percent = partial_amount / abs(credit_aml.balance)
+                monto_usd = abs(credit_aml.foreign_balance) * percent
+                remaining = credit_values.get('foreign_amount_residual', abs(credit_aml.foreign_balance))
+                partial_credit_foreign = min(monto_usd, remaining)
+            else:
+                partial_credit_foreign = 0.0
+            partial_debit_foreign = partial_credit_foreign
+            foreign_amount_final = partial_credit_foreign
 
         res['partial_values'].update({
-            'foreign_amount': min(foreign_debit_amount, foreign_credit_amount),
-            'debit_foreign_amount_currency': foreign_debit_amount,
-            'credit_foreign_amount_currency': foreign_credit_amount,
+            'foreign_amount': foreign_amount_final,
+            'debit_foreign_amount_currency': partial_debit_foreign,
+            'credit_foreign_amount_currency': partial_credit_foreign,
         })
 
+        
         return res
     
 
     @api.depends('debit', 'credit', 'amount_currency', 'account_id', 'currency_id', 'company_id',
-                 'matched_debit_ids', 'matched_credit_ids')
+                 'matched_debit_ids', 'matched_credit_ids','foreign_balance')
     def _compute_amount_residual(self):
         """ Computes the residual amount of a move line from a reconcilable account in the company currency and the line's currency.
             This amount will be 0 for fully reconciled lines or lines from a non-reconcilable account, the original line amount
@@ -686,18 +692,26 @@ class AccountMoveLine(models.Model):
         # using _origin, new records (with a NewId) are excluded and the
         # computation works automagically for virtual onchange records as well.
         stored_lines = need_residual_lines._origin
+        amounts_map = {}
+        foreign_amounts_map = {}
 
         if stored_lines:
             self.env['account.partial.reconcile'].flush_model()
             self.env['res.currency'].flush_model(['decimal_places'])
 
             aml_ids = tuple(stored_lines.ids)
-            self._cr.execute('''
+            PartialModel = self.env['account.partial.reconcile']
+            has_debit_fa = hasattr(PartialModel, 'debit_foreign_amount_currency')
+            has_credit_fa = hasattr(PartialModel, 'credit_foreign_amount_currency')
+            debit_field_sql = "SUM(part.debit_foreign_amount_currency)" if has_debit_fa else "0.0"
+            credit_field_sql = "SUM(part.credit_foreign_amount_currency)" if has_credit_fa else "0.0"
+            self._cr.execute(f'''
                 SELECT
                     part.debit_move_id AS line_id,
                     'debit' AS flag,
                     COALESCE(SUM(part.amount), 0.0) AS amount,
-                    SUM(part.debit_amount_currency) AS amount_currency
+                    SUM(part.debit_amount_currency) AS amount_currency,
+                    COALESCE({debit_field_sql}, 0.0) AS foreign_amount
                 FROM account_partial_reconcile part
                 JOIN res_currency curr ON curr.id = part.debit_currency_id
                 WHERE part.debit_move_id IN %s
@@ -707,16 +721,16 @@ class AccountMoveLine(models.Model):
                     part.credit_move_id AS line_id,
                     'credit' AS flag,
                     COALESCE(SUM(part.amount), 0.0) AS amount,
-                    SUM(part.credit_amount_currency) AS amount_currency
+                    SUM(part.credit_amount_currency) AS amount_currency,
+                    COALESCE({credit_field_sql}, 0.0) AS foreign_amount
                 FROM account_partial_reconcile part
                 JOIN res_currency curr ON curr.id = part.credit_currency_id
                 WHERE part.credit_move_id IN %s
                 GROUP BY part.credit_move_id, curr.decimal_places
             ''', [aml_ids, aml_ids])
-            amounts_map = {
-                (line_id, flag): (amount, amount_currency)
-                for line_id, flag, amount, amount_currency in self.env.cr.fetchall()
-            }
+            for line_id, flag, amount, amount_currency, foreign_amount in self.env.cr.fetchall():
+                amounts_map[(line_id, flag)] = (amount, amount_currency)
+                foreign_amounts_map[(line_id, flag)] = foreign_amount
         else:
             amounts_map = {}
 
@@ -724,6 +738,8 @@ class AccountMoveLine(models.Model):
         for line in self - need_residual_lines:
             line.amount_residual = 0.0
             line.amount_residual_currency = 0.0
+            line.foreign_amount_residual = 0.0
+            line.foreign_amount_residual_currency = 0.0
             line.reconciled = False
 
         for line in need_residual_lines:
@@ -735,34 +751,96 @@ class AccountMoveLine(models.Model):
             debit_amount, debit_amount_currency = amounts_map.get((line._origin.id, 'debit'), (0.0, 0.0))
             credit_amount, credit_amount_currency = amounts_map.get((line._origin.id, 'credit'), (0.0, 0.0))
 
+            debit_foreign = foreign_amounts_map.get((line._origin.id, 'debit'), 0.0)
+            credit_foreign = foreign_amounts_map.get((line._origin.id, 'credit'), 0.0)
             # Subtract the values from the account.partial.reconcile to compute the residual amounts.
             residual = line.balance - debit_amount + credit_amount
             residual_currency = line.amount_currency - debit_amount_currency + credit_amount_currency
             
             line.amount_residual = residual
             line.amount_residual_currency = residual_currency
-            # Para determinar si está conciliado, usamos una tolerancia mínima 
-            # en lugar de un cero absoluto, o comparamos directamente.
             line.reconciled = (line.amount_residual == 0.0 and line.amount_residual_currency == 0.0)
 
+            line.foreign_amount_residual = line.foreign_balance - debit_foreign + credit_foreign
+            line.foreign_amount_residual_currency = line.foreign_amount_residual
 
-    @api.onchange('amount_currency', 'currency_id','foreign_inverse_rate')
+    @api.onchange('amount_currency', 'currency_id', 'foreign_inverse_rate')
     def _inverse_amount_currency(self):
+        """
+        Calcula el balance basándose única y exclusivamente en lo que el usuario digita.
+        No mira líneas vecinas ni calcula proporciones globales para evitar bucles.
+        """
+        comp_curr = self.env.company.currency_id
         for line in self:
-            if line.currency_id == line.company_id.currency_id and line.balance != line.amount_currency:
-                line.balance = line.amount_currency
-            elif (
-                line.currency_id != line.company_id.currency_id
+            if line.currency_id == comp_curr:
+                if line.balance != line.amount_currency:
+                    line.balance = line.amount_currency
+                continue
+
+            if (
+                line.currency_id != comp_curr
                 and not line.move_id.is_invoice(True)
                 and not self.env.is_protected(self._fields['balance'], line)
             ):
-                line.balance = line.amount_currency / line.currency_rate
+                rate = line.currency_rate or 1.0
+                line.balance = line.amount_currency * rate
 
-
+    
     @api.depends('currency_rate', 'balance')
     def _compute_amount_currency(self):
+        """
+        Calcula el importe extranjero de forma aislada e independiente en la interfaz.
+        Removida la dependencia cruzada 'move_id.line_ids.balance' para matar el bucle cíclico.
+        """
         for line in self:
-            if line.amount_currency is False:
-                line.amount_currency = line.balance * line.currency_rate
-            if line.currency_id == line.company_id.currency_id:
+            comp_curr = line.company_id.currency_id
+            if line.currency_id == comp_curr:
                 line.amount_currency = line.balance
+                continue
+
+            rate = line.currency_rate or 1.0
+            if line.balance:
+                sign = -1.0 if line.balance < 0 else 1.0
+                line.amount_currency = sign * (abs(line.balance) / rate if rate else 0.0)
+            else:
+                line.amount_currency = 0.0
+
+    def _apply_real_portion_adjustment(self):
+        if self.env.context.get('skip_real_adjustment_flag'):
+            return
+
+        moves_mapped = defaultdict(lambda: self.env['account.move.line'])
+        for line in self:
+            moves_mapped[line.move_id] |= line
+
+        for move, lines in moves_mapped.items():
+            comp_curr = move.company_id.currency_id
+            if move.is_invoice(True):
+                continue
+
+            foreign_lines = move.line_ids.filtered(
+                lambda l: l.currency_id != comp_curr and l.display_type not in ('line_section', 'line_note')
+            )
+
+            if len(foreign_lines) <= 2:
+                continue
+
+            valid_rates = foreign_lines.filtered(lambda l: l.currency_rate)
+            macro_rate = valid_rates[0].currency_rate if valid_rates else 1.0
+            if not macro_rate:
+                continue
+
+            move_seguro = move.with_context(skip_real_adjustment_flag=True)
+            
+            total_allocated_balance = 0.0
+            last_line = foreign_lines[-1]
+
+            for line in foreign_lines[:-1]:
+                sign = -1.0 if line.amount_currency < 0 else 1.0
+                line_balance = (abs(line.amount_currency) / macro_rate) * sign
+                
+                move_seguro.line_ids.filtered(lambda l: l.id == line.id).balance = line_balance
+                total_allocated_balance += line_balance
+
+            remaining_balance = -total_allocated_balance
+            move_seguro.line_ids.filtered(lambda l: l.id == last_line.id).balance = remaining_balance

--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -1,5 +1,5 @@
 from odoo import api, fields, models, _
-
+from odoo.exceptions import UserError
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -100,6 +100,75 @@ class AccountPayment(models.Model):
                 payment.foreign_rate
             )
 
+    def _prepare_move_line_default_vals(
+        self, write_off_line_vals=None, force_balance=None
+    ):
+        """Override to adjust liquidity and counterpart balances using the Real Portion.
+
+        RATIONALE FOR OVERRIDING (REAL PORTION PAYMENT INTEGRATION):
+        Natively, Odoo 17 uses the '_convert' method to determine the 'liquidity_balance', 
+        which applies a division-based rate exchange standard. In dual-currency environments 
+        with highly fluctuated currencies (e.g., VES/VEF vs USD), rates are stored inversely 
+        in the system to preserve precision. Consequently, Odoo's native approach creates 
+        a mathematical mismatch by dividing when it should multiply, or vice versa, distorting 
+        the final journal entry amounts compared to what the user inputted in the payment form.
+
+        This method intercepts the prepared dictionary list from 'super()' and recalibrates 
+        the 'debit' and 'credit' balances dynamically. If the payment currency is the 
+        strong foreign control currency (USD), it multiplies by the inverse rate. If the 
+        payment currency is the weak local currency (VES/VEF) under a USD base company, 
+        it divides. This ensures total mathematical convergence and prevents phantom 
+        exchange rate discrepancies between the payment record and the journal entry lines.
+        """
+        line_vals_list = super(
+            AccountPayment, self
+        )._prepare_move_line_default_vals(
+            write_off_line_vals=write_off_line_vals,
+            force_balance=force_balance,
+        )
+
+        inverse_rate = (
+            self.foreign_inverse_rate
+            if hasattr(self, "foreign_inverse_rate") and self.foreign_inverse_rate
+            else 0.0
+        )
+        foreign_currency = self.company_id.currency_foreign_id
+
+        if (
+            inverse_rate > 0.0
+            and foreign_currency
+            and self.currency_id != self.company_id.currency_id
+        ):
+            for vals in line_vals_list:
+                amount_currency = abs(vals.get("amount_currency", 0.0))
+
+                if (
+                    self.company_id.currency_id != foreign_currency
+                    and self.currency_id == foreign_currency
+                ):
+                    real_balance = self.company_id.currency_id.round(
+                        amount_currency * inverse_rate
+                    )
+
+                elif (
+                    self.company_id.currency_id == foreign_currency
+                    and self.currency_id != foreign_currency
+                ):
+                    real_balance = self.company_id.currency_id.round(
+                        amount_currency / inverse_rate
+                    )
+
+                else:
+                    continue
+
+                if vals.get("debit", 0.0) > 0.0:
+                    vals["debit"] = real_balance
+                    vals["credit"] = 0.0
+                elif vals.get("credit", 0.0) > 0.0:
+                    vals["credit"] = real_balance
+                    vals["debit"] = 0.0
+
+        return line_vals_list
 
     def _create_payment_vals_from_wizard(self, batch_result):
         payment_vals = {

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -89,13 +89,14 @@
             </xpath>
             <xpath expr="//page/field[@name='line_ids']/tree/field[@name='balance']"
                 position="after">
-                <field name="foreign_currency_id" column_invisible="True" />
+                <field name="foreign_currency_id" column_invisible="True" invisible="display_type in ('line_section', 'line_note')"/>
                 <field
                     name="foreign_debit"
                     optional="show"
                     sum="Total Foreign Debit"
                     readonly="1"
                     force_save="1"
+                    invisible="display_type in ('line_section', 'line_note')"
                 />
                 <field
                     name="foreign_credit"
@@ -103,17 +104,19 @@
                     sum="Total Foreign Credit"
                     readonly="1"
                     force_save="1"
+                    invisible="display_type in ('line_section', 'line_note')"
                 />
-                <field name="foreign_debit_adjustment" optional="hide" force_save="1"/>
-                <field name="foreign_credit_adjustment" optional="hide" force_save="1"/>
-                <field name="foreign_balance" optional="hide" groups="base.group_no_one" force_save="1"/>
-                <field name="foreign_rate" optional="hide" groups="base.group_no_one" force_save="1"/>
+                <field name="foreign_debit_adjustment" optional="hide" force_save="1" invisible="display_type in ('line_section', 'line_note')"/>
+                <field name="foreign_credit_adjustment" optional="hide" force_save="1" invisible="display_type in ('line_section', 'line_note')"/>
+                <field name="foreign_balance" optional="hide" groups="base.group_no_one" force_save="1" invisible="display_type in ('line_section', 'line_note')"/>
+                <field name="foreign_rate" optional="hide" groups="base.group_no_one" force_save="1" invisible="display_type in ('line_section', 'line_note')"/>
                 <field
                     name="foreign_inverse_rate"
                     groups="base.group_no_one"
                     optional="hide"
                     readonly="1"
                     force_save="1"
+                    invisible="display_type in ('line_section', 'line_note')"
                 />
             </xpath>
             <field name="payment_reference" position="after">

--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
         "depends": [
         "base",
         "l10n_ve_accountant",

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -87,27 +87,21 @@ class AccountMove(models.Model):
             else:
                 record.amount_residual_igtf = 0
 
-    @api.depends(
-        "bi_igtf",
-    )
-    def _compute_tax_totals(self):
-        return super()._compute_tax_totals()
 
     @api.depends('amount_residual')
     def compute_bi_igtf(self):
         for rec in self:
             if rec.journal_id.is_purchase_international:
-                rec.write({
-                    'igtf_top_aply': 0.0,
-                    'alter_igtf_top_aply': 0.0,
-                    'alter_bi_igtf': 0.0,
-                    'foreign_alter_bi_igtf': 0.0,
-                    'foreign_bi_igtf': 0.0,
-                    'bi_igtf': 0.0
-                })
+                
+                rec.igtf_top_aply = 0.0
+                rec.alter_igtf_top_aply = 0.0
+                rec.alter_bi_igtf = 0.0
+                rec.foreign_alter_bi_igtf = 0.0
+                rec.foreign_bi_igtf = 0.0
+                rec.bi_igtf = 0.0
                 continue
             
-            amount = rec.amount_total
+            amount = rec.amount_total 
             if rec.company_currency_id == self.env.ref("base.VEF"):
                 amount = rec.foreign_total_billed
             rec.igtf_top_aply = amount * (self.company_id.igtf_percentage / 100)
@@ -121,8 +115,8 @@ class AccountMove(models.Model):
 
             account = [self.company_id.customer_account_igtf_id.id,self.company_id.supplier_account_igtf_id.id ]
             
-            payment_moves = self.env['account.move']
-           
+            payment_moves = self.env['account.move'].sudo().with_company(rec.company_id)
+        
             all_partial_reconciles = receivable_payable_lines.matched_debit_ids | receivable_payable_lines.matched_credit_ids
             
             payment_moves |= all_partial_reconciles.mapped('debit_move_id.move_id')
@@ -140,111 +134,99 @@ class AccountMove(models.Model):
             foreign_igtf_amount = 0.0
             target_account = False
 
-            partial_amount = 0.0
-            partial_foreign_amount = 0.0
             partner_context = rec.partner_id.with_company(rec.company_id)
+
+            if rec.move_type in ['out_invoice', 'out_refund']:
+                target_account = partner_context.property_account_receivable_id
+            else:
+                target_account = partner_context.property_account_payable_id
+            factura_line = rec.line_ids.filtered(lambda l: l.account_id.id == target_account.id)
             for payment_move in final_payment_moves:
                 igtf_line = payment_move.line_ids.filtered(lambda line: line.account_id.id in account)
                 bank_line = payment_move.line_ids.filtered(lambda line: line.account_id.account_type in ['asset_cash','asset_receivable'])
-                
-                if rec.move_type in ['out_invoice', 'out_refund']:
-                    target_account = partner_context.property_account_receivable_id
-                else:
-                    target_account = partner_context.property_account_payable_id
-
-                factura_line = rec.line_ids.filtered(lambda l: l.account_id.id == target_account.id)
-
                 pago_line = payment_move.line_ids.filtered(lambda l: l.account_id.id == target_account.id)
-                
-                partial = self.env['account.partial.reconcile'].search([
-                    '|',
-                    '&', ('debit_move_id', '=', factura_line.id), ('credit_move_id', 'in', pago_line.ids),
-                    '&', ('debit_move_id', 'in', pago_line.ids), ('credit_move_id', '=', factura_line.id)
-                ], limit=1)
-
-                if partial:
-                    if bank_line and bank_line[0].company_currency_id == self.env.ref("base.VEF"):
-                        partial_amount = abs(partial.foreign_amount)
-                        partial_foreign_amount = abs(partial.amount)
-                    else:
-                        partial_amount = abs(partial.amount)
-                        partial_foreign_amount = abs(partial.foreign_amount)
-
-                if bank_line:
-                   
-                    bank_amount = partial_amount
-                    foreign_bank_amount = partial_foreign_amount
-                        
-               
-                if igtf_line:
-                    if igtf_line[0].company_currency_id == self.env.ref("base.VEF"):
-                        igtf_amount = abs(igtf_line[0].foreign_balance) 
-                        foreign_igtf_amount = abs(igtf_line[0].balance) 
-                    else:
-                        igtf_amount = abs(igtf_line[0].balance)
-                        foreign_igtf_amount = abs(igtf_line[0].foreign_balance) 
-
-
-                if not igtf_line and bank_line:
-                    
-                    igtf_top += bank_amount
-
-
-
                 amount_base_payment = 0.0
                 foreign_amount_base_payment = 0.0
-
-                if igtf_line and bank_line:
-
-                    if payment_move.payment_id and payment_move.payment_id.reconciled_invoices_count > 1:
-
-                        amount_base_payment = partial_amount
-                        foreign_amount_base_payment = partial_foreign_amount
+                if bank_line:
+                    partials = self.env['account.partial.reconcile'].search([
+                        '|',
+                        '&', ('debit_move_id', 'in', factura_line.ids), ('credit_move_id', 'in', pago_line.ids),
+                        '&', ('debit_move_id', 'in', pago_line.ids), ('credit_move_id', 'in', factura_line.ids)
+                    ])
+                    partial_amount = 0.0
+                    partial_foreign_amount = 0.0
                     
-
-                    elif (bank_amount* (rec.company_id.igtf_percentage / 100)) < igtf_amount:
-                        if (bank_amount * (rec.company_id.igtf_percentage / 100)) == igtf_amount:
+                    for partial in partials:
+                        if bank_line and bank_line[0].company_currency_id == self.env.ref("base.VEF"):
+                            partial_amount += abs(partial.foreign_amount)
+                            partial_foreign_amount += abs(partial.amount)
+                        else:
+                            partial_amount += abs(partial.amount)
+                            partial_foreign_amount += abs(partial.foreign_amount or partial.amount) # Resguardo si es nulo
+                    
+                        bank_amount = partial_amount
+                        foreign_bank_amount = partial_foreign_amount
                             
-                            amount_base_payment = bank_amount
-                            foreign_amount_base_payment = foreign_bank_amount
+                
+                    if igtf_line:
+                        if igtf_line[0].company_currency_id == self.env.ref("base.VEF"):
+                            igtf_amount = abs(igtf_line[0].foreign_balance) 
+                            foreign_igtf_amount = abs(igtf_line[0].balance) 
+                        else:
+                            igtf_amount = abs(igtf_line[0].balance)
+                            foreign_igtf_amount = abs(igtf_line[0].foreign_balance) 
+
+
+                    if not igtf_line and bank_line:
+                        
+                        igtf_top += bank_amount
+
+                    if igtf_line and bank_line:
+
+                        if payment_move.payment_id and payment_move.payment_id.reconciled_invoices_count > 1:
+
+                            amount_base_payment = partial_amount
+                            foreign_amount_base_payment = partial_foreign_amount
+                        
+
+                        elif (bank_amount* (rec.company_id.igtf_percentage / 100)) < igtf_amount:
+                            if (bank_amount * (rec.company_id.igtf_percentage / 100)) == igtf_amount:
+                                
+                                amount_base_payment = bank_amount
+                                foreign_amount_base_payment = foreign_bank_amount
+                            else:
+                                
+                                amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
+                                foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
+
+                            
+                            if 'pos_payment_ids' in bank_line[0].move_id._fields:
+                                if bank_line[0].move_id.pos_payment_ids:
+                                    amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
+                                    foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
                         else:
                             
+
                             amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
                             foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
 
+                    if igtf_line:
                         
-                        if 'pos_payment_ids' in bank_line[0].move_id._fields:
-                            if bank_line[0].move_id.pos_payment_ids:
-                                amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
-                                foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
-                    else:
-                        
-
-                        amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
-                        foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
-
-                if igtf_line:
-                    
-                    alter_bi_igtf += igtf_amount
-                    foreign_alter_bi_igtf += foreign_igtf_amount
+                        alter_bi_igtf += igtf_amount
+                        foreign_alter_bi_igtf += foreign_igtf_amount
 
                 total_bi_igtf += amount_base_payment
                 total_foreign_bi_igtf += foreign_amount_base_payment
-            
-            
             apply = rec.igtf_top_aply - (igtf_top * (rec.company_id.igtf_percentage / 100))
             alter_apply = 0.0
             if rec.company_currency_id == self.env.ref("base.VEF"):
                 alter_apply = apply / rec.foreign_inverse_rate
             else:
                 alter_apply = apply * rec.foreign_inverse_rate
-
             
-            rec.write({
-                'igtf_top_aply': apply,
-                'alter_igtf_top_aply': alter_apply,
-                'alter_bi_igtf': alter_bi_igtf,
-                'foreign_alter_bi_igtf': foreign_alter_bi_igtf,
-                'foreign_bi_igtf': total_foreign_bi_igtf
-            })
+            rec.igtf_top_aply = apply
+            rec.alter_igtf_top_aply = alter_apply
+            rec.alter_bi_igtf = alter_bi_igtf
+            rec.foreign_alter_bi_igtf = foreign_alter_bi_igtf
+            rec.foreign_bi_igtf = total_foreign_bi_igtf
             rec.bi_igtf = total_bi_igtf

--- a/l10n_ve_igtf/models/account_tax.py
+++ b/l10n_ve_igtf/models/account_tax.py
@@ -1,8 +1,5 @@
 from odoo import models, _
 from odoo.tools.misc import formatLang
-from odoo.tools.float_utils import float_round, float_is_zero
-from odoo.exceptions import UserError
-
 
 import logging
 
@@ -15,163 +12,86 @@ class AccountTax(models.Model):
     def _prepare_tax_totals(
         self, base_lines, currency, tax_lines=None, igtf_base_amount=False, is_company_currency_requested=False
     ):
-        """
-        This function add values and calculated of igtf on invoices
-        ---------------
-        Returns: (Return inherited)
-        We add the following values to the dictionary:
-            - igtf :
-                - igtf_base_amount: float
-                - igtf_amount: float
-                - foreign_igtf_amount: float
-                - foreign_igtf_base_amount: float
-                - formatted_igtf_amount: str
-                - formatted_igtf_base_amount: str
-                - formatted_foreign_igtf_amount: str
-                - formatted_foreign_igtf_base_amount: str
-                - apply_igtf: bool
-            - amount_total_igtf : float
-            - formatted_amount_total_igtf: str
-            - foreign_amount_total_igtf: float
-            - formatted_foreign_amount_total_igtf: str
-        """
-        res = super()._prepare_tax_totals(base_lines, currency, tax_lines)
+        res = super()._prepare_tax_totals(
+            base_lines, currency, tax_lines, is_company_currency_requested=is_company_currency_requested
+        )
 
-        invoice = self.env["account.move"]
+        invoice = False
         order = False
-        apply_igtf = False
         type_model = ""
-        base_igtf = 0
-        foreign_base_igtf = 0
         is_igtf_suggested = False
-        invoice_payments_widget = False
-        payments_igtf = False
 
         for base_line in base_lines:
             type_model = base_line["record"]._name
-            if base_line["record"]._name == "account.move.line":
+            if type_model == "account.move.line":
                 invoice = base_line["record"].move_id
-            if base_line["record"]._name == "sale.order.line":
+            if type_model == "sale.order.line":
                 order = base_line["record"].order_id
 
-        foreign_currency = self.env.company.currency_foreign_id
-        rate = 0
+        float_igtf_percentage = self.env.company.igtf_percentage or 0.0
+        igtf_percentage = float_igtf_percentage / 100.0
 
-        if type_model == "account.move.line":
-            rate = invoice.foreign_inverse_rate
-        if type_model == "sale.order.line":
-            rate = order.foreign_inverse_rate
+        base_igtf_bs = 0.0
+        foreign_base_igtf = 0.0
 
-        float_igtf_percentage = self.env.company.igtf_percentage
-
-        igtf_percentage = (float_igtf_percentage or 0) / 100
-
-        if (
-            type_model == "account.move.line"
-            and self.env.company.show_igtf_suggested_account_move
-            and invoice.payment_state == "not_paid"
-        ):
-            is_igtf_suggested = True
-            base_igtf = res.get("amount_total", 0)
-            foreign_base_igtf = res.get("foreign_amount_total", 0)
-        if (
-            type_model == "sale.order.line"
-            and self.env.company.show_igtf_suggested_sale_order
-        ):
-            is_igtf_suggested = True
-            base_igtf = res.get("amount_total", 0)
-            foreign_base_igtf = res.get("foreign_amount_total", 0)
-
-        if invoice.bi_igtf:
-            if invoice.company_currency_id != self.env.ref("base.VEF"):
-               
-                base_igtf = invoice.bi_igtf
-                foreign_base_igtf =invoice.foreign_bi_igtf
-
-            else:
-
-                foreign_base_igtf = invoice.bi_igtf
-                base_igtf =  invoice.foreign_bi_igtf
-
-        igtf_base_amount = base_igtf 
-        igtf_foreign_base_amount = foreign_base_igtf 
-
-        if (
-            float_is_zero(igtf_base_amount, precision_rounding=currency.rounding)
-            == False
-        ):
-            apply_igtf = True
-
-        foreign_igtf_base_amount = igtf_foreign_base_amount 
-
-        igtf_amount = igtf_base_amount * igtf_percentage
-
-        foreign_igtf_amount = igtf_foreign_base_amount * igtf_percentage
+        if type_model == "account.move.line" and invoice:
+            if self.env.company.show_igtf_suggested_account_move and invoice.payment_state == "not_paid":
+                is_igtf_suggested = True
+                base_igtf_bs = res.get("amount_total", 0.0)
+                foreign_base_igtf = res.get("foreign_amount_total", 0.0)
             
+            elif hasattr(invoice, 'bi_igtf') and invoice.bi_igtf:
+                base_igtf_bs = invoice.bi_igtf
+                amount_total_bs = res.get("amount_total", 0.0)
+                if amount_total_bs > 0.0:
+                    porcion_base_igtf = base_igtf_bs / amount_total_bs
+                    foreign_base_igtf = res.get("foreign_amount_total", 0.0) * porcion_base_igtf
+                else:
+                    foreign_base_igtf = getattr(invoice, 'foreign_bi_igtf', 0.0) or base_igtf_bs
 
-        res["igtf"] = {}
-        res["igtf"]["apply_igtf"] = apply_igtf
-        res["igtf"]["name"] = f"{float_igtf_percentage} %"
+        elif type_model == "sale.order.line" and order:
+            if self.env.company.show_igtf_suggested_sale_order:
+                is_igtf_suggested = True
+                base_igtf_bs = res.get("amount_total", 0.0)
+                foreign_base_igtf = res.get("foreign_amount_total", 0.0)
+            elif hasattr(order, 'bi_igtf') and order.bi_igtf:
+                base_igtf_bs = order.bi_igtf
+                amount_total_bs = res.get("amount_total", 0.0)
+                if amount_total_bs > 0.0:
+                    porcion_base_igtf = base_igtf_bs / amount_total_bs
+                    foreign_base_igtf = res.get("foreign_amount_total", 0.0) * porcion_base_igtf
+                else:
+                    foreign_base_igtf = base_igtf_bs
 
-        res["igtf"]["igtf_base_amount"] = igtf_base_amount
-        res["igtf"]["formatted_igtf_base_amount"] = formatLang(
-            self.env, igtf_base_amount, currency_obj=currency
-        )
-        res["igtf"]["foreign_igtf_base_amount"] = foreign_igtf_base_amount
-        res["igtf"]["formatted_foreign_igtf_base_amount"] = formatLang(
-            self.env, foreign_igtf_base_amount, currency_obj=foreign_currency
-        )
+        apply_igtf = not currency.is_zero(base_igtf_bs)
 
-        res["igtf"]["igtf_amount"] = igtf_amount
-        res["igtf"]["formatted_igtf_amount"] = formatLang(
-            self.env, igtf_amount, currency_obj=currency
-        )
+        igtf_amount_bs = base_igtf_bs * igtf_percentage
+        foreign_igtf_amount = foreign_base_igtf * igtf_percentage
+        foreign_currency_id = self.env.company.currency_foreign_id
+        res["igtf"] = {
+            "apply_igtf": apply_igtf,
+            "name": f"{float_igtf_percentage} %",
+            "is_igtf_suggested": is_igtf_suggested,
+            
+            "igtf_base_amount": base_igtf_bs,
+            "formatted_igtf_base_amount": formatLang(self.env, base_igtf_bs, currency_obj=currency),
+            "foreign_igtf_base_amount": foreign_base_igtf,
+            "formatted_foreign_igtf_base_amount": formatLang(self.env, foreign_base_igtf, currency_obj=foreign_currency_id),
+            
+            "igtf_amount": igtf_amount_bs,
+            "formatted_igtf_amount": formatLang(self.env, igtf_amount_bs, currency_obj=currency),
+            "foreign_igtf_amount": foreign_igtf_amount,
+            "formatted_foreign_igtf_amount": formatLang(self.env, foreign_igtf_amount, currency_obj=foreign_currency_id),
+        }
 
-        res["igtf"]["foreign_igtf_amount"] = foreign_igtf_amount
-        res["igtf"]["formatted_foreign_igtf_amount"] = formatLang(
-            self.env, foreign_igtf_amount, currency_obj=foreign_currency
-        )
-        
-
-        res["amount_total_igtf"] = float_round(
-            res["amount_total"] + igtf_amount, precision_rounding=currency.rounding
-        )
+        res["amount_total_igtf"] = res.get("amount_total", 0.0) + igtf_amount_bs
         res["formatted_amount_total_igtf"] = formatLang(
             self.env, res["amount_total_igtf"], currency_obj=currency
         )
-        res["foreign_amount_total_igtf"] = float_round(
-            res["foreign_amount_total"] + foreign_igtf_amount,
-            precision_rounding=foreign_currency.rounding,
-        )
+
+        res["foreign_amount_total_igtf"] = res.get("foreign_amount_total", 0.0) + foreign_igtf_amount
         res["formatted_foreign_amount_total_igtf"] = formatLang(
-            self.env, res["foreign_amount_total_igtf"], currency_obj=foreign_currency
+            self.env, res["foreign_amount_total_igtf"], currency_obj=foreign_currency_id
         )
-        res["igtf"]["is_igtf_suggested"] = is_igtf_suggested
 
         return res
-
-    def process_payments_to_igtf(self,invoice):
-        invoice_payments_widget = invoice.invoice_payments_widget
-        content = invoice_payments_widget.get("content", False) if invoice_payments_widget else False
-
-        if not content:
-            return 0
-
-        payments_id = [
-            payment['account_payment_id']
-            for payment in content
-            if 'account_payment_id' in payment
-        ]
-
-        payments = self.env["account.payment"].browse(payments_id)
-
-        payments_igtf = payments.filtered(lambda p: p.is_igtf_on_foreign_exchange)
-
-        amount_to_igtf = [
-            payment["amount"]
-            for payment in content
-            if 'account_payment_id' in payment and payment['account_payment_id'] in payments_igtf.ids
-        ]
-        total_amount_to_igtf = sum(amount_to_igtf)  
-
-        return total_amount_to_igtf

--- a/l10n_ve_purchase/__manifest__.py
+++ b/l10n_ve_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Compras",
-    "version": "17.0.0.0.1",
+    "version": "17.0.0.0.2",
     "license": "LGPL-3",
     "summary": "Módulo para gestionar compras en Venezuela",
     "description": """

--- a/l10n_ve_purchase/models/purchase_order_line.py
+++ b/l10n_ve_purchase/models/purchase_order_line.py
@@ -4,12 +4,11 @@ from odoo import models, api, fields
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
-    def _prepare_account_move_line(self, move=False):
-        """
+    """def _prepare_account_move_line(self, move=False):
+        
         Override the account move line to use the price total instead of the price unit discounted.
         This fix ensures proper rounding to avoid precision residues (example, 0.0005) 
         that cause unbalanced move errors.
-        """
         res = super()._prepare_account_move_line(move=move)
         if 'balance' not in res:
             total_wo_tax = self.price_total
@@ -20,4 +19,4 @@ class PurchaseOrderLine(models.Model):
                 self.order_id.date_order or fields.Date.today(),
                 round=True,
             )
-        return res
+        return res"""

--- a/l10n_ve_rate/__manifest__.py
+++ b/l10n_ve_rate/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.0.0.4",
+    "version": "17.0.0.0.5",
     # any module necessary for this one to work correctly
     "depends": ["base", "l10n_ve_base"],
     "data": [

--- a/l10n_ve_rate/models/res_currency.py
+++ b/l10n_ve_rate/models/res_currency.py
@@ -1,50 +1,54 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.float_utils import float_round, float_compare, float_is_zero
 
 
 class ResCurrency(models.Model):
     _inherit = "res.currency"
 
-    def _convert(self, from_amount, to_currency, company=None, date=None, round=False, custom_rate=0.0):
-        """Returns the converted amount of ``from_amount``` from the currency
-           ``self`` to the currency ``to_currency`` for the given ``date`` and
-           company.
-
-           :param company: The company from which we retrieve the convertion rate
-           :param date: The nearest date from which we retriev the conversion rate.
-           :param round: Round the result or not
+    def _convert(self, from_amount, to_currency, company=None, date=None, round=True, custom_rate=0.0):
+        """
+        Versión Integrada: Soporta custom_rate y garantiza simetría de redondeo
+        para evitar descuadres de 0.01 en Bolívares y otras monedas.
         """
         if date is None:
             date = fields.Date.today()
         if company is None:
-            company = self.rate_ids.company_id
+            company = self.env.company
+            
         self, to_currency = self or to_currency, to_currency or self
         assert self, "convert amount from unknown currency"
         assert to_currency, "convert amount to unknown currency"
-        assert company, "convert amount from unknown company"
-        assert date, "convert amount from unknown date"
-        # apply conversion rate
+
+        if self == to_currency:
+            rate = 1.0
+        elif custom_rate > 0:
+            rate = custom_rate
+        else:
+            rate = self._get_conversion_rate(self, to_currency, company, date)
+
         if from_amount:
-            if custom_rate > 0:
-                to_amount = from_amount * custom_rate 
-            else:
-                to_amount = from_amount * self._get_conversion_rate(self, to_currency, company, date)
+            to_amount = from_amount * rate
         else:
             return 0.0
 
+        if round:
+            rounded_res = to_currency.round(to_amount)
+            
+            # PRUEBA DE REVERSIBILIDAD: ¿El redondeo mantiene la paridad?
+            # Dividimos el resultado redondeado entre la tasa para volver al origen
+            back_to_foreign = rounded_res / rate if rate else 0.0
+            diff_foreign = from_amount - back_to_foreign
+            
+            # Si hay una diferencia infinitesimal en la moneda origen (ruido de decimales)
+            if not float_is_zero(diff_foreign, precision_rounding=self.rounding):
+                # Calculamos el ajuste necesario en la moneda destino (Bolívares, Euros, etc.)
+                adjustment = float_round(diff_foreign * rate, precision_rounding=to_currency.rounding)
+                # Aplicamos el ajuste para que el asiento sea perfectamente reversible
+                
+                return rounded_res + adjustment
+     
+            return rounded_res
+        
         return to_amount
-    #override
-    def round(self, amount):
-        """"""
-        self.ensure_one()
-        amount_float = float(amount)
-
-        try:
-            amount_float = float(amount)
-        except (ValueError, TypeError):
-            return super(ResCurrency, self).round(amount)
-
-        if abs(amount_float - round(amount_float, 6)) > 1e-9:
-            return amount_float
-
-        return super(ResCurrency, self).round(amount_float)
+   

--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "17.0.1.1.22",
+    "version": "17.0.1.1.23",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -49,7 +49,6 @@ class SaleOrder(models.Model):
     foreign_inverse_rate = fields.Float(
         help="Rate that will be used as factor to multiply of the foreign currency for this move.",
         compute="_compute_rate",
-        digits=(16, 15),
         store=True,
         readonly=False,
     )
@@ -253,7 +252,6 @@ class SaleOrder(models.Model):
                 sale.foreign_rate = 0.0
                 sale.foreign_inverse_rate = 0.0
 
-    
 
     def _get_invoiceable_lines(self, final=False):
         if self._context.get("ignore_limit", False):

--- a/l10n_ve_sale/models/sale_order_line.py
+++ b/l10n_ve_sale/models/sale_order_line.py
@@ -58,28 +58,73 @@ class SaleOrderLine(models.Model):
             if record.foreign_inverse_rate != valor_orden:
                 record.foreign_inverse_rate = valor_orden
 
-    @api.depends("price_unit", "foreign_inverse_rate")
+    @api.depends("price_unit", "order_id.foreign_inverse_rate", "order_id.currency_id")
     def _compute_foreign_price(self):
+        """
+        Computes the foreign price unit for the sale order line applying strict alternate logic.
+        Uses standard, English-compliant abstract variable names.
+        """
         for line in self:
-            if line.price_unit and line.foreign_inverse_rate:
+            # Initialize to prevent CacheMiss errors
+            line.foreign_price = 0.0
+            
+            # Skip non-product lines (sections, notes) or zero prices
+            if line.display_type or not line.price_unit:
+                continue
                 
-                line.foreign_price = line.price_unit * line.order_id.foreign_inverse_rate
+            order = line.order_id
+            foreign_currency = self.env.company.currency_foreign_id
+            
+            if not order or not foreign_currency:
+                continue
+
+            # Extract the alternate inverse rate from the header safely
+            inverse_rate = order.foreign_inverse_rate if hasattr(order, "foreign_inverse_rate") else 0.0
+            
+            # Fallback security: use day rate if current record rate is not yet set
+            if inverse_rate <= 0.0:
+                inverse_rate = foreign_currency._get_conversion_rate(
+                    self.env.company.currency_id,
+                    foreign_currency,
+                    self.env.company,
+                    order.date_order or fields.Date.today(),
+                ) or 1.0
+
+            # =========================================================================
+            # CORRECT CURRENCY CONVERSION MATRIX (Odoo Standard Convention)
+            # =========================================================================
+            company_currency = self.env.company.currency_id
+            document_currency = line.currency_id
+
+            if document_currency == company_currency:
+                # If the document is in Company Currency (e.g., Base), 
+                # we MULTIPLY by the inverse rate to get the alternate value.
+                line.foreign_price = foreign_currency.round(line.price_unit * inverse_rate)
             else:
-                line.foreign_price = 0.0
+                # If the document is already in Foreign/Alternate Currency,
+                # we DIVIDE by the inverse rate to bring it back to the company's base value.
+                line.foreign_price = foreign_currency.round(line.price_unit / inverse_rate) if inverse_rate else 0.0
 
     @api.depends("product_uom_qty", "foreign_price", "discount")
     def _compute_foreign_subtotal(self):
-        
         for line in self:
-            if not line.product_uom_qty or not line.foreign_price:
-                line.foreign_subtotal = 0.0
-                continue
-            
             discount = line.discount if line.discount and not float_is_zero(line.discount, precision_digits=2) else 0.0
-            
+
             price_with_discount = line.foreign_price * (1 - (discount / 100.0))
-            
-            line.foreign_subtotal = price_with_discount * line.product_uom_qty
+            foreign_subtotal_teoric = price_with_discount * line.product_uom_qty
+
+           
+            if foreign_subtotal_teoric > 0.0 and line.price_subtotal > 0.0:
+                line.foreign_subtotal = foreign_subtotal_teoric
+                
+                porcion_total_con_iva = line.price_total / line.price_subtotal
+                
+                if hasattr(line, 'foreign_price_total'):
+                    line.foreign_price_total = foreign_subtotal_teoric * porcion_total_con_iva
+            else:
+                line.foreign_subtotal = foreign_subtotal_teoric
+                if hasattr(line, 'foreign_price_total'):
+                    line.foreign_price_total = foreign_subtotal_teoric
             
     def _prepare_invoice_line(self, **optional_values):
        

--- a/l10n_ve_sale/views/sale_order.xml
+++ b/l10n_ve_sale/views/sale_order.xml
@@ -23,13 +23,13 @@
 
             <xpath expr="//notebook/page/field[@name='order_line']/tree/field[@name='price_unit']"
                 position="after">
-                <field name="foreign_price" force_save="1" readonly="1"/>
+                <field name="foreign_price" widget="monetary" options="{'precision': 'Foreign Product Price'}" force_save="1" readonly="1"/>
             </xpath>
 
             <xpath
                 expr="//notebook/page/field[@name='order_line']/tree/field[@name='price_subtotal']"
                 position="after">
-                <field name="foreign_subtotal" />
+                <field name="foreign_subtotal" widget="monetary" options="{'precision': 'Foreign Product Price'}" />
                 <field name="foreign_rate" optional="hide" readonly="1" force_save="1"/>
                 <field
                     name="foreign_inverse_rate"

--- a/l10n_ve_tax/__manifest__.py
+++ b/l10n_ve_tax/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     # any module necessary for this one to work correctly
     "depends": ["base", "account", "l10n_ve_base", "l10n_ve_rate"],
     "data": [

--- a/l10n_ve_tax/models/account_tax.py
+++ b/l10n_ve_tax/models/account_tax.py
@@ -1,5 +1,5 @@
 from odoo.tools.float_utils import float_round, float_compare
-from odoo import api, models, _
+from odoo import api, models, _, fields
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools.misc import formatLang
 
@@ -15,122 +15,166 @@ class AccountTax(models.Model):
     def _prepare_tax_totals(
         self, base_lines, currency, tax_lines=None, is_company_currency_requested=False
     ):
+        """This function adds the alternate currency tax amounts to tax_totals.
+
+        It features an adaptive currency matrix that accurately determines whether to
+        multiply or divide to calculate alternate values (USD or VEF), ensuring precise
+        proportions without performance-heavy redundant loops.
         """
-        This function adds the alternate currency tax amounts to tax_totals.
-        In it, the parent function is executed 2 times, once for the original
-        currency and once for the alternate currency.
-        The data that is brought is not recalculated, that is, it comes from the lines of the entry
-        ------
-        Parameters: (Parameters inherited)
-            base_lines: list of dict
-            currency: res.currency
-        ------
-        Returns: (Return inherited)
-            dict: Now returns additionally:
-            "subtotal": float
-            "formatted_subtotal": str
-            "discount_amount": float
-            "foreign_subtotal": float
-            "foreign_formatted_subtotal": str
-            "formatted_discount_amount": str
-            "groups_by_foreign_subtotal": dict
-            "foreign_discount_amount": float
-            "foreign_formatted_discount_amount": str
-            "foreign_subtotals": list of dict
-            "foreign_amount_untaxed": float
-            "foreign_amount_total": float
-            "foreign_formatted_amount_untaxed": str
-            "foreign_formatted_amount_total": str
-        """
+        is_manual_edit = self.env.context.get('real_portion_manual_edit', False)
+        
         foreign_currency = self.env.company.currency_foreign_id or False
         if not foreign_currency:
             raise ValidationError(_("No foreign currency configured in the company"))
 
-        # Base Currency
+        # 1. Base Currency: Único llamado nativo necesario
         res = super()._prepare_tax_totals(
             base_lines,
             currency,
             tax_lines,
             is_company_currency_requested=is_company_currency_requested,
         )
-        res_without_discount = res.copy()
-        has_discount = not currency.is_zero(sum([line["discount"] for line in base_lines]))
 
-        if has_discount:
-            base_without_discount = [line.copy() for line in base_lines if line]
-            for base_line in base_without_discount:
-                base_line["discount"] = 0
-
-            res_without_discount = super()._prepare_tax_totals(
-                base_without_discount,
-                currency,
-                tax_lines,
-                is_company_currency_requested=is_company_currency_requested,
-            )
-
-        foreign_base_lines, foreign_tax_lines = self.get_foreign_base_tax_lines(
-            base_lines, tax_lines, foreign_currency
-        )
-
-        # Foreign Currency
-        foreign_taxes = super()._prepare_tax_totals(
-            foreign_base_lines,
-            foreign_currency,
-            foreign_tax_lines,
-            is_company_currency_requested=is_company_currency_requested,
-        )
-
-        foreign_taxes_without_discount = foreign_taxes.copy()
-        if has_discount:
-            foreign_without_discount = [line.copy() for line in foreign_base_lines if line]
-            for foreign_base_line in foreign_without_discount:
-                foreign_base_line["discount"] = 0
-
-            foreign_taxes_without_discount = super()._prepare_tax_totals(
-                foreign_without_discount,
+        # 2. Capturar el move para extraer la tasa inversa de la Porción Real
+        move = self._get_move_from_base_lines(base_lines)
+        inverse_rate = move.foreign_inverse_rate if move and hasattr(move, "foreign_inverse_rate") else 0.0
+        
+        if inverse_rate <= 0.0:
+            inverse_rate = foreign_currency._get_conversion_rate(
+                self.env.company.currency_id,
                 foreign_currency,
-                foreign_tax_lines,
-                is_company_currency_requested=is_company_currency_requested,
-            )
+                self.env.company,
+                move.date if move else fields.Date.today(),
+            ) or 1.0
 
-        res["groups_by_foreign_subtotal"] = foreign_taxes["groups_by_subtotal"]
-        res["foreign_subtotals"] = foreign_taxes["subtotals"]
-        res["foreign_amount_untaxed"] = foreign_taxes["amount_untaxed"]
-        res["foreign_amount_total"] = foreign_taxes["amount_total"]
-        res["foreign_formatted_amount_untaxed"] = foreign_taxes["formatted_amount_untaxed"]
-        res["foreign_formatted_amount_total"] = foreign_taxes["formatted_amount_total"]
+        # =========================================================================
+        # CORRECCIÓN CRÍTICA: MATRIZ DINÁMICA DE CONVERSIÓN 
+        # =========================================================================
+        # Evaluamos las monedas por su código/identificador para evitar fallas de contexto.
+        # 'currency' es la moneda de la factura actual. 'foreign_currency' es la alterna.
+        
+        if currency == foreign_currency:
+            # Si la factura ya está en la moneda alterna, el alterno debe ser la moneda base.
+            # Por ende, para pasar de la alterna (ej. VEF) a la base (ej. USD), se DIVIDE entre la tasa.
+            multiply_dir = False
+        else:
+            # Si la factura está en la moneda base (ej. USD) y queremos la alterna (ej. VEF), se MULTIPLICA.
+            # Si la factura está en una moneda x y la alterna es la débil (VEF), típicamente multiplicamos por la tasa.
+            multiply_dir = True
+
+        # Seguridad extrema contra tasas en cero para evitar caídas del sistema
+        if inverse_rate == 0.0:
+            inverse_rate = 1.0
+        # =========================================================================
+
+        # 3. Procesar importes globales alternos aplicando la dirección corregida
+        #foreign_amount_untaxed = foreign_currency.round(res["amount_untaxed"] * inverse_rate if multiply_dir else res["amount_untaxed"] / inverse_rate)
+        #foreign_amount_total = foreign_currency.round(res["amount_total"] * inverse_rate if multiply_dir else res["amount_total"] / inverse_rate)
+        is_manual_edit = self.env.context.get('real_portion_manual_edit', False)
+
+        if is_manual_edit and move and move.invoice_line_ids:
+            # Si el usuario editó un precio foráneo, SUMAMOS la masa real de la interfaz.
+            # No usamos la tasa porque la masa foránea ahora es independiente.
+            valid_lines = move.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_section', 'line_note'))
+            
+            foreign_amount_untaxed = sum(getattr(l, 'foreign_subtotal', 0.0) for l in valid_lines)
+            foreign_amount_total = sum(getattr(l, 'foreign_price_total', 0.0) for l in valid_lines)
+            
+            # Calculamos una tasa efectiva global basada en el IVA real acumulado de las líneas
+            # para que los grupos de impuestos inferiores se cuadren al centavo con la masa manual.
+            native_tax_total = res["amount_total"] - res["amount_untaxed"]
+            foreign_tax_total = foreign_amount_total - foreign_amount_untaxed
+            
+            effective_tax_rate = foreign_tax_total / native_tax_total if native_tax_total > 0.0 else inverse_rate
+        else:
+            # Flujo Automático Tradicional (Usa la conversión teórica por tasa)
+            foreign_amount_untaxed = res["amount_untaxed"] * inverse_rate if multiply_dir else res["amount_untaxed"] / inverse_rate
+            foreign_amount_total = res["amount_total"] * inverse_rate if multiply_dir else res["amount_total"] / inverse_rate
+            effective_tax_rate = inverse_rate
+
+        foreign_amount_untaxed = foreign_currency.round(foreign_amount_untaxed)
+        foreign_amount_total = foreign_currency.round(foreign_amount_total)
+        # 4. Mapear 'groups_by_foreign_subtotal' iterando sobre los grupos nativos
+        groups_by_foreign_subtotal = {}
+        for subtotal_title, tax_groups in res.get("groups_by_subtotal", {}).items():
+            f_groups = []
+            for group in tax_groups:
+                f_base = foreign_currency.round(group["tax_group_base_amount"] * inverse_rate if multiply_dir else group["tax_group_base_amount"] / inverse_rate)
+                #f_tax = foreign_currency.round(group["tax_group_amount"] * inverse_rate if multiply_dir else group["tax_group_amount"] / inverse_rate)
+                # El impuesto del grupo se recalcula usando la tasa efectiva de la masa de las líneas
+                if is_manual_edit:
+                    f_tax = foreign_currency.round(group["tax_group_amount"] * effective_tax_rate)
+                else:
+                    f_tax = foreign_currency.round(group["tax_group_amount"] * inverse_rate if multiply_dir else group["tax_group_amount"] / inverse_rate)
+
+                f_groups.append({
+                    **group,
+                    "tax_group_base_amount": f_base,
+                    "tax_group_amount": f_tax,
+                    "formatted_tax_group_base_amount": formatLang(self.env, f_base, currency_obj=foreign_currency),
+                    "formatted_tax_group_amount": formatLang(self.env, f_tax, currency_obj=foreign_currency),
+                })
+            groups_by_foreign_subtotal[subtotal_title] = f_groups
+
+        # 5. Mapear 'foreign_subtotals' iterando sobre los subtotales nativos
+        foreign_subtotals = []
+        for subtotal in res.get("subtotals", []):
+            #f_sub_amt = foreign_currency.round(subtotal["amount"] * inverse_rate if multiply_dir else subtotal["amount"] / inverse_rate)
+            if is_manual_edit:
+                # Si es manual, reflejamos directamente el monto untaxed consolidado de las líneas
+                f_sub_amt = foreign_amount_untaxed
+            else:
+                f_sub_amt = foreign_currency.round(subtotal["amount"] * inverse_rate if multiply_dir else subtotal["amount"] / inverse_rate)
+
+            foreign_subtotals.append({
+                **subtotal,
+                "amount": f_sub_amt,
+                "formatted_amount": formatLang(self.env, f_sub_amt, currency_obj=foreign_currency),
+            })
+
+        # 6. Gestión de Descuentos (Base y Alterno)
+        res_without_discount_untaxed = res["amount_untaxed"]
+        has_discount = not currency.is_zero(sum([line.get("discount", 0.0) for line in base_lines if "discount" in line]))
+
+        if has_discount and move:
+            total_gross_local = sum((line.price_unit * line.quantity) for line in move.invoice_line_ids)
+            if total_gross_local > res["amount_untaxed"]:
+                res_without_discount_untaxed = total_gross_local
+
+        #foreign_subtotal = foreign_currency.round(res_without_discount_untaxed * inverse_rate if multiply_dir else res_without_discount_untaxed / inverse_rate)
+        if is_manual_edit and move and move.invoice_line_ids:
+            valid_lines = move.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_section', 'line_note'))
+            # Sumamos los precios extranjeros directos multiplicados por la cantidad (antes de descuento)
+            foreign_subtotal = sum((l.foreign_price * l.quantity) for l in valid_lines)
+        else:
+            foreign_subtotal = res_without_discount_untaxed * inverse_rate if multiply_dir else res_without_discount_untaxed / inverse_rate
+
+        # 7. Inyección de valores en el diccionario 'res' conservando tus claves originales
+        res["groups_by_foreign_subtotal"] = groups_by_foreign_subtotal
+        res["foreign_subtotals"] = foreign_subtotals
+        res["foreign_amount_untaxed"] = foreign_amount_untaxed
+        res["foreign_amount_total"] = foreign_amount_total
+        res["foreign_formatted_amount_untaxed"] = formatLang(self.env, foreign_amount_untaxed, currency_obj=foreign_currency)
+        res["foreign_formatted_amount_total"] = formatLang(self.env, foreign_amount_total, currency_obj=foreign_currency)
 
         res["show_discount"] = self.env.company.show_discount_on_moves
 
-        res["subtotal"] = res_without_discount["amount_untaxed"]
+        res["subtotal"] = res_without_discount_untaxed
         res["formatted_subtotal"] = formatLang(self.env, res["subtotal"], currency_obj=currency)
 
-        res["foreign_subtotal"] = foreign_taxes_without_discount["amount_untaxed"]
-        res["foreign_formatted_subtotal"] = formatLang(
-            self.env, res["foreign_subtotal"], currency_obj=foreign_currency
-        )
+        res["foreign_subtotal"] = foreign_subtotal
+        res["foreign_formatted_subtotal"] = formatLang(self.env, res["foreign_subtotal"], currency_obj=foreign_currency)
 
-        res["discount_amount"] = res["amount_untaxed"] - res_without_discount["amount_untaxed"]
-        res["formatted_discount_amount"] = formatLang(
-            self.env, res["discount_amount"], currency_obj=currency
-        )
-        res["foreign_discount_amount"] = (
-            foreign_taxes["amount_untaxed"] - foreign_taxes_without_discount["amount_untaxed"]
-        )
-        res["foreign_formatted_discount_amount"] = formatLang(
-            self.env, res["foreign_discount_amount"], currency_obj=foreign_currency
-        )
+        res["discount_amount"] = res["amount_untaxed"] - res_without_discount_untaxed
+        res["formatted_discount_amount"] = formatLang(self.env, res["discount_amount"], currency_obj=currency)
+        
+        res["foreign_discount_amount"] = foreign_amount_untaxed - foreign_subtotal
+        res["foreign_formatted_discount_amount"] = formatLang(self.env, res["foreign_discount_amount"], currency_obj=foreign_currency)
 
-        move = self._get_move_from_base_lines(base_lines)
-
+        # 8. Pagos y Residuales Alternos
         amounts = self._get_total_paid_foreign(move, foreign_currency) if move else []
-
-
         res["foreign_total_amount_paid"] = sum(amounts)
            
-
-        foreign_amount_total = res.get('foreign_amount_total', 0.0)
-
         res["foreign_total_residual"] = foreign_amount_total - res["foreign_total_amount_paid"]
 
         formatted_result = 0 if float_compare(res['foreign_total_residual'], 0, precision_digits=foreign_currency.decimal_places) < 0 else res['foreign_total_residual']
@@ -161,413 +205,14 @@ class AccountTax(models.Model):
             return []
 
         amounts = []
-        # Odoo almacena esto como dict o como string JSON dependiendo de la versión/estado
         widget_data = move.invoice_payments_widget
         content = widget_data.get('content') or []
 
         for payment in content:
-            # Extraemos directamente el valor que vemos en tu imagen
-            # Usamos .get() por seguridad si el campo no existe en algún pago
             f_amount = payment.get('foreign_amount', 0.0)
 
-            # Opcional: Validar que el pago sea de la moneda que buscas
-            # En tu imagen sale 'foreign_id': 2
             amounts.append(f_amount)
 
         return amounts
 
-    def get_foreign_base_tax_lines(self, base_lines, tax_lines, currency):
-        foreign_base_lines = [line.copy() for line in base_lines if line]
-        foreign_tax_lines = None
-        if tax_lines:
-            foreign_tax_lines = [line.copy() for line in tax_lines if line]
-        taxes = []
-        for base_line in foreign_base_lines:
-            is_exists_foreign_price = "foreign_price" in base_line["record"]
-
-            if is_exists_foreign_price:
-                base_line["price_unit"] = base_line["record"].foreign_price
-                base_line["price_subtotal"] = base_line["record"].foreign_subtotal
-                base_line["currency"] = currency
-            else:
-                base_line["price_unit"] = base_line["record"].price_unit
-                base_line["price_subtotal"] = base_line["record"].price_subtotal
-                base_line["currency"] = base_line["record"].currency_id
-
-            if base_line["taxes"]:
-                taxes.append(
-                    {
-                        "tax": base_line["taxes"][0],
-                        "price": base_line["price_unit"],
-                        "base": base_line["price_subtotal"],
-                    }
-                )
-
-        tax_values_list = []
-        for base_line in foreign_base_lines:
-            tax_values_list += self._compute_taxes_for_single_line(base_line)[1]
-
-        round_globally = self.env.company.tax_calculation_rounding_method == "round_globally"
-
-        if foreign_tax_lines:
-            for tax_line in foreign_tax_lines:
-                tax_line["currency"] = currency
-                tax_line["tax_amount"] = 0.0
-                amount = 0.0
-                for tax in tax_values_list:
-                    if tax["tax_repartition_line"].id == tax_line["tax_repartition_line"].id:
-                        if not round_globally:
-                            amount += float_round(
-                                tax["amount"], precision_digits=currency.decimal_places
-                            )
-                        else:
-                            amount += tax["amount"]
-
-                tax_line["tax_amount"] = float_round(
-                    amount, precision_digits=currency.decimal_places
-                )
-
-        return foreign_base_lines, foreign_tax_lines
-
-    def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, is_refund=False, handle_price_include=True, include_caba_tags=False, fixed_multiplicator=1):
-        """Compute all information required to apply taxes (in self + their children in case of a tax group).
-        We consider the sequence of the parent for group of taxes.
-            Eg. considering letters as taxes and alphabetic order as sequence :
-            [G, B([A, D, F]), E, C] will be computed as [A, D, F, C, E, G]
-
-
-
-        :param price_unit: The unit price of the line to compute taxes on.
-        :param currency: The optional currency in which the price_unit is expressed.
-        :param quantity: The optional quantity of the product to compute taxes on.
-        :param product: The optional product to compute taxes on.
-            Used to get the tags to apply on the lines.
-        :param partner: The optional partner compute taxes on.
-            Used to retrieve the lang to build strings and for potential extensions.
-        :param is_refund: The optional boolean indicating if this is a refund.
-        :param handle_price_include: Used when we need to ignore all tax included in price. If False, it means the
-            amount passed to this method will be considered as the base of all computations.
-        :param include_caba_tags: The optional boolean indicating if CABA tags need to be taken into account.
-        :param fixed_multiplicator: The amount to multiply fixed amount taxes by.
-        :return: {
-            'total_excluded': 0.0,    # Total without taxes
-            'total_included': 0.0,    # Total with taxes
-            'total_void'    : 0.0,    # Total with those taxes, that don't have an account set
-            'base_tags: : list<int>,  # Tags to apply on the base line
-            'taxes': [{               # One dict for each tax in self and their children
-                'id': int,
-                'name': str,
-                'amount': float,
-                'base': float,
-                'sequence': int,
-                'account_id': int,
-                'refund_account_id': int,
-                'analytic': bool,
-                'price_include': bool,
-                'tax_exigibility': str,
-                'tax_repartition_line_id': int,
-                'group': recordset,
-                'tag_ids': list<int>,
-                'tax_ids': list<int>,
-            }],
-        } """
-        if not self:
-            company = self.env.company
-        else:
-            company = self[0].company_id._accessible_branches()[:1] or self[0].company_id
-
-        # 1) Flatten the taxes.
-        taxes, groups_map = self.flatten_taxes_hierarchy(create_map=True)
-
-        # 2) Deal with the rounding methods
-        if not currency:
-            currency = company.currency_id
-
-        # By default, for each tax, tax amount will first be computed
-        # and rounded at the 'Account' decimal precision for each
-        # PO/SO/invoice line and then these rounded amounts will be
-        # summed, leading to the total amount for that tax. But, if the
-        # company has tax_calculation_rounding_method = round_globally,
-        # we still follow the same method, but we use a much larger
-        # precision when we round the tax amount for each line (we use
-        # the 'Account' decimal precision + 5), and that way it's like
-        # rounding after the sum of the tax amounts of each line
-        prec = currency.rounding
-
-        # In some cases, it is necessary to force/prevent the rounding of the tax and the total
-        # amounts. For example, in SO/PO line, we don't want to round the price unit at the
-        # precision of the currency.
-        # The context key 'round' allows to force the standard behavior.
-        round_tax = False if company.tax_calculation_rounding_method == 'round_globally' else True
-        if 'round' in self.env.context:
-            round_tax = bool(self.env.context['round'])
-
-        if not round_tax:
-            prec *= 1e-5
-
-        # 3) Iterate the taxes in the reversed sequence order to retrieve the initial base of the computation.
-        #     tax  |  base  |  amount  |
-        # /\ ----------------------------
-        # || tax_1 |  XXXX  |          | <- we are looking for that, it's the total_excluded
-        # || tax_2 |   ..   |          |
-        # || tax_3 |   ..   |          |
-        # ||  ...  |   ..   |    ..    |
-        #    ----------------------------
-        def recompute_base(base_amount, incl_tax_amounts):
-            """ Recompute the new base amount based on included fixed/percent amounts and the current base amount. """
-            fixed_amount = incl_tax_amounts['fixed_amount']
-            division_amount = sum(tax_factor for _i, tax_factor in incl_tax_amounts['division_taxes'])
-            percent_amount = sum(tax_amount * sum_repartition_factor for _i, tax_amount, sum_repartition_factor in incl_tax_amounts['percent_taxes'])
-
-            if company.country_code == 'IN':
-                # For the indian case, when facing two percent price-included taxes having the same percentage,
-                # both need to produce the same tax amounts. To do that, the tax amount of those taxes are computed
-                # directly during the first traveling in reversed order.
-                total_tax_amount = 0.0
-                for i, tax_amount, sum_repartition_factor in incl_tax_amounts['percent_taxes']:
-                    gross_tax_amount = float_round(base * tax_amount / (100 + percent_amount), precision_rounding=prec)
-                    factored_tax_amount = float_round(gross_tax_amount * sum_repartition_factor, precision_rounding=prec)
-                    total_tax_amount += factored_tax_amount
-                    cached_tax_amounts[i] = gross_tax_amount
-                    fixed_amount += factored_tax_amount
-                for i, _tax_amount, _sum_repartition_factor in incl_tax_amounts['percent_taxes']:
-                    cached_base_amounts[i] = base - total_tax_amount
-                percent_amount = 0.0
-
-            incl_tax_amounts.update({
-                'percent_taxes': [],
-                'division_taxes': [],
-                'fixed_amount': 0.0,
-            })
-
-            return (base_amount - fixed_amount) / (1.0 + percent_amount / 100.0) * (100 - division_amount) / 100
-
-        # The first/last base must absolutely be rounded to work in round globally.
-        # Indeed, the sum of all taxes ('taxes' key in the result dictionary) must be strictly equals to
-        # 'price_included' - 'price_excluded' whatever the rounding method.
-        #
-        # Example using the global rounding without any decimals:
-        # Suppose two invoice lines: 27000 and 10920, both having a 19% price included tax.
-        #
-        #                   Line 1                      Line 2
-        # -----------------------------------------------------------------------
-        # total_included:   27000                       10920
-        # tax:              27000 / 1.19 = 4310.924     10920 / 1.19 = 1743.529
-        # total_excluded:   22689.076                   9176.471
-        #
-        # If the rounding of the total_excluded isn't made at the end, it could lead to some rounding issues
-        # when summing the tax amounts, e.g. on invoices.
-        # In that case:
-        #  - amount_untaxed will be 22689 + 9176 = 31865
-        #  - amount_tax will be 4310.924 + 1743.529 = 6054.453 ~ 6054
-        #  - amount_total will be 31865 + 6054 = 37919 != 37920 = 27000 + 10920
-        #
-        # By performing a rounding at the end to compute the price_excluded amount, the amount_tax will be strictly
-        # equals to 'price_included' - 'price_excluded' after rounding and then:
-        #   Line 1: sum(taxes) = 27000 - 22689 = 4311
-        #   Line 2: sum(taxes) = 10920 - 2176 = 8744
-        #   amount_tax = 4311 + 8744 = 13055
-        #   amount_total = 31865 + 13055 = 37920
-        base = price_unit * quantity
-        if self._context.get('round_base', True):
-            base = currency.round(base)
-
-        # For the computation of move lines, we could have a negative base value.
-        # In this case, compute all with positive values and negate them at the end.
-        sign = 1
-        if currency.is_zero(base):
-            sign = -1 if fixed_multiplicator < 0 else 1
-        elif base < 0:
-            sign = -1
-            base = -base
-
-        # Store the totals to reach when using price_include taxes (only the last price included in row)
-        total_included_checkpoints = {}
-        i = len(taxes) - 1
-        store_included_tax_total = True
-        # Keep track of the accumulated included fixed/percent amount.
-        incl_tax_amounts = {
-            'percent_taxes': [],
-            'division_taxes': [],
-            'fixed_amount': 0.0,
-        }
-        custom_fixed_amount_after = 0.0
-        # Store the tax amounts we compute while searching for the total_excluded
-        cached_base_amounts = {}
-        cached_tax_amounts = {}
-        is_base_affected = True
-        if handle_price_include:
-            for tax in reversed(taxes):
-                tax_repartition_lines = (
-                    is_refund
-                    and tax.refund_repartition_line_ids
-                    or tax.invoice_repartition_line_ids
-                ).filtered(lambda x: x.repartition_type == "tax")
-                sum_repartition_factor = sum(tax_repartition_lines.mapped("factor"))
-
-                if tax.include_base_amount and is_base_affected:
-                    base = recompute_base(base, incl_tax_amounts)
-                    store_included_tax_total = True
-                if self._context.get('force_price_include', tax.price_include):
-                    if tax.amount_type == 'percent':
-                        incl_tax_amounts['percent_taxes'].append((i, tax.amount, sum_repartition_factor))
-                    elif tax.amount_type == 'division':
-                        incl_tax_amounts['division_taxes'].append((i, tax.amount * sum_repartition_factor))
-                    elif tax.amount_type == 'fixed':
-                        incl_tax_amounts['fixed_amount'] = abs(quantity) * tax.amount * sum_repartition_factor * abs(fixed_multiplicator)
-                    else:
-                        # tax.amount_type == other (python)
-                        tax_amount = tax._compute_amount(base, sign * price_unit, quantity, product, partner, fixed_multiplicator)
-                        tax_amount = float_round(tax_amount, precision_rounding=prec)
-                        incl_tax_amounts['fixed_amount'] += tax_amount
-                        # Avoid unecessary re-computation
-                        cached_tax_amounts[i] = tax_amount
-                        custom_fixed_amount_after += tax_amount
-                    # In case of a zero tax, do not store the base amount since the tax amount will
-                    # be zero anyway. Group and Python taxes have an amount of zero, so do not take
-                    # them into account.
-                    if (
-                        store_included_tax_total
-                        and (tax.amount or tax.amount_type not in ("percent", "division", "fixed"))
-                        and i not in cached_tax_amounts
-                    ):
-                        total_included_checkpoints[i] = base - custom_fixed_amount_after
-                        store_included_tax_total = False
-                        custom_fixed_amount_after = 0.0
-                i -= 1
-                is_base_affected = tax.is_base_affected
-
-        total_excluded = recompute_base(base, incl_tax_amounts)
-        if self._context.get('round_base', True):
-            total_excluded = currency.round(total_excluded)
-
-        # 4) Iterate the taxes in the sequence order to compute missing tax amounts.
-        # Start the computation of accumulated amounts at the total_excluded value.
-        base = total_included = total_void = total_excluded
-
-        # Flag indicating the checkpoint used in price_include to avoid rounding issue must be skipped since the base
-        # amount has changed because we are currently mixing price-included and price-excluded include_base_amount
-        # taxes.
-        skip_checkpoint = False
-
-        # Get product tags, account.account.tag objects that need to be injected in all
-        # the tax_tag_ids of all the move lines created by the compute all for this product.
-        product_tag_ids = product.sudo().account_tag_ids.ids if product else []
-
-        taxes_vals = []
-        i = 0
-        cumulated_tax_included_amount = 0
-        for tax in taxes:
-            price_include = self._context.get('force_price_include', tax.price_include)
-
-            if price_include and i in cached_base_amounts:
-                tax_base_amount = cached_base_amounts[i]
-            elif price_include or tax.is_base_affected:
-                tax_base_amount = base
-            else:
-                tax_base_amount = total_excluded
-
-            tax_repartition_lines = (is_refund and tax.refund_repartition_line_ids or tax.invoice_repartition_line_ids).filtered(lambda x: x.repartition_type == 'tax')
-            sum_repartition_factor = sum(tax_repartition_lines.mapped('factor'))
-
-            #compute the tax_amount
-            if price_include and i in cached_tax_amounts:
-                tax_amount = cached_tax_amounts[i]
-            elif not skip_checkpoint and price_include and total_included_checkpoints.get(i) is not None and sum_repartition_factor != 0:
-                # We know the total to reach for that tax, so we make a substraction to avoid any rounding issues
-                tax_amount = total_included_checkpoints[i] - (base + cumulated_tax_included_amount)
-                cumulated_tax_included_amount = 0
-            else:
-                tax_amount = tax.with_context(force_price_include=False)._compute_amount(
-                    tax_base_amount, sign * price_unit, quantity, product, partner, fixed_multiplicator)
-
-            # Round the tax_amount multiplied by the computed repartition lines factor.
-            tax_amount = float_round(tax_amount, precision_rounding=prec)
-            factorized_tax_amount = float_round(tax_amount * sum_repartition_factor, precision_rounding=prec)
-
-            if price_include and total_included_checkpoints.get(i) is None:
-                cumulated_tax_included_amount += factorized_tax_amount
-
-            # If the tax affects the base of subsequent taxes, its tax move lines must
-            # receive the base tags and tag_ids of these taxes, so that the tax report computes
-            # the right total
-            subsequent_taxes = self.env['account.tax']
-            subsequent_tags = self.env['account.account.tag']
-            if tax.include_base_amount:
-                subsequent_taxes = taxes[i+1:].filtered('is_base_affected')
-
-                taxes_for_subsequent_tags = subsequent_taxes
-
-                if not include_caba_tags:
-                    taxes_for_subsequent_tags = subsequent_taxes.filtered(lambda x: x.tax_exigibility != 'on_payment')
-
-                subsequent_tags = taxes_for_subsequent_tags.get_tax_tags(is_refund, 'base')
-
-            # Compute the tax line amounts by multiplying each factor with the tax amount.
-            # Then, spread the tax rounding to ensure the consistency of each line independently with the factorized
-            # amount. E.g:
-            #
-            # Suppose a tax having 4 x 50% repartition line applied on a tax amount of 0.03 with 2 decimal places.
-            # The factorized_tax_amount will be 0.06 (200% x 0.03). However, each line taken independently will compute
-            # 50% * 0.03 = 0.01 with rounding. It means there is 0.06 - 0.04 = 0.02 as total_rounding_error to dispatch
-            # in lines as 2 x 0.01.
-            repartition_line_amounts = [float_round(tax_amount * line.factor, precision_rounding=prec) for line in tax_repartition_lines]
-            total_rounding_error = float_round(factorized_tax_amount - sum(repartition_line_amounts), precision_rounding=prec)
-            nber_rounding_steps = int(abs(total_rounding_error / currency.rounding))
-            rounding_error = float_round(nber_rounding_steps and total_rounding_error / nber_rounding_steps or 0.0, precision_rounding=prec)
-
-            for repartition_line, line_amount in zip(tax_repartition_lines, repartition_line_amounts):
-
-                if nber_rounding_steps:
-                    line_amount += rounding_error
-                    nber_rounding_steps -= 1
-
-                if not include_caba_tags and tax.tax_exigibility == 'on_payment':
-                    repartition_line_tags = self.env['account.account.tag']
-                else:
-                    repartition_line_tags = repartition_line.tag_ids
-
-                taxes_vals.append({
-                    'id': tax.id,
-                    'name': partner and tax.with_context(lang=partner.lang).name or tax.name,
-                    'amount': sign * line_amount,
-                    'base': float_round(sign * tax_base_amount, precision_rounding=prec),
-                    'sequence': tax.sequence,
-                    'account_id': repartition_line._get_aml_target_tax_account(force_caba_exigibility=include_caba_tags).id,
-                    'analytic': tax.analytic,
-                    'use_in_tax_closing': repartition_line.use_in_tax_closing,
-                    'price_include': price_include,
-                    'tax_exigibility': tax.tax_exigibility,
-                    'tax_repartition_line_id': repartition_line.id,
-                    'group': groups_map.get(tax),
-                    'tag_ids': (repartition_line_tags + subsequent_tags).ids + product_tag_ids,
-                    'tax_ids': subsequent_taxes.ids,
-                })
-
-                if not repartition_line.account_id:
-                    total_void += line_amount
-
-            # Affect subsequent taxes
-            if tax.include_base_amount:
-                base += factorized_tax_amount
-                if not price_include:
-                    skip_checkpoint = True
-
-            total_included += factorized_tax_amount
-            i += 1
-
-        base_taxes_for_tags = taxes
-        if not include_caba_tags:
-            base_taxes_for_tags = base_taxes_for_tags.filtered(lambda x: x.tax_exigibility != 'on_payment')
-
-        base_rep_lines = base_taxes_for_tags.mapped(is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids').filtered(lambda x: x.repartition_type == 'base')
-        round_base = self._context.get('round_base', True)
-        if round_base:
-            total_included = currency.round(total_included)
-        return {
-            'base_tags': base_rep_lines.tag_ids.ids + product_tag_ids,
-            'taxes': taxes_vals,
-            'total_excluded': sign * total_excluded,
-            'total_included': sign * total_included,
-            'total_void': sign * total_void,
-        }
+    


### PR DESCRIPTION
[FIX] l10n_ve_accountant, l10n_ve_igtf, l10n_ve_ta, l10n_ve_igtf, l10n_ve_sale, l10n_ve_tax:

-El campo foreign_amount_residual  en los apuntes contables al calcularse independientemente del amount_residual y no hacerlo de la misma forma que amount_residual no determinaba correctamente su valor para evitar este error se migra su logica a la funcion_compute_amount_residual desde donde se calcula amount_residual y de esta forma garantizar que tome los valores correctos, debido a esto se elimina _get_manual_foreign_amount_residual y _compute_foreign_amount_residuals

- Se refactoriza _prepare_reconciliation_single_partial la misma determinaba incorrectamente el valor alterno de las reconciliaciones parciales al convertir al convertir los motnos parciales por la tasa o tomando el balance alterno de la linea a reconciliar, lo q llevaba a que cuando el monto de los alternos no corresponde a la conversion usando la tasa los montos no cuadraran, esto pasa cuando se ajusta el precio alterno en las facturas o los montos alternos en los asientos lo cual tambien descuadraba los libros contables en cxc/cxp

- Se Ajustan las dependencias del caompo calculado foreign_amount_residual en el asiento contable, el mismo se ejcutaba de forma independiente de del campo amount_residual en el asiento contable, se unio a la logica nativa del amount_residual para q los mismos se calculen al mismo tiempo evitando llamados repetitivos, el mismo se ingreso a la funcion _compute_amount para q respetara la misma logica de los calculos.

- la funcion _compute_needed_terms() El método _compute_needed_terms es el encargado en Odoo v17 de precalcular los plazos de vencimiento y cuotas de una factura antes de transformarlos en apuntes contables (account.move.line). Este cambio extiende dicho método para inyectar de forma proporcional el balance en moneda extranjera (foreign_balance) en cada una de las cuotas generadas, basándose estrictamente en el peso porcentual que tiene cada cuota sobre el total de la factura en la moneda base ($\text{Bs.}$).

- ⚡ Impacto en el Sistema: Precisión en la Generación del Asiento: Afecta directamente la creación de las líneas de cuentas por cobrar y por pagar (account.move.line). Al dividir la factura en cuotas (por ejemplo, 50% inicial y 50% a 30 días), el asiento contable ya no arrastrará montos lineales inflados, sino que dividirá los dólares en la misma proporción matemática exacta.
- Agnóstico a las Tasas: Al calcularse por porción de documento (Cuota  / Total ) y no re-multiplicando por tasas flotantes del día en cada iteración, se bloquea la aparición de diferencias por redondeos decimales.

- 🎯 Beneficios Contables Consistencia en Cobros y Pagos: Los plazos de pago reflejarán el saldo real en dólares/bolivares que se le debe al proveedor o que el cliente nos debe por cada fecha de vencimiento.Fin de los "Picos" en la Conciliación: Al nacer las cuotas del asiento contable con sus dólares bien distribuidos desde el principio, los métodos de conciliación parcial (_prepare_reconciliation_single_partial) podrán amortizar los pagos sin generar distorsiones, montos agigantados o residuos erróneos en el histórico.

- se ajusta la funcion compute_bi_igtf para contemplar los pagos en diferentes plazos en una factura ya que el mismo no lo hacia.

-  Se elimina funcion compute_all() en la cual se trataba de eliminar los redondeos en los alternos debido a que ya se reformulo la funcion q calculo los impuestos alternos y _prepare_tax_totals para usar el enfoque de porcion real

References:

Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/12987 https://binaural.odoo.com/odoo/helpdesk/action-389/13098
- PR:
- Otros: