### PR TITLE
[FIX] l10n_ve_pos, l10n_ve_pos_mf: corregir error al abrir POS por redondeo de tasa

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.10",
+    "version": "17.0.1.0.0",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -37,8 +37,10 @@ patch(Order.prototype, {
   assert_editable() { },
   get init_conversion_rate() {
     //FIXME :Buscar una manera de esto sea por id y no por name
-    if (this.pos.currency.name == "VEF") {
-      return round_di(this.pos.config.foreign_inverse_rate, this.pos.currency.decimal_places);
+    if (this.pos.currency.name == "VEF" || this.pos.currency.name == "VES") {
+      // IMPORTANT: do not round inverse rate for Bolivar base.
+      // Small values (e.g. 0.0018...) rounded to 2 decimals become 0.00.
+      return this.pos.config.foreign_inverse_rate;
     }
     if (this.pos.currency.name == "USD") {
       return round_di(this.pos.config.foreign_rate, this.pos.foreign_currency.decimal_places);

--- a/l10n_ve_pos/static/src/overrides/models/payment_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/payment_model.js
@@ -45,7 +45,7 @@ patch(Payment.prototype, {
 	set_foreign_amount(amount, only = false) {
 		this.foreign_amount = amount;
 		if (!only) {
-			if (this.pos.currency.name == "VEF") {
+			if (this.pos.currency.name == "VEF" || this.pos.currency.name == "VES") {
 				if (this.payment_method.is_foreign_currency) {
 					this.amount = round_pr(this.foreign_amount * 1 / this.pos.foreign_currency.rate, this.pos.currency.rounding)
 					return;

--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
-    "version": "17.0.1.0.5",
+    "version": "17.0.2.0.0",
     "category": "Accounting",
     "summary": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
     "description": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",

--- a/l10n_ve_pos_mf/static/src/js/PosState.js
+++ b/l10n_ve_pos_mf/static/src/js/PosState.js
@@ -120,7 +120,7 @@ patch(PosStore.prototype, {
 
     if (order.orderlines.length > 0) {
 
-      let vef_base = this.currency.name === "VEF"
+      let vef_base = this.currency.name === "VEF" || this.currency.name === "VES"
 
       invoice['invoice_lines'] = order.orderlines.map((el) => {
 
@@ -289,4 +289,3 @@ patch(PosStore.prototype, {
     return await super.push_single_order.apply(this, [order, opts]);
   },
 })
-


### PR DESCRIPTION
Se elimina el redondeo de la tasa inversa cuando la moneda base es VES/VEF. Debido a que el valor de la tasa inversa es muy pequeño, el redondeo a los decimales de la moneda (2) resultaba en 0.00, impidiendo la apertura correcta del Punto de Venta y cálculos posteriores.

Se añade también soporte explícito para el nombre de moneda 'VES' y se actualizan las versiones de los módulos afectados.

References: https://binaural.odoo.com/odoo/helpdesk.ticket/13268