### PR TITLE
FIX#13504 Not displaying total foreign

### DIFF
--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -98,6 +98,8 @@
                     sum="Total Foreign Debit"
                     readonly="1"
                     force_save="1"
+                    widget="monetary"
+                    options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"
                 />
                 <field
                     name="foreign_credit"
@@ -105,10 +107,12 @@
                     sum="Total Foreign Credit"
                     readonly="1"
                     force_save="1"
+                    widget="monetary"
+                    options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"
                 />
                 <field name="foreign_debit_adjustment" optional="hide" force_save="1"/>
                 <field name="foreign_credit_adjustment" optional="hide" force_save="1"/>
-                <field name="foreign_balance" optional="hide" groups="base.group_no_one" force_save="1"/>
+                <field name="foreign_balance" optional="hide" groups="base.group_no_one" force_save="1" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
                 <field name="foreign_rate" optional="hide" groups="base.group_no_one" force_save="1"/>
                 <field
                     name="foreign_inverse_rate"

--- a/l10n_ve_accountant/views/account_move_line.xml
+++ b/l10n_ve_accountant/views/account_move_line.xml
@@ -25,11 +25,12 @@
 	<field name="inherit_id" ref="account.view_move_line_tree"/>
 	<field name="arch" type="xml">
 	    <xpath expr="//field[@name='balance']" position="after">
-		<field name="foreign_debit" readonly="1" optional="show" sum="Total Foreign Debit" options="{'precision': 'Foreign Product Price'}"/>
+		<field name="foreign_currency_id" column_invisible="True"/>
+		<field name="foreign_debit" readonly="1" optional="show" sum="Total Foreign Debit" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
 		<field name="foreign_debit_adjustment" optional="hide" options="{'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_credit" readonly="1" optional="show" sum="Total Foreign Credit" options="{'precision': 'Foreign Product Price'}"/>
+		<field name="foreign_credit" readonly="1" optional="show" sum="Total Foreign Credit" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
 		<field name="foreign_credit_adjustment" optional="hide" options="{'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_balance" readonly="1" optional="hide" options="{'precision': 'Foreign Product Price'}"/>
+		<field name="foreign_balance" readonly="1" optional="hide" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
                     
 
 	    </xpath>


### PR DESCRIPTION
Al visualizar los account.move.line desde un pago o cruce, el footer del tree mostraba (--) en la sumatoria de los campos foreign_debit y foreign_credit, mientras que en moneda base (debit/credit) sí aparecía el total correctamente.

Solucion:
  1. foreign_currency_id — Sin esto, ese dato nunca llega al contexto y el widget del footer se queda sin saber contra qué moneda trabajar.
  2. widget='monetary' — fuerza el uso del componente MonetaryField de forma explícita, que es quien sabe leer la columna anterior y resolver el símbolo y los decimales a usar.
  3. options con currency_field — le indica al widget cuál de todas las columnas del tree contiene el id de la moneda que le interesa.

Ticket: https://binaural.odoo.com/odoo/my-tickets/13504