### PR TITLE
 Verificar error al momento de conciliar un pago, encuentra dos cuentas por cobrar que no lo permite

### DIFF
--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
         "depends": [
         "base",
         "l10n_ve_accountant",

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -87,27 +87,21 @@ class AccountMove(models.Model):
             else:
                 record.amount_residual_igtf = 0
 
-    @api.depends(
-        "bi_igtf",
-    )
-    def _compute_tax_totals(self):
-        return super()._compute_tax_totals()
 
     @api.depends('amount_residual')
     def compute_bi_igtf(self):
         for rec in self:
             if rec.journal_id.is_purchase_international:
-                rec.write({
-                    'igtf_top_aply': 0.0,
-                    'alter_igtf_top_aply': 0.0,
-                    'alter_bi_igtf': 0.0,
-                    'foreign_alter_bi_igtf': 0.0,
-                    'foreign_bi_igtf': 0.0,
-                    'bi_igtf': 0.0
-                })
+                
+                rec.igtf_top_aply = 0.0
+                rec.alter_igtf_top_aply = 0.0
+                rec.alter_bi_igtf = 0.0
+                rec.foreign_alter_bi_igtf = 0.0
+                rec.foreign_bi_igtf = 0.0
+                rec.bi_igtf = 0.0
                 continue
             
-            amount = rec.amount_total
+            amount = rec.amount_total 
             if rec.company_currency_id == self.env.ref("base.VEF"):
                 amount = rec.foreign_total_billed
             rec.igtf_top_aply = amount * (self.company_id.igtf_percentage / 100)
@@ -121,8 +115,8 @@ class AccountMove(models.Model):
 
             account = [self.company_id.customer_account_igtf_id.id,self.company_id.supplier_account_igtf_id.id ]
             
-            payment_moves = self.env['account.move']
-           
+            payment_moves = self.env['account.move'].sudo().with_company(rec.company_id)
+        
             all_partial_reconciles = receivable_payable_lines.matched_debit_ids | receivable_payable_lines.matched_credit_ids
             
             payment_moves |= all_partial_reconciles.mapped('debit_move_id.move_id')
@@ -140,111 +134,99 @@ class AccountMove(models.Model):
             foreign_igtf_amount = 0.0
             target_account = False
 
-            partial_amount = 0.0
-            partial_foreign_amount = 0.0
             partner_context = rec.partner_id.with_company(rec.company_id)
+
+            if rec.move_type in ['out_invoice', 'out_refund']:
+                target_account = partner_context.property_account_receivable_id
+            else:
+                target_account = partner_context.property_account_payable_id
+            factura_line = rec.line_ids.filtered(lambda l: l.account_id.id == target_account.id)
             for payment_move in final_payment_moves:
                 igtf_line = payment_move.line_ids.filtered(lambda line: line.account_id.id in account)
                 bank_line = payment_move.line_ids.filtered(lambda line: line.account_id.account_type in ['asset_cash','asset_receivable'])
-                
-                if rec.move_type in ['out_invoice', 'out_refund']:
-                    target_account = partner_context.property_account_receivable_id
-                else:
-                    target_account = partner_context.property_account_payable_id
-
-                factura_line = rec.line_ids.filtered(lambda l: l.account_id.id == target_account.id)
-
                 pago_line = payment_move.line_ids.filtered(lambda l: l.account_id.id == target_account.id)
-                
-                partial = self.env['account.partial.reconcile'].search([
-                    '|',
-                    '&', ('debit_move_id', '=', factura_line.id), ('credit_move_id', 'in', pago_line.ids),
-                    '&', ('debit_move_id', 'in', pago_line.ids), ('credit_move_id', '=', factura_line.id)
-                ], limit=1)
-
-                if partial:
-                    if bank_line and bank_line[0].company_currency_id == self.env.ref("base.VEF"):
-                        partial_amount = abs(partial.foreign_amount)
-                        partial_foreign_amount = abs(partial.amount)
-                    else:
-                        partial_amount = abs(partial.amount)
-                        partial_foreign_amount = abs(partial.foreign_amount)
-
-                if bank_line:
-                   
-                    bank_amount = partial_amount
-                    foreign_bank_amount = partial_foreign_amount
-                        
-               
-                if igtf_line:
-                    if igtf_line[0].company_currency_id == self.env.ref("base.VEF"):
-                        igtf_amount = abs(igtf_line[0].foreign_balance) 
-                        foreign_igtf_amount = abs(igtf_line[0].balance) 
-                    else:
-                        igtf_amount = abs(igtf_line[0].balance)
-                        foreign_igtf_amount = abs(igtf_line[0].foreign_balance) 
-
-
-                if not igtf_line and bank_line:
-                    
-                    igtf_top += bank_amount
-
-
-
                 amount_base_payment = 0.0
                 foreign_amount_base_payment = 0.0
-
-                if igtf_line and bank_line:
-
-                    if payment_move.payment_id and payment_move.payment_id.reconciled_invoices_count > 1:
-
-                        amount_base_payment = partial_amount
-                        foreign_amount_base_payment = partial_foreign_amount
+                if bank_line:
+                    partials = self.env['account.partial.reconcile'].search([
+                        '|',
+                        '&', ('debit_move_id', 'in', factura_line.ids), ('credit_move_id', 'in', pago_line.ids),
+                        '&', ('debit_move_id', 'in', pago_line.ids), ('credit_move_id', 'in', factura_line.ids)
+                    ])
+                    partial_amount = 0.0
+                    partial_foreign_amount = 0.0
                     
-
-                    elif (bank_amount* (rec.company_id.igtf_percentage / 100)) < igtf_amount:
-                        if (bank_amount * (rec.company_id.igtf_percentage / 100)) == igtf_amount:
+                    for partial in partials:
+                        if bank_line and bank_line[0].company_currency_id == self.env.ref("base.VEF"):
+                            partial_amount += abs(partial.foreign_amount)
+                            partial_foreign_amount += abs(partial.amount)
+                        else:
+                            partial_amount += abs(partial.amount)
+                            partial_foreign_amount += abs(partial.foreign_amount or partial.amount) # Resguardo si es nulo
+                    
+                        bank_amount = partial_amount
+                        foreign_bank_amount = partial_foreign_amount
                             
-                            amount_base_payment = bank_amount
-                            foreign_amount_base_payment = foreign_bank_amount
+                
+                    if igtf_line:
+                        if igtf_line[0].company_currency_id == self.env.ref("base.VEF"):
+                            igtf_amount = abs(igtf_line[0].foreign_balance) 
+                            foreign_igtf_amount = abs(igtf_line[0].balance) 
+                        else:
+                            igtf_amount = abs(igtf_line[0].balance)
+                            foreign_igtf_amount = abs(igtf_line[0].foreign_balance) 
+
+
+                    if not igtf_line and bank_line:
+                        
+                        igtf_top += bank_amount
+
+                    if igtf_line and bank_line:
+
+                        if payment_move.payment_id and payment_move.payment_id.reconciled_invoices_count > 1:
+
+                            amount_base_payment = partial_amount
+                            foreign_amount_base_payment = partial_foreign_amount
+                        
+
+                        elif (bank_amount* (rec.company_id.igtf_percentage / 100)) < igtf_amount:
+                            if (bank_amount * (rec.company_id.igtf_percentage / 100)) == igtf_amount:
+                                
+                                amount_base_payment = bank_amount
+                                foreign_amount_base_payment = foreign_bank_amount
+                            else:
+                                
+                                amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
+                                foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
+
+                            
+                            if 'pos_payment_ids' in bank_line[0].move_id._fields:
+                                if bank_line[0].move_id.pos_payment_ids:
+                                    amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
+                                    foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
                         else:
                             
+
                             amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
                             foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
 
+                    if igtf_line:
                         
-                        if 'pos_payment_ids' in bank_line[0].move_id._fields:
-                            if bank_line[0].move_id.pos_payment_ids:
-                                amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
-                                foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
-                    else:
-                        
-
-                        amount_base_payment = igtf_amount / (rec.company_id.igtf_percentage / 100)
-                        foreign_amount_base_payment = foreign_igtf_amount / (rec.company_id.igtf_percentage / 100)
-
-                if igtf_line:
-                    
-                    alter_bi_igtf += igtf_amount
-                    foreign_alter_bi_igtf += foreign_igtf_amount
+                        alter_bi_igtf += igtf_amount
+                        foreign_alter_bi_igtf += foreign_igtf_amount
 
                 total_bi_igtf += amount_base_payment
                 total_foreign_bi_igtf += foreign_amount_base_payment
-            
-            
             apply = rec.igtf_top_aply - (igtf_top * (rec.company_id.igtf_percentage / 100))
             alter_apply = 0.0
             if rec.company_currency_id == self.env.ref("base.VEF"):
                 alter_apply = apply / rec.foreign_inverse_rate
             else:
                 alter_apply = apply * rec.foreign_inverse_rate
-
             
-            rec.write({
-                'igtf_top_aply': apply,
-                'alter_igtf_top_aply': alter_apply,
-                'alter_bi_igtf': alter_bi_igtf,
-                'foreign_alter_bi_igtf': foreign_alter_bi_igtf,
-                'foreign_bi_igtf': total_foreign_bi_igtf
-            })
+            rec.igtf_top_aply = apply
+            rec.alter_igtf_top_aply = alter_apply
+            rec.alter_bi_igtf = alter_bi_igtf
+            rec.foreign_alter_bi_igtf = foreign_alter_bi_igtf
+            rec.foreign_bi_igtf = total_foreign_bi_igtf
             rec.bi_igtf = total_bi_igtf

--- a/l10n_ve_purchase/__manifest__.py
+++ b/l10n_ve_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Compras",
-    "version": "17.0.0.0.1",
+    "version": "17.0.0.0.2",
     "license": "LGPL-3",
     "summary": "Módulo para gestionar compras en Venezuela",
     "description": """

--- a/l10n_ve_purchase/models/purchase_order_line.py
+++ b/l10n_ve_purchase/models/purchase_order_line.py
@@ -10,7 +10,8 @@ class PurchaseOrderLine(models.Model):
         This fix ensures proper rounding to avoid precision residues (example, 0.0005) 
         that cause unbalanced move errors.
         """
-        res = super()._prepare_account_move_line(move=move)
+        "Se comenta porq esto se solucion solventando la cantidad de digitos en la tasa inversa la cual estaba limitada y en ocaciones procia la diferenc"
+        """res = super()._prepare_account_move_line(move=move)
         if 'balance' not in res:
             total_wo_tax = self.price_total
             res['balance'] = self.currency_id._convert(
@@ -20,4 +21,4 @@ class PurchaseOrderLine(models.Model):
                 self.order_id.date_order or fields.Date.today(),
                 round=True,
             )
-        return res
+        return res"""

--- a/l10n_ve_purchase/models/purchase_order_line.py
+++ b/l10n_ve_purchase/models/purchase_order_line.py
@@ -4,21 +4,4 @@ from odoo import models, api, fields
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
-    def _prepare_account_move_line(self, move=False):
-        """
-        Override the account move line to use the price total instead of the price unit discounted.
-        This fix ensures proper rounding to avoid precision residues (example, 0.0005) 
-        that cause unbalanced move errors.
-        """
-        "Se comenta porq esto se solucion solventando la cantidad de digitos en la tasa inversa la cual estaba limitada y en ocaciones procia la diferenc"
-        """res = super()._prepare_account_move_line(move=move)
-        if 'balance' not in res:
-            total_wo_tax = self.price_total
-            res['balance'] = self.currency_id._convert(
-                total_wo_tax,
-                self.company_id.currency_id,
-                self.company_id,
-                self.order_id.date_order or fields.Date.today(),
-                round=True,
-            )
-        return res"""
+    


### PR DESCRIPTION
[FIX] l10n_ve_igtft, l10n_ve_ipurshase: Verificar error al momento de conciliar un pago, encuentra dos cuentas por cobrar que no lo permite

Descripción corta en español (1 línea).

- Se solventa el error al reformular la funcion de compute_big_igtf para que tome en cuenta que ina factura puede tener varias cuentas por cobrar para su calculo.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/13326
- Tarea:
- PR:
- Otros: