### PR TITLE
[FIX] #13905: l10n_ve_stock

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "19.0.1.0.1",
+    "version": "19.0.1.0.2",
     "depends": [
         "stock",
         "product",

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -57,14 +57,26 @@ class ProductTemplate(models.Model):
             if product.list_price < 0:
                 raise ValidationError(_("Price cannot be negative."))
 
-    @api.constrains("taxes_id")
-    def _check_taxes_id(self):
+    def write(self, vals):
+        res = super().write(vals)
+        if "taxes_id" in vals:
+            self._validate_single_sale_tax()
+        return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        # Always validate after creation because default taxes can come from multiple sources
+        records._validate_single_sale_tax()
+        return records
+
+    def _validate_single_sale_tax(self):
         for product in self:
             taxes_by_company = defaultdict(int)
             for tax in product.taxes_id.sudo():
                 taxes_by_company[tax.company_id] += 1
                 if taxes_by_company[tax.company_id] > 1:
-                    raise ValidationError(_("This product must have only one tax."))                
+                    raise ValidationError(_("This product must have only one tax."))   
 
     @api.depends("list_price")
     def _compute_prices_with_tax(self):


### PR DESCRIPTION
Problema: Al momento de crear o editar un producto con 2 impuestos y guardar debe salir la validacion de "Este producto debe tener un solo impuesto"

Solucion: Se reemplaza el @api.constrains por overrides explícitos de write() y create() con un método helper _validate_single_sale_tax(), asegurando que la validación se ejecute siempre que se cree o modifique el campo taxes_id.

Ticket (link): https://binaural.odoo.com/odoo/helpdesk.ticket/13905