### PR TITLE
[FIX] l10n_ve_accountant: Ajuste en el create de la nota de credito

### DIFF
--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -399,6 +399,13 @@ class AccountMove(models.Model):
                     % ({"rate": move.foreign_rate, "last_rate": last_foreign_rate})
                 )
 
+            if move.move_type in ('out_refund', 'in_refund') and move.reversed_entry_id:
+                original_journal = move.reversed_entry_id.journal_id
+                if original_journal != move.journal_id:
+                    move._update_invoice_lines_with_new_journal(
+                        original_journal.id, move.journal_id.id
+                    )
+
         return moves
 
   


### PR DESCRIPTION
Ticket 13461: Inconsistencia con la cuenta de notas de crédito no muestra en los asientos la configurada

Se agrego una condicion en el create de account_move que se ejecuta en las notas de credito. La condicion usa el metodo _update_invoice_lines_with_new_journal para hacer el ajuste de la cuenta asociada al diario. De esta manera se usa el mismo metodo que en el write manteniendo una consistencia en las cuentas que se van a usar.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13461
- Tarea:
- PR:
- Otros: