### PR TITLE
[FEAT] l10n_ve_invoice:

### DIFF
--- a/l10n_ve_invoice/README.rst
+++ b/l10n_ve_invoice/README.rst
@@ -1,0 +1,33 @@
+=====================
+Venezuela - Facturación
+=====================
+
+.. |badge1| image:: https://img.shields.io/badge/licence-LGPL--3-blue.png
+    :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+    :alt: License: LGPL-3
+
+|badge1|
+
+Módulo de Facturación Venezuela.
+
+**Tabla de Contenidos**
+
+.. contents::
+   :local:
+
+Créditos
+========
+
+Autor/es
+~~~~~~~~
+
+* Binauraldev
+
+Mantenedor/es
+~~~~~~~~~~~~~
+
+Este módulo es mantenido por Binaural.
+
+.. image:: https://binauraldev.com/wp-content/uploads/2022/01/logo-binaural.png
+   :alt: Binaural dev
+   :target: https://binauraldev.com/

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "17.0.1.0.2",
+    "version": "17.0.1.0.3",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -5,7 +5,7 @@
     """,
     "version": "17.0.1.0.3",
     "license": "LGPL-3",
-    "author": "binaural-dev",
+    "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
     "depends": [

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -251,7 +251,7 @@ msgstr "Libro de Compras"
 #: code:addons/l10n_ve_invoice/wizard/accounting_reports.py:0
 #, python-format
 msgid "Check the move %s does not have an invoice date and its id is %s"
-msgstr "Verifique el asiento %s no tiene una fecha de factura"
+msgstr "Verifique el asiento %s no tiene una fecha de factura y su id es %s"
 
 #. module: l10n_ve_invoice
 #: model:ir.model,name:l10n_ve_invoice.model_res_company

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250522\n"
+"Project-Id-Version: Odoo Server 17.0+e-20251016\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-25 20:45+0000\n"
-"PO-Revision-Date: 2026-03-25 20:45+0000\n"
+"POT-Creation-Date: 2026-06-15 16:04+0000\n"
+"PO-Revision-Date: 2026-06-15 16:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -432,6 +432,16 @@ msgid ""
 msgstr ""
 "Permite habilitar las secuencias de la facturación por series en los diarios"
 " de ventas."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+#, python-format
+msgid ""
+"It is not possible to confirm with a date posterior to the current one. "
+"Please verify the document date before proceeding."
+msgstr "No es posible confirmar con una fecha posterior a la actual. "
+"Por favor, verifique la fecha del documento antes de continuar."
 
 #. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_account_move_form_l10n_ve_invoice

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -4,7 +4,6 @@ import logging
 import calendar
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
-from odoo.tools import format_date
 from odoo.tools import format_date, float_is_zero, float_compare
 
 _logger = logging.getLogger(__name__)
@@ -105,7 +104,7 @@ class AccountMove(models.Model):
             invoices = record.env['account.move'].with_company(self.env.company.id).sudo().search([("correlative","=",correlative),('move_type', 'in',["out_invoice","out_refund"]),('company_id', '=', self.env.company.id)])
 
             if invoices and record.move_type in ["out_invoice","out_refund"]:
-                raise ValidationError(_("An invoice already exists with the Control Number: %s" % correlative))
+                raise ValidationError(_("An invoice already exists with the Control Number: %s") % correlative)
             if record.invoice_date and record.date and record.date < record.invoice_date:
                 raise UserError(_("The accounting date cannot be earlier than the invoice date."))
             if record.invoice_date:
@@ -208,7 +207,7 @@ class AccountMove(models.Model):
             max_product_invoice = self.company_id.max_product_invoice
             if len(self.invoice_line_ids) > max_product_invoice:
                 raise ValidationError(
-                    _("You can not add more than %s products to the invoice." % max_product_invoice)
+                    _("You can not add more than %s products to the invoice.") % max_product_invoice
                 )
 
     @api.depends("payment_term_details")
@@ -354,13 +353,11 @@ class AccountMove(models.Model):
 
             if changes:
                 move.message_post(
-                    body=_(
-                        """
+                    body="""
                         <div>
                             <ul>%s</ul>
                         </div>
-                        """
-                    ) % "".join(changes),
+                        """ % "".join(changes),
                     message_type='notification',
                     body_is_html=True
                 )

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -104,7 +104,7 @@ class AccountMove(models.Model):
             invoices = record.env['account.move'].with_company(self.env.company.id).sudo().search([("correlative","=",correlative),('move_type', 'in',["out_invoice","out_refund"]),('company_id', '=', self.env.company.id)])
 
             if invoices and record.move_type in ["out_invoice","out_refund"]:
-                raise ValidationError(_("An invoice already exists with the Control Number: %s") % correlative)
+                raise ValidationError(_("An invoice already exists with the Control Number: %s", correlative))
             if record.invoice_date and record.date and record.date < record.invoice_date:
                 raise UserError(_("The accounting date cannot be earlier than the invoice date."))
             if record.invoice_date:
@@ -207,7 +207,7 @@ class AccountMove(models.Model):
             max_product_invoice = self.company_id.max_product_invoice
             if len(self.invoice_line_ids) > max_product_invoice:
                 raise ValidationError(
-                    _("You can not add more than %s products to the invoice.") % max_product_invoice
+                    _("You can not add more than %s products to the invoice.", max_product_invoice)
                 )
 
     @api.depends("payment_term_details")

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -108,6 +108,10 @@ class AccountMove(models.Model):
                 raise ValidationError(_("An invoice already exists with the Control Number: %s" % correlative))
             if record.invoice_date and record.date and record.date < record.invoice_date:
                 raise UserError(_("The accounting date cannot be earlier than the invoice date."))
+            if record.invoice_date:
+                today = fields.Date.context_today(record)
+                if record.invoice_date > today:
+                    raise ValidationError(_("It is not possible to confirm with a date posterior to the current one. Please verify the document date before proceeding."))
         return super().action_post()
 
     @api.model_create_multi

--- a/l10n_ve_invoice/tests/test_account_move.py
+++ b/l10n_ve_invoice/tests/test_account_move.py
@@ -132,6 +132,17 @@ class TestAccountMove(TransactionCase):
             }
         )
 
+        self.debit_journal = self.env["account.journal"].create(
+            {
+                "name": "Diario de Débito",
+                "code": "DEB",
+                "type": "sale",
+                "is_debit": True,
+                "sequence_id": sequence.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
         self.other_sales_journal = self.env["account.journal"].create(
             {
                 "name": "Diario de Ventas Otra Compañía",
@@ -394,3 +405,47 @@ class TestAccountMove(TransactionCase):
 
         with self.assertRaises(ValidationError):
             invoice.action_post()
+
+    def test_08_action_post_future_invoice_date_validation(self):
+        invoice = self._create_invoice(
+            products=[{"product_id": self.product.id, "price_unit": 100}],
+            move_type="out_invoice",
+            invoice_date=fields.Date.today() + timedelta(days=1),
+            date=fields.Date.today() + timedelta(days=1),
+            journal=self.sales_journal,
+        )
+        with self.assertRaises(ValidationError) as cm:
+            invoice.action_post()
+        self.assertIn("It is not possible to confirm with a date posterior to the current one", str(cm.exception))
+
+        original_invoice = self._create_invoice(
+            products=[{"product_id": self.product.id, "price_unit": 100}],
+            move_type="out_invoice",
+            invoice_date=fields.Date.today(),
+            date=fields.Date.today(),
+            journal=self.sales_journal,
+        )
+        original_invoice.action_post()
+        credit_note = self._create_invoice(
+            products=[{"product_id": self.product.id, "price_unit": 100}],
+            move_type="out_refund",
+            reversed_entry_id=original_invoice,
+            invoice_date=fields.Date.today() + timedelta(days=1),
+            date=fields.Date.today() + timedelta(days=1),
+            journal=self.sales_journal,
+        )
+        with self.assertRaises(ValidationError) as cm:
+            credit_note.action_post()
+        self.assertIn("It is not possible to confirm with a date posterior to the current one", str(cm.exception))
+
+        debit_note = self._create_invoice(
+            products=[{"product_id": self.product.id, "price_unit": 100}],
+            move_type="out_invoice",
+            debit_origin_id=original_invoice,
+            invoice_date=fields.Date.today() + timedelta(days=1),
+            date=fields.Date.today() + timedelta(days=1),
+            journal=self.debit_journal,
+        )
+        with self.assertRaises(ValidationError) as cm:
+            debit_note.action_post()
+        self.assertIn("It is not possible to confirm with a date posterior to the current one", str(cm.exception))


### PR DESCRIPTION
- Añadir validación del campo 'invoice_date' en el 'action_post' para evitar la publicación de documentos con fecha futura.
- Añadir pruebas unitarias para facturas, notas de crédito y notas de débito.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13536