### PR TITLE
Ajuste en el cuadro resùmen del Libro de Ventas

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.4",
+    "version": "19.0.1.0.5",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -835,12 +835,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 "values": self._determinate_resume_books(moves, "exempt_aliquot"),
             },
             {
-                "name": "Exportaciones Gravadas por Alícuota General",
-                "format": "number",
-                "values": self._determinate_resume_books(moves),
-            },
-            {
-                "name": "Exportaciones Gravadas por Alícuota General más Adicional",
+                "name": "Ventas de Exportación",
                 "format": "number",
                 "values": self._determinate_resume_books(moves),
             },
@@ -853,6 +848,11 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 "name": "Ventas Internas Gravadas por Alícuota Reducida",
                 "format": "number",
                 "values": self._determinate_resume_books(moves, "reduced_aliquot"),
+            },
+            {
+                "name": "Ventas Internas Gravadas por Alícuota General más Adicional",
+                "format": "number",
+                "values": self._determinate_resume_books(moves, "extend_aliquot"),
             },
             {
                 "name": "Ajustes a los Débitos Fiscales de Periodos Anteriores",


### PR DESCRIPTION
[TASK] l10n_ve_invoice: Ajuste en el cuadro resùmen del Libro de Ventas
- Se agrega el Resumen del Libro de Ventas, el renglon de Ventas Internas Gravadas por Alicuota General mas adicional ademas de sus calculos

References:
- Ticket: https://binaural.odoo.com/odoo/action-341/72864
- Tarea:
- PR:
- Otros: