### PR TITLE
FIX #13728: l10n_ve_sale filtrar residuales redondeo facturacion

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "17.0.1.1.22",
+    "version": "17.0.1.1.23",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -254,11 +254,19 @@ class SaleOrder(models.Model):
 
     
 
+    @api.model
+    def _has_significant_invoiceable_quantity(self, line):
+        if line.display_type:
+            return True
+        return abs(line.qty_to_invoice) >= line.product_uom.rounding
+
     def _get_invoiceable_lines(self, final=False):
         if self._context.get("ignore_limit", False):
             return super()._get_invoiceable_lines(final)
 
         res = super()._get_invoiceable_lines(final)
+        res = res.filtered(self._has_significant_invoiceable_quantity)
+
         limit = self.company_id.max_product_invoice
         if len(res) > limit:
             res = res[:limit]
@@ -268,14 +276,13 @@ class SaleOrder(models.Model):
         return res
 
     def _create_invoices(self, grouped=False, final=False, date=None):
-       
         invoices = self.env["account.move"]
         for order in self:
             if order._context.get("ignore_while", False):
                 invoices |= super()._create_invoices(grouped, final, date)
                 continue
             invoiceable_lines = order._get_invoiceable_lines(final)
-            while len(invoiceable_lines) != 0:
+            while invoiceable_lines:
                 invoices |= super()._create_invoices(grouped, final, date)
                 invoiceable_lines = order._get_invoiceable_lines(final)
 


### PR DESCRIPTION
problema: al facturar una OC con cantidad de 3 decimales (ej. 355.715), la línea del asiento contable redondea a 2 (355.72), dejando un residual de ±0.005. Ese residual se sigue facturando en el while loop de _create_invoices, que oscila infinitamente entre +0.005 y -0.005.

solucion: descartar las líneas con qty_to_invoice menor al rounding de la UoM del producto. Si abs(qty) < rounding, la cantidad no es significativa y se ignora. Con esto el while loop termina naturalmente tras la primera factura.

link: https://binaural.odoo.com/odoo/action-390/13728 ticket de triaje-atc [x]