### PR TITLE
-fix(l10n_ve_contact #Ticket13369): evitar error de validación al fus…

### DIFF
--- a/l10n_ve_contact/__init__.py
+++ b/l10n_ve_contact/__init__.py
@@ -1,5 +1,5 @@
 from . import models
-
+from . import wizard
 import logging
 
 _logger = logging.getLogger(__name__)

--- a/l10n_ve_contact/__manifest__.py
+++ b/l10n_ve_contact/__manifest__.py
@@ -10,7 +10,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Contacts/Contacts",
-    "version": "17.0.0.0.6",
+    "version": "17.0.0.0.7",
     "depends": ["base", "contacts", "l10n_ve_rate", "l10n_ve_location"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_ve_contact/__manifest__.py
+++ b/l10n_ve_contact/__manifest__.py
@@ -10,7 +10,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Contacts/Contacts",
-    "version": "17.0.0.0.7",
+    "version": "17.0.0.0.9",
     "depends": ["base", "contacts", "l10n_ve_rate", "l10n_ve_location"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_ve_contact/i18n/es_VE.po
+++ b/l10n_ve_contact/i18n/es_VE.po
@@ -44,6 +44,13 @@ msgstr "Ya existe un cliente con el mismo RIF/CI/PAS para esta compañía."
 #. module: l10n_ve_contact
 #. odoo-python
 #: code:addons/l10n_ve_contact/models/res_partner.py:0
+#, python-format
+msgid "A partner with the same VAT number already exists."
+msgstr "Ya existe un cliente con la misma identificación."
+
+#. module: l10n_ve_contact
+#. odoo-python
+#: code:addons/l10n_ve_contact/models/res_partner.py:0
 #: code:addons/l10n_ve_contact/models/res_partner.py:0
 #, python-format
 msgid "A partner with the same email address already exists for this company."

--- a/l10n_ve_contact/models/res_partner.py
+++ b/l10n_ve_contact/models/res_partner.py
@@ -99,7 +99,7 @@ class ResPartner(models.Model):
 
     def check_duplicate_vat(self, prefix_vat, vat, company_id=None):
         error_message = ""
-        merge_partner_ids = self.env.context.get("active_ids") or []
+        merge_partner_ids = self.env.context.get("l10n_ve_merge_partner_ids") or []
         if isinstance(merge_partner_ids, int):
             merge_partner_ids = [merge_partner_ids]
 
@@ -109,7 +109,7 @@ class ResPartner(models.Model):
             ("id", "!=", self.id if self else False),
         ]
 
-        if merge_partner_ids and self.env.context.get("active_model") == "res.partner":
+        if self.env.context.get("l10n_ve_partner_merge_validation") and merge_partner_ids:
             domain.append(("id", "not in", merge_partner_ids))
 
         if prefix_vat and vat:

--- a/l10n_ve_contact/models/res_partner.py
+++ b/l10n_ve_contact/models/res_partner.py
@@ -99,11 +99,18 @@ class ResPartner(models.Model):
 
     def check_duplicate_vat(self, prefix_vat, vat, company_id=None):
         error_message = ""
+        merge_partner_ids = self.env.context.get("active_ids") or []
+        if isinstance(merge_partner_ids, int):
+            merge_partner_ids = [merge_partner_ids]
+
         domain = [
             ("prefix_vat", "=", prefix_vat),
             ("vat", "=", vat),
             ("id", "!=", self.id if self else False),
         ]
+
+        if merge_partner_ids and self.env.context.get("active_model") == "res.partner":
+            domain.append(("id", "not in", merge_partner_ids))
 
         if prefix_vat and vat:
             if self.env.company.validate_user_creation_by_company:

--- a/l10n_ve_contact/models/res_partner.py
+++ b/l10n_ve_contact/models/res_partner.py
@@ -126,8 +126,12 @@ class ResPartner(models.Model):
                 error_message = _(
                     "A partner with the same VAT number already exists for this company."
                 )
+            else:
+                error_message = _(
+                    "A partner with the same VAT number already exists."
+                )
 
-            existing_partner = self.env["res.partner"].search(domain)
+            existing_partner = self.env["res.partner"].search(domain, limit=1)
             if existing_partner:
                 raise ValidationError(error_message)
 
@@ -183,7 +187,7 @@ class ResPartner(models.Model):
                     if not flag:
                         continue
                     vals["name"] = name
-            if "vat" and "prefix_vat" in vals:
+            if "vat" in vals and "prefix_vat" in vals:
                 self.check_duplicate_vat(vals.get("prefix_vat"), vals.get("vat"))
             if "email" in vals:
                 self.check_duplicate_email(vals.get("email"))
@@ -191,9 +195,12 @@ class ResPartner(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if "prefix_vat" and "vat" in vals:
+        if "vat" in vals or "prefix_vat" in vals:
             for record in self:
-                record.check_duplicate_vat(vals.get("prefix_vat"), vals.get("vat"))
+                record.check_duplicate_vat(
+                    vals.get("prefix_vat", record.prefix_vat),
+                    vals.get("vat", record.vat),
+                )
         if "email" in vals:
             for record in self:
                 record.check_duplicate_email(vals.get("email"))

--- a/l10n_ve_contact/tests/test_l1on_ve_contact.py
+++ b/l10n_ve_contact/tests/test_l1on_ve_contact.py
@@ -48,6 +48,37 @@ class TestResPartner(TransactionCase):
         # Should not raise
         self.partner._check_vat()
 
+    def test_duplicate_vat_with_active_ids_context_still_fails(self):
+        partner_2 = self.env["res.partner"].create({
+            "name": "Context Partner",
+            "prefix_vat": "V",
+            "vat": "99887766",
+            "email": "context@example.com",
+            "country_id": self.env.ref("base.ve").id,
+        })
+
+        with self.assertRaises(ValidationError):
+            partner_2.with_context(
+                active_model="res.partner",
+                active_ids=[self.partner.id, partner_2.id],
+            ).write({"prefix_vat": "V", "vat": self.partner.vat})
+
+    def test_duplicate_vat_with_explicit_merge_context_is_allowed(self):
+        partner_2 = self.env["res.partner"].create({
+            "name": "Merge Partner",
+            "prefix_vat": "V",
+            "vat": "11223344",
+            "email": "merge@example.com",
+            "country_id": self.env.ref("base.ve").id,
+        })
+
+        partner_2.with_context(
+            l10n_ve_partner_merge_validation=True,
+            l10n_ve_merge_partner_ids=[self.partner.id, partner_2.id],
+        ).write({"prefix_vat": "V", "vat": self.partner.vat})
+
+        self.assertEqual(partner_2.vat, self.partner.vat)
+
     def _create_partner_transaction(self, partner):
         """Create at least one related transaction for the partner when possible.
 

--- a/l10n_ve_contact/wizard/__init__.py
+++ b/l10n_ve_contact/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import base_partner_merge_automatic_wizard

--- a/l10n_ve_contact/wizard/base_partner_merge_automatic_wizard.py
+++ b/l10n_ve_contact/wizard/base_partner_merge_automatic_wizard.py
@@ -12,6 +12,8 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
                 "l10n_ve_merge_partner_ids": (src_partners | dst_partner).ids,
             }
         )
+        src_partners_ctx = src_partners.with_context(merge_context)
+        dst_partner_ctx = dst_partner.with_context(merge_context)
         return super(
             BasePartnerMergeAutomaticWizard, self.with_context(merge_context)
-        )._update_values(src_partners, dst_partner)
+        )._update_values(src_partners_ctx, dst_partner_ctx)

--- a/l10n_ve_contact/wizard/base_partner_merge_automatic_wizard.py
+++ b/l10n_ve_contact/wizard/base_partner_merge_automatic_wizard.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class BasePartnerMergeAutomaticWizard(models.TransientModel):
+    _inherit = "base.partner.merge.automatic.wizard"
+
+    def _update_values(self, src_partners, dst_partner):
+        merge_context = dict(self.env.context)
+        merge_context.update(
+            {
+                "l10n_ve_partner_merge_validation": True,
+                "l10n_ve_merge_partner_ids": (src_partners | dst_partner).ids,
+            }
+        )
+        return super(
+            BasePartnerMergeAutomaticWizard, self.with_context(merge_context)
+        )._update_values(src_partners, dst_partner)


### PR DESCRIPTION
…ionar

-Se ajusta la validación de duplicado de RIF/VAT en check_duplicate_vat. Durante la fusión de contactos (active_model = res.partner), se excluyen los IDs en active_ids del dominio de búsqueda. Esto evita que los propios contactos en proceso de merge sean detectados como duplicados entre sí. Se permite completar la fusión y continuar el flujo sin ValidationError. 
-https://binaural.odoo.com/odoo/all-tickets/13369