### PR TITLE
[FIX] l10n_ve_pos, l10n_ve_sale: Inconsistencia en redondeo de POS y …

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.0.11",
+    "version": "17.0.0.0.13",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/static/src/overrides/models/order_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/order_model.js
@@ -43,7 +43,7 @@ patch(Order.prototype, {
       return this.pos.config.foreign_inverse_rate;
     }
     if (this.pos.currency.name == "USD") {
-      return round_di(this.pos.config.foreign_rate, this.pos.dp["Tasa"]);
+      return this.pos.config.foreign_rate;
     }
   },
   get_display_rate() {

--- a/l10n_ve_pos/static/src/overrides/models/payment_model.js
+++ b/l10n_ve_pos/static/src/overrides/models/payment_model.js
@@ -37,7 +37,7 @@ patch(Payment.prototype, {
 				this.set_foreign_amount(this.order.get_foreign_due() + this.order.get_foreign_rounding_applied(), true);
 				return res;
 			}
-			this.foreign_amount = round_di(amount * this.pos.foreign_currency.rate, this.pos.dp["Foreign Product Price"]); 
+			this.foreign_amount = round_di(amount * this.pos.foreign_currency.rate, this.pos.foreign_currency.decimal_places);
 
 		}
 		return res;

--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "17.0.1.1.22",
+    "version": "17.0.1.1.23",
     # any module necessary for this one to work correctly
     "depends": [
         "base",


### PR DESCRIPTION
…Ventas

Ticket 13254: Inconsistencia en redondeo de pedido de venta que es rescatado en POS

Se ajusto la precision decimal con la que se hacia el calculo de los montos alternos en POS. Tambien se ajusto el calculo de la tasa inversa usada para las lineas de venta para que sea consistente.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13254
- Tarea:
- PR:
- Otros: