### PR TITLE
Discrepancia de montos en Reporte de Vencido…por Pagar (Moneda Alterna)

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.50",
+    "version": "17.0.0.0.51",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -166,12 +166,38 @@ class AccountMove(models.Model):
     
     foreign_inverse_rate_vef = fields.Float(compute="_compute_inverse_rate_vef",store=True)
 
-    foreign_amount_residual = fields.Monetary('Foreign Amount Residual',copy=False, compute = "_compute_foreign_amount_residual", currency_field="foreign_currency_id",readonly=False)
+    foreign_amount_residual = fields.Monetary('Foreign Amount Residual',copy=False, compute = "_compute_amount", currency_field="foreign_currency_id",readonly=False)
 
-    @api.depends('amount_residual','company_currency_id','foreign_inverse_rate')
-    def _compute_foreign_amount_residual(self):
-        for rec in self:
-            rec.foreign_amount_residual = rec.amount_residual * rec.foreign_inverse_rate
+    @api.depends(
+        'line_ids.matched_debit_ids.debit_move_id.move_id.payment_id.is_matched',
+        'line_ids.matched_debit_ids.debit_move_id.move_id.line_ids.amount_residual',
+        'line_ids.matched_debit_ids.debit_move_id.move_id.line_ids.amount_residual_currency',
+        'line_ids.matched_credit_ids.credit_move_id.move_id.payment_id.is_matched',
+        'line_ids.matched_credit_ids.credit_move_id.move_id.line_ids.amount_residual',
+        'line_ids.matched_credit_ids.credit_move_id.move_id.line_ids.amount_residual_currency',
+        'line_ids.balance',
+        'line_ids.currency_id',
+        'line_ids.amount_currency',
+        'line_ids.amount_residual',
+        'line_ids.amount_residual_currency',
+        'line_ids.payment_id.state',
+        'line_ids.full_reconcile_id',
+        'state',
+        'line_ids.matched_debit_ids.debit_move_id.move_id.line_ids.foreign_amount_residual',
+        'line_ids.matched_credit_ids.credit_move_id.move_id.line_ids.foreign_amount_residual',
+    )
+    def _compute_amount(self):
+        super()._compute_amount()
+        for move in self:
+            total_residual_currency = 0.0
+            for line in move.line_ids:
+                if line.display_type == 'payment_term':
+                    total_residual_currency += line.foreign_amount_residual
+            sign = move.direction_sign
+            if move.is_invoice(include_receipts=True):
+                move.foreign_amount_residual = -sign * total_residual_currency
+            else:
+                move.foreign_amount_residual = abs(total_residual_currency)
             
          
 
@@ -274,44 +300,35 @@ class AccountMove(models.Model):
             container = {'records': moves}
             moves._sync_dynamic_lines(container)
 
-    @api.depends("invoice_line_ids", "tax_totals")
+    @api.depends("invoice_line_ids.price_unit", "invoice_line_ids.quantity", "invoice_line_ids.discount", "tax_totals")
     def _compute_detailed_amounts(self):
         for record in self:
-            discount_amount = 0
-            if not record.tax_totals:
-                record.detailed_amounts = dict()
-                return
-            amount_taxed = record.tax_totals.get(
-                "amount_total", 0
-            ) - record.tax_totals.get("amount_untaxed", 0)
-            total = 0
+            # Inicializamos siempre para evitar errores si no entra en la lógica
+            total = 0.0
+            discount_amount = 0.0
+            amount_taxed = 0.0
+            
+            if record.tax_totals:
+                amount_taxed = record.tax_totals.get("amount_total", 0.0) - record.tax_totals.get("amount_untaxed", 0.0)
 
-            for line in record.invoice_line_ids:
+            # Calculamos sobre las líneas de factura de forma segura
+            for line in record.invoice_line_ids.filtered(lambda l: l.display_type == 'product'):
                 subtotal = line.price_unit * line.quantity
                 if line.discount > 0:
