### PR TITLE
[FIX] l10n_ve_account_fiscalyear_closing: Ajustes al campo date de la…

### DIFF
--- a/l10n_ve_account_fiscalyear_closing/__manifest__.py
+++ b/l10n_ve_account_fiscalyear_closing/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.0",
+    "version": "17.0.0.0.1",
     "depends": [
         "account_fiscal_year_closing",
         "l10n_ve_contact",

--- a/l10n_ve_account_fiscalyear_closing/models/account_fiscalyear_closing.py
+++ b/l10n_ve_account_fiscalyear_closing/models/account_fiscalyear_closing.py
@@ -12,6 +12,8 @@ _logger = logging.getLogger(__name__)
 class AccountFiscalyearClosingConfig(models.Model):
     _inherit = "account.fiscalyear.closing.config"
 
+    date = fields.Date(string="Move date", required=True)
+
     @api.onchange("l_map")
     def onchange_l_map(self):
         accounts = (


### PR DESCRIPTION
… configuracion de cierre fiscal.

Ticket 13686: Error al momento de calcular el cierre fiscal

Se heredo el campo date de account.fiscalyear.closing.config para agregar el atributo required=True Esto para evitar que al momento de hacer el calculo salte un error por la falta de un valor en dicho campo

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13686
- Tarea:
- PR:
- Otros: