### PR TITLE
[FIX] l10n_ve_pos: Error de tasa en reembolso

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.11",
+    "version": "17.0.0.0.14",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -36,6 +36,9 @@ patch(Order.prototype, {
   },
   assert_editable() { },
   get init_conversion_rate() {
+    if (this._original_conversion_rate) {
+      return this._original_conversion_rate;
+    }
     //FIXME :Buscar una manera de esto sea por id y no por name
     if (this.pos.currency.name == "VEF" || this.pos.currency.name == "VES") {
       // IMPORTANT: do not round inverse rate for Bolivar base.
@@ -47,6 +50,9 @@ patch(Order.prototype, {
     }
   },
   get_display_rate() {
+    if (this._original_conversion_rate) {
+      return round_di(this._original_conversion_rate, this.pos.foreign_currency.decimal_places);
+    }
     return parseFloat(this.pos.config.foreign_rate.toFixed(this.pos.dp["Tasa"]));
   },
 
@@ -57,6 +63,9 @@ patch(Order.prototype, {
   },
   get_conversion_rate() {
     if (this.orderlines.length != 0) {
+      if (this.orderlines[0].foreign_currency_rate) {
+        return round_di(this.orderlines[0].foreign_currency_rate, this.pos.foreign_currency.decimal_places);
+      }
       return this.orderlines[0].currency_rate_display();
     }
     if (!this.init_conversion_rate) {
@@ -111,6 +120,12 @@ patch(Order.prototype, {
     super.set_orderline_options(...arguments);
     if (options.foreign_price !== undefined) {
       orderline.set_foreign_unit_price(options.foreign_price);
+    }
+    if (options.foreign_currency_rate !== undefined) {
+      orderline.foreign_currency_rate = options.foreign_currency_rate;
+      if (!this._original_conversion_rate) {
+        this._original_conversion_rate = options.foreign_currency_rate;
+      }
     }
   },
 

--- a/l10n_ve_pos/static/src/overrides/screens/ticket_screen/ticket_screen.js
+++ b/l10n_ve_pos/static/src/overrides/screens/ticket_screen/ticket_screen.js
@@ -15,6 +15,10 @@ patch(TicketScreen, {
 patch(TicketScreen.prototype, {
   async addAdditionalRefundInfo(order, destinationOrder) {
     destinationOrder.to_receipt = order.to_receipt;
+    const rate = order.orderlines[0]?.foreign_currency_rate;
+    if (rate) {
+      destinationOrder._original_conversion_rate = rate;
+    }
     return Promise.resolve();
   },
 


### PR DESCRIPTION
Ticket 13505: Inconsistencia al momento de realizar un reembolso trae la tasa del día y no la tasa de la factura

No se estaba tomando en cuenta la tasa de la factura al momento de realizar los reembolsos. Ahora la tasa de la factura se toma en cuenta para el visual de la orden, las lineas de orden y la tasa mostrada en la interfaz de POS.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13505
- Tarea:
- PR:
- Otros: