### PR TITLE
fix: Retencion Municipales estan saliendo solamente con la informacio…

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.23",
+    "version": "17.0.0.0.32",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.31",
+    "version": "17.0.0.0.23",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/controllers/municipal_report.py
+++ b/l10n_ve_payment_extension/controllers/municipal_report.py
@@ -56,7 +56,7 @@ class ControllerMunicipalRetentionXlsx(http.Controller):
         else:
             name_document = _("Cancelled Municipal Ret")
 
-        filecontent = report_obj.xlsx_file(tabla, name_document, int(retention_id))
+        filecontent = report_obj.xlsx_file(tabla, name_document, int(retention_id), company_id=retention.company_id.id)
 
         if not filecontent:
             return Response(

--- a/l10n_ve_payment_extension/report/municipal_retention_xlsx.py
+++ b/l10n_ve_payment_extension/report/municipal_retention_xlsx.py
@@ -10,9 +10,12 @@ from collections import OrderedDict
 class MunicipalRetentionXlsx(models.AbstractModel):
     _name = "municipal.retention.xlsx"
 
-    def xlsx_file(self, tabla, nombre, retention_id):
-        # --- 1. DATOS INICIALES Y WORKBOOK ---
-        company = self.env.company
+    def xlsx_file(self, tabla, nombre, retention_id, company_id=None):
+        if company_id:
+            company = self.env['res.company'].browse(company_id)
+        else:
+            company = self.env.company
+        currency_symbol = self.env.ref("base.VEF").symbol
         retention = self.env["account.retention"].browse(retention_id)
         currency_symbol = self.env.ref("base.VEF").symbol
         

--- a/l10n_ve_payment_extension/report/municipal_retention_xlsx.py
+++ b/l10n_ve_payment_extension/report/municipal_retention_xlsx.py
@@ -15,7 +15,6 @@ class MunicipalRetentionXlsx(models.AbstractModel):
             company = self.env['res.company'].browse(company_id)
         else:
             company = self.env.company
-        currency_symbol = self.env.ref("base.VEF").symbol
         retention = self.env["account.retention"].browse(retention_id)
         currency_symbol = self.env.ref("base.VEF").symbol
         


### PR DESCRIPTION
…n de la Compañia INDUVAR

PROBLEMA:
- En el método xlsx_file de municipal.retention.xlsx se usaba self.env.company para obtener la compañía, lo cual siempre retornaba la compañía principal del usuario en lugar de la compañía del registro actual.
- Esto causaba que al generar reportes desde una empresa diferente a la primera configurada, los datos mostrados siempre correspondían a la empresa principal.
- El error se presentaba porque self.env.company en modelos abstractos no respeta el contexto de la compañía desde donde se invoca el método.

SOLUCIÓN:
- Se añade el parámetro opcional 'company_id' al método xlsx_file.
- Si se proporciona company_id, se obtiene la compañía desde la base de datos.
- Si no se proporciona, se mantiene el comportamiento por defecto con self.env.company para mantener la retrocompatibilidad.
- Desde el wizard o modelo que invoca el reporte, se pasa el company_id del registro actual para asegurar que se utiliza la compañía correcta.

Ticket#13591 https://binaural.odoo.com/odoo/all-tickets/13591