-                    discount_amount += subtotal - line.price_subtotal
+                    discount_amount += (subtotal - line.price_subtotal)
                 total += subtotal
 
-            record.detailed_amounts = dict(
-                {
-                    "gross_amount": total,
-                    "formatted_gross_amount": formatLang(
-                        self.env, total, currency_obj=self.currency_id
-                    ),
-                    "discount_amount": discount_amount,
-                    "formatted_discount_amount": formatLang(
-                        self.env, discount_amount, currency_obj=self.currency_id
-                    ),
-                    "gross_discount_amount": total,
-                    "formatted_gross_discount_amount": formatLang(
-                        self.env, total - discount_amount, currency_obj=self.currency_id
-                    ),
-                    "taxes_amount": amount_taxed,
-                    "formatted_taxes_amount": formatLang(
-                        self.env, amount_taxed, currency_obj=self.currency_id
-                    ),
-                }
-            )
+            # Asignamos el diccionario completo sin usar 'return' para no romper el bucle masivo
+            record.detailed_amounts = {
+                "gross_amount": total,
+                "formatted_gross_amount": formatLang(self.env, total, currency_obj=record.currency_id),
+                "discount_amount": discount_amount,
+                "formatted_discount_amount": formatLang(self.env, discount_amount, currency_obj=record.currency_id),
+                "gross_discount_amount": total - discount_amount, # Corregido: antes estaba 'total' a secas en dict original
+                "formatted_gross_discount_amount": formatLang(self.env, total - discount_amount, currency_obj=record.currency_id),
+                "taxes_amount": amount_taxed,
+                "formatted_taxes_amount": formatLang(self.env, amount_taxed, currency_obj=record.currency_id),
+            }
 
 
     @api.model

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -82,15 +82,15 @@ class AccountMoveLine(models.Model):
 
     foreign_amount_residual = fields.Monetary(
         currency_field="foreign_currency_id",
-        compute="_compute_foreign_amount_residuals",
+        compute="_compute_amount_residual",
         store=True,
-        readonly=True,
+        readonly=False,
     )
     foreign_amount_residual_currency = fields.Monetary(
         currency_field="foreign_currency_id",
-        compute="_compute_foreign_amount_residuals",
+        compute="_compute_amount_residual",
         store=True,
-        readonly=True,
+        readonly=False,
     )
 
 
@@ -114,27 +114,41 @@ class AccountMoveLine(models.Model):
             else:
                 line.foreign_price = 0.0
 
-    @api.depends("foreign_price", "quantity", "discount", "tax_ids", "price_unit")
+    @api.depends('foreign_price', 'quantity', 'discount', 'price_subtotal', 'price_total')
     def _compute_foreign_subtotal(self):
-        for line in self:
-            line_discount_price_unit = line.foreign_price * (
-                1 - (line.discount / 100.0)
-            )
-            foreign_subtotal = line_discount_price_unit * line.quantity
+        for move in self.mapped('move_id'):
+            lines = self.filtered(lambda l: l.move_id == move and l.display_type not in ('line_section', 'line_note'))
+            if not lines:
+                continue
 
