### PR TITLE
[IMP] #13908: l10n_ve_invoice

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.5",
+    "version": "19.0.1.0.6",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -240,6 +240,16 @@ msgid "BORRADOR"
 msgstr ""
 
 #. module: l10n_ve_invoice
+#: model:res.groups,name:l10n_ve_invoice.group_show__button
+msgid "Binaural - Mostrar campo nativo \"Cancelar\" en facturación de ventas"
+msgstr ""
+
+#. module: l10n_ve_invoice
+#: model:res.groups,name:l10n_ve_invoice.group_show_preview_button
+msgid "Binaural - Mostrar campo nativo \"Vista previa\" en facturación de ventas"
+msgstr ""
+
+#. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_res_company__block_invoice_display_date_upper_than_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_res_config_settings__block_invoice_display_date_upper_than_date
 msgid "Block Invoice Display Date Upper Than Date"
@@ -249,6 +259,11 @@ msgstr "Evitar que la fecha de factura sea mayor a la fecha contable"
 #: model:ir.model.fields.selection,name:l10n_ve_invoice.selection__wizard_accounting_reports__report__purchase
 msgid "Book Purchase"
 msgstr "Libro de Compras"
+
+#. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.view_account_move_form_l10n_ve_invoice
+msgid "Cancel"
+msgstr "Cancelar"
 
 #. module: l10n_ve_invoice
 #. odoo-python

--- a/l10n_ve_invoice/security/l10n_ve_invoice_groups.xml
+++ b/l10n_ve_invoice/security/l10n_ve_invoice_groups.xml
@@ -14,4 +14,12 @@
             <field name="name">Edit Taxes on Invoice Lines</field>
         </record>
     </data>
+    <data noupdate="1">
+        <record id="group_show_preview_button" model="res.groups">
+            <field name="name">Binaural - Mostrar campo nativo "Vista previa" en facturación de ventas</field>
+        </record>
+        <record id="group_show_cancel_button" model="res.groups">
+            <field name="name">Binaural - Mostrar campo nativo "Cancelar" en facturación de ventas</field>
+        </record>
+    </data>
 </odoo>

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -82,6 +82,23 @@
                 <attribute name="invisible">move_type in ['out_invoice', 'out_refund'] or state == 'draft'</attribute>
             </button>
 
+            <!-- Preview: visible only to the group (native already sales-only) -->
+            <xpath expr="//header/button[@name='preview_invoice']" position="attributes">
+                <attribute name="groups">l10n_ve_invoice.group_show_preview_button</attribute>
+            </xpath>
+
+            <!-- Native invoice cancel button: visible only to the group -->
+            <xpath expr="//header/button[@name='button_cancel'][@string='Cancel']" position="attributes">
+                <attribute name="groups">l10n_ve_invoice.group_show_cancel_button</attribute>
+            </xpath>
+
+            <!-- Alternative cancel: visible on purchases for users not in the group -->
+            <xpath expr="//header/button[@name='button_cancel'][2]" position="after">
+                <button name="button_cancel" string="Cancel" type="object"
+                    invisible="not entry_in_period and (not id or state != 'draft') or move_type in ('out_invoice', 'out_refund', 'out_receipt', 'entry')"
+                    groups="!l10n_ve_invoice.group_show_cancel_button"
+                    data-hotkey="x"/>
+            </xpath>
 
         </field>
     </record>


### PR DESCRIPTION
Problema: Por defecto, todos los usuarios pueden ver y usar los botones nativos "Preview" y "Cancel" en el formulario de facturas de ventas (out_invoice, out_refund, out_receipt). Se requiere que estos botones estén ocultos por defecto en facturación de ventas, y solo se muestren a usuarios con permisos específicos. Sin embargo, en facturas de compras estos botones deben seguir visibles para todos sin restricción.

Solución:

Se crean dos nuevos grupos de seguridad en l10n_ve_invoice/security/l10n_ve_invoice_groups.xml:
  - group_show_preview_button
  - group_show_cancel_button

En l10n_ve_invoice/views/account_move.xml se aplica el atributo groups al botón nativo preview_invoice para que solo sea visible al grupo correspondiente. Para el botón Cancel, se aplica groups al botón nativo button_cancel[2] (facturas) y se inserta un botón alternativo con groups="!..." que solo aparece en compras (in_invoice, in_refund, in_receipt), garantizando que:
  - Ventas: Cancel solo visible si el usuario tiene el grupo.
  - Compras: Cancel siempre visible para todos, usando el botón alternativo cuando el usuario no tiene el grupo.

Ticket (link): https://binaural.odoo.com/odoo/helpdesk.ticket/13908