### PR TITLE
[FIX] l10n_ve_donation:

### DIFF
--- a/l10n_ve_donation/__manifest__.py
+++ b/l10n_ve_donation/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Donaciones",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.2",
     "category": "Accounting/Accounting",
     "summary": "Venezuela - Donaciones",
     "author": "",

--- a/l10n_ve_donation/models/stock_scrap.py
+++ b/l10n_ve_donation/models/stock_scrap.py
@@ -54,7 +54,7 @@ class StockScrap(models.Model):
             move.with_context(is_scrap=True)._action_done()
             scrap.write({'state': 'done'})
             scrap.date_done = fields.Datetime.now()
-            if scrap.should_replenish:
+            if scrap.should_replenish and not scrap.is_donation:
                 scrap.do_replenish()
 
         # Delegar scraps no-donación al comportamiento estándar

--- a/l10n_ve_donation/views/stock_scrap_views.xml
+++ b/l10n_ve_donation/views/stock_scrap_views.xml
@@ -4,6 +4,9 @@
     <field name="model">stock.scrap</field>
     <field name="inherit_id" ref="stock.stock_scrap_form_view"/>
     <field name="arch" type="xml">
+        <xpath expr="//field[@name='should_replenish']" position="attributes">
+            <attribute name="invisible">is_donation</attribute>
+        </xpath>
         <xpath expr="//field[@name='product_id']" position="after">
             <field name="is_donation" invisible="not is_donation" readonly="1"/>
         </xpath>


### PR DESCRIPTION
Deshabilitar reabastecimiento automático en donaciones

- Se oculta el campo 'should_replenish' en la vista del formulario de scrap cuando el registro es una donación (is_donation = True).
- Se agrega condición en do_scrap para que el flujo de reabastecimiento (do_replenish) no se ejecute en donaciones.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13922