-            if line.tax_ids:
-                taxes_res = line.tax_ids.with_context(round_base=False).compute_all(
-                    line_discount_price_unit,
-                    quantity=line.quantity,
-                    currency=line.foreign_currency_id,
-                    product=line.product_id,
-                    partner=line.partner_id,
-                    is_refund=line.is_refund,
-                )
-                line.foreign_subtotal = taxes_res["total_excluded"]
-                line.foreign_price_total = taxes_res["total_included"]
-            else:
-                line.foreign_price_total = line.foreign_subtotal = foreign_subtotal
+            total_foreign_subtotal_target = sum(l.foreign_price * l.quantity * (1 - l.discount / 100.0) for l in lines)
+            
+            accumulated_subtotal = 0.0
+            accumulated_total = 0.0
+            last_line = lines[-1]
+
+            for line in lines:
+                disc_factor = 1 - (line.discount / 100.0)
+                
+                if line != last_line:
+                    line.foreign_subtotal = line.foreign_price * disc_factor * line.quantity
+                    
+                    ratio_iva = line.price_total / line.price_subtotal if line.price_subtotal else 1.0
+                    line.foreign_price_total = line.foreign_subtotal * ratio_iva
+                    
+                    accumulated_subtotal += line.foreign_subtotal
+                    accumulated_total += line.foreign_price_total
+                else:
+                   
+                    line.foreign_subtotal = total_foreign_subtotal_target - accumulated_subtotal
+                    
+                    total_base_move = sum(l.price_total for l in lines)
+                    subtotal_base_move = sum(l.price_subtotal for l in lines)
+                    
+                    global_ratio = total_base_move / subtotal_base_move if subtotal_base_move else 1.0
+                    total_foreign_target = total_foreign_subtotal_target * global_ratio
+                    
+                    line.foreign_price_total = total_foreign_target - accumulated_total
 
     @api.depends(
         "debit",
@@ -239,10 +253,7 @@ class AccountMoveLine(models.Model):
             foreign_currency = line.company_id.currency_foreign_id
             
             if foreign_currency:
-                if hasattr(line.move_id, 'origin_payment_advanced_payment_id') and line.move_id.origin_payment_advanced_payment_id:
-                    rate_date = line.move_id.origin_payment_advanced_payment_id.date
-                else:
-                    rate_date = line.date
+                rate_date = line.date
                 rate = foreign_currency._get_conversion_rate(
                     line.company_id.currency_id,
                     foreign_currency,
@@ -691,7 +702,7 @@ class AccountMoveLine(models.Model):
     
 
     @api.depends('debit', 'credit', 'amount_currency', 'account_id', 'currency_id', 'company_id',
-                 'matched_debit_ids', 'matched_credit_ids')
+                 'matched_debit_ids', 'matched_credit_ids','foreign_balance')
     def _compute_amount_residual(self):
         """ Computes the residual amount of a move line from a reconcilable account in the company currency and the line's currency.
             This amount will be 0 for fully reconciled lines or lines from a non-reconcilable account, the original line amount
@@ -702,18 +713,26 @@ class AccountMoveLine(models.Model):
         # using _origin, new records (with a NewId) are excluded and the
         # computation works automagically for virtual onchange records as well.
         stored_lines = need_residual_lines._origin
+        amounts_map = {}
+        foreign_amounts_map = {}
 
         if stored_lines:
             self.env['account.partial.reconcile'].flush_model()
             self.env['res.currency'].flush_model(['decimal_places'])
 
             aml_ids = tuple(stored_lines.ids)
-            self._cr.execute('''
+            PartialModel = self.env['account.partial.reconcile']
+            has_debit_fa = hasattr(PartialModel, 'debit_foreign_amount_currency')
+            has_credit_fa = hasattr(PartialModel, 'credit_foreign_amount_currency')
+            debit_field_sql = "SUM(part.debit_foreign_amount_currency)" if has_debit_fa else "0.0"
+            credit_field_sql = "SUM(part.credit_foreign_amount_currency)" if has_credit_fa else "0.0"
+            self._cr.execute(f'''
                 SELECT
                     part.debit_move_id AS line_id,
                     'debit' AS flag,
                     COALESCE(SUM(part.amount), 0.0) AS amount,
-                    SUM(part.debit_amount_currency) AS amount_currency
+                    SUM(part.debit_amount_currency) AS amount_currency,
+                    COALESCE({debit_field_sql}, 0.0) AS foreign_amount
                 FROM account_partial_reconcile part
                 JOIN res_currency curr ON curr.id = part.debit_currency_id
                 WHERE part.debit_move_id IN %s
@@ -723,16 +742,16 @@ class AccountMoveLine(models.Model):
                     part.credit_move_id AS line_id,
                     'credit' AS flag,
                     COALESCE(SUM(part.amount), 0.0) AS amount,
-                    SUM(part.credit_amount_currency) AS amount_currency
+                    SUM(part.credit_amount_currency) AS amount_currency,
+                    COALESCE({credit_field_sql}, 0.0) AS foreign_amount
                 FROM account_partial_reconcile part
                 JOIN res_currency curr ON curr.id = part.credit_currency_id
                 WHERE part.credit_move_id IN %s
                 GROUP BY part.credit_move_id, curr.decimal_places
             ''', [aml_ids, aml_ids])
-            amounts_map = {
-                (line_id, flag): (amount, amount_currency)
-                for line_id, flag, amount, amount_currency in self.env.cr.fetchall()
-            }
+            for line_id, flag, amount, amount_currency, foreign_amount in self.env.cr.fetchall():
+                amounts_map[(line_id, flag)] = (amount, amount_currency)
+                foreign_amounts_map[(line_id, flag)] = foreign_amount
         else:
             amounts_map = {}
 
@@ -740,6 +759,8 @@ class AccountMoveLine(models.Model):
         for line in self - need_residual_lines:
             line.amount_residual = 0.0
             line.amount_residual_currency = 0.0
+            line.foreign_amount_residual = 0.0
+            line.foreign_amount_residual_currency = 0.0
             line.reconciled = False
 
         for line in need_residual_lines:
@@ -751,15 +772,18 @@ class AccountMoveLine(models.Model):
             debit_amount, debit_amount_currency = amounts_map.get((line._origin.id, 'debit'), (0.0, 0.0))
             credit_amount, credit_amount_currency = amounts_map.get((line._origin.id, 'credit'), (0.0, 0.0))
 
+            debit_foreign = foreign_amounts_map.get((line._origin.id, 'debit'), 0.0)
+            credit_foreign = foreign_amounts_map.get((line._origin.id, 'credit'), 0.0)
             # Subtract the values from the account.partial.reconcile to compute the residual amounts.
             residual = line.balance - debit_amount + credit_amount
             residual_currency = line.amount_currency - debit_amount_currency + credit_amount_currency
             
             line.amount_residual = residual
             line.amount_residual_currency = residual_currency
-            # Para determinar si está conciliado, usamos una tolerancia mínima 
-            # en lugar de un cero absoluto, o comparamos directamente.
             line.reconciled = (line.amount_residual == 0.0 and line.amount_residual_currency == 0.0)
+
+            line.foreign_amount_residual = line.foreign_balance - debit_foreign + credit_foreign
+            line.foreign_amount_residual_currency = line.foreign_amount_residual
 
 
     @api.onchange('amount_currency', 'currency_id','foreign_inverse_rate')


### PR DESCRIPTION
[FIX]l10n_ve_accountant: Discrepancia de montos en Reporte de Vencido…por Pagar (Moneda Alterna)

- Se verifica que la discrepancia entre el monto que se muestra en el reporte contable y la factura se debe a que el campo foreign_amount_residual es que dicho campo en la factura es la simple conversion del monto residual nativo en la tasa que se realizo la factura, se cambio para que el misno se calculara de igual forma que el amount_residual nativo, se unio en la misma funcion para q se ejecuten al mismo tiempo (_compute_amount)

- la funcion _compute_detailed_amounts() se ajusto para q trabajara correctamente con el tipo de dato ya que trabajaba con Dicts pero los trataba como tupla provocando q en ocaciones el los montos no se computaran bien

-foreign_amount_residual y foreign_amount_residual_currency ahora se computan correctamente dentro de la funcion nativa _compute_amount_residual

- _compute_foreign_subtotal() al recalcularse cuando cambiaba el monto foraneo en ocaciones descuadraba el asiento ya que el mismo no contemplaba el importe total alterno del asiento, se aplico el principo de Porcion real para mantener la congruencia(aun puede existir una pequeña diferencia de decimales dependiendo de las tasas)

-
References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/12987
- Tarea:
- PR:
- Otros: