### PR TITLE
FIX #72707: l10n_ve_sale

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -359,7 +359,7 @@ class SaleOrder(models.Model):
                 not self.env.company.update_sale_order_rate_using_date_order
                 and not float_is_zero(
                     sale.foreign_rate,
-                    precision_rounding=self.env.company.currency_id.rounding,
+                    precision_rounding=sale.company_id.currency_id.rounding,
                 )
             ):
                 continue


### PR DESCRIPTION
Problema: sincronizacion de las ordenes de venta entre los ambientes

Solución:

- Se adapta la validacion de float is zero para que use la compania de la orden de venta, ya que desde los controladores de los modulos de integracion no siempre el env esta bien definido.

Tarea (Link): https://binaural.odoo.com/odoo/action-341/72707

Tarea de proyecto [x]
Ticket de soporte []