### PR TITLE
[FIX] l10n_ve_stock_account: Omitir validación de consignación para servicios

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "19.0.2.0.1",
+    "version": "19.0.2.0.2",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/sale_order.py
+++ b/l10n_ve_stock_account/models/sale_order.py
@@ -95,6 +95,8 @@ class SaleOrder(models.Model):
         for order in self:
             if order.warehouse_id.is_consignation_warehouse:
                 for line in order.order_line:
+                    if line.product_id and line.product_id.type == "service":
+                        continue
                     picking_location_count = self.env["stock.quant"].search_count(
                         [
                             ("product_id", "=", line.product_id.id),

--- a/l10n_ve_stock_account/models/sale_order_line.py
+++ b/l10n_ve_stock_account/models/sale_order_line.py
@@ -11,27 +11,29 @@ class SaleOrderLine(models.Model):
     @api.constrains("product_id", "order_id")
     def _check_product_in_consignation(self):
         for line in self:
-            warehouse = line.order_id.warehouse_id
-            if warehouse and warehouse.is_consignation_warehouse:
-                picking_location = self.env["stock.quant"].search_count(
-                    [
-                        ("product_id", "=", line.product_id.id),
-                        ("location_id.partner_id", "=", line.order_id.partner_id.id),
-                        ("location_id.usage", "=", "internal"),
-                        ("quantity", ">", 0),
-                    ]
-                )
-                if picking_location == 0:
-                    raise ValidationError(
-                        _("The product is not available in the customer's consignation location.")
+            if line.product_id and line.product_id.type != "service":
+                warehouse = line.order_id.warehouse_id
+                if warehouse and warehouse.is_consignation_warehouse:
+                    picking_location = self.env["stock.quant"].search_count(
+                        [
+                            ("product_id", "=", line.product_id.id),
+                            ("location_id.partner_id", "=", line.order_id.partner_id.id),
+                            ("location_id.usage", "=", "internal"),
+                            ("quantity", ">", 0),
+                        ]
                     )
+                    if not picking_location:
+                        raise ValidationError(
+                            _("The product is not available in the customer's consignation location.")
+                        )
 
     @api.constrains("product_uom_qty")
     def _check_quantity_in_consignation(self):
         for line in self:
-            warehouse = line.order_id.warehouse_id
-            if warehouse and warehouse.is_consignation_warehouse:
-                if line.product_uom_qty > line.free_qty_today:
-                    raise ValidationError(
-                        _("Cannot sell more than the available consignation stock.")
-                    )
+            if line.product_id and line.product_id.type != "service":
+                warehouse = line.order_id.warehouse_id
+                if warehouse and warehouse.is_consignation_warehouse:
+                    if line.product_uom_qty > line.free_qty_today:
+                        raise ValidationError(
+                            _("Cannot sell more than the available consignation stock.")
+                        )


### PR DESCRIPTION
Evitar validaciones de disponibilidad y cantidad en ubicaciones de consignación en pedidos de venta para productos de tipo servicio.

- En 'SaleOrder' ('models/sale_order.py'), se omite la validación de ubicación de consignación cuando el tipo de producto en la línea es de tipo servicio ('service').
- En 'SaleOrderLine' ('models/sale_order_line.py'), se restringen las restricciones ('_check_product_in_consignation' y '_check_quantity_in_consignation') para que se ejecuten únicamente en productos que no sean servicios.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13704