### PR TITLE
Retención de IVA NC en el Libro de Compras se suma en el resumen

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.18",
+    "version": "19.0.2.0.19",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/tests/test_retention_flow_restriction.py
+++ b/l10n_ve_payment_extension/tests/test_retention_flow_restriction.py
@@ -9,6 +9,9 @@ class TestRetentionFlowRestriction(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestRetentionFlowRestriction, cls).setUpClass()
+        cls.company = cls.env.user.company_id
+        cls.company.currency_id = cls.env.ref('base.VEF')
+        cls.company.foreign_currency_id = cls.env.ref("base.USD")
 
         cls.partner = cls.env["res.partner"].create({"name": "Test Partner Retention Flow Restriction"})
         cls.product = cls.env["product.product"].create({"name": "Test Service Flow Restriction", "type": "service"})

--- a/l10n_ve_payment_extension/tests/test_retention_islr_tarifa_2.py
+++ b/l10n_ve_payment_extension/tests/test_retention_islr_tarifa_2.py
@@ -12,6 +12,7 @@ class TestRetentionISLRTarifa2(TransactionCase):
 
         cls.company = cls.env.user.company_id
         cls.company.currency_id = cls.env.ref('base.VEF')
+        cls.company.foreign_currency_id = cls.env.ref('base.USD')
         
         # Activar el uso de retenciones de ISLR
         cls.env['ir.config_parameter'].sudo().set_param('l10n_ve_payment_extension.use_islr_retention', True)

--- a/l10n_ve_payment_extension/wizard/accounting_reports.py
+++ b/l10n_ve_payment_extension/wizard/accounting_reports.py
@@ -223,7 +223,6 @@ class WizardAccountingReports(models.TransientModel):
     def get_retention_iva_values(self, move_id):
         move = self.env["account.move"].browse(move_id)
         is_purchase = self.report == "purchase"
-        multiplier = -1 if move.move_type in ["out_refund", "in_refund"] else 1
         ret_lines = (
             move.retention_iva_line_ids.filtered(lambda x: x.retention_id.state == "emitted")
             if move.state == "posted"
@@ -247,7 +246,7 @@ class WizardAccountingReports(models.TransientModel):
             ret_vals["date_retention"] = self._format_date(ret_line.mapped("retention_id").date)
             ret_vals["number_retention"] = move.iva_voucher_number
             ret_vals["iva_retained"] = ret_vals["iva_retained"] + (
-                self._sum_retention_total(ret_line) * multiplier
+                self._sum_retention_total(ret_line)
                 if ret_line.move_id.state != "cancel"
                 else 0
             )
@@ -271,9 +270,14 @@ class WizardAccountingReports(models.TransientModel):
                 continue
 
             if not is_check_currency_system:
-                total += line.foreign_retention_amount
+                amount = line.foreign_retention_amount
             else:
-                total += line.retention_amount
+                amount = line.retention_amount
+
+            if line.move_id and line.move_id.move_type in ["out_refund", "in_refund"]:
+                amount *= -1
+
+            total += amount
 
         return total
 


### PR DESCRIPTION
[fix] l10n_ve_payment_extension: Retención de IVA NC en el Libro de Compras se suma en el resumen

- Se ajusta el multiplicador en las funciones correspondientes ya que los valores en las retenciones siempre son en positivo y no corresponden a lo q se mostraba en el reporte

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/13897
- Tarea:
- PR:
- Otros: