### PR TITLE
[FIX] l10n_ve_accountant: restringir eliminación de monedas y edición de tasas al grupo de soporte fiscal

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.51",
+    "version": "17.0.0.0.52",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250522\n"
+"Project-Id-Version: Odoo Server 17.0+e-20260707\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-28 03:36+0000\n"
-"PO-Revision-Date: 2026-01-28 03:36+0000\n"
+"POT-Creation-Date: 2026-07-08 15:48+0000\n"
+"PO-Revision-Date: 2026-07-08 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -632,6 +632,14 @@ msgstr "Estadísticas de facturas"
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_payment__is_reset_to_draft_for_price_change
 msgid "Is Reset To Draft For Price Change"
 msgstr ""
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/res_currency.py:0
+#: code:addons/odoo-venezuela/l10n_ve_accountant/models/res_currency.py:0
+#, python-format
+msgid "It is not possible to delete currency records."
+msgstr "No es posible eliminar los registros de monedas."
 
 #. module: l10n_ve_accountant
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_payment_report__journal_id

--- a/l10n_ve_accountant/models/res_currency.py
+++ b/l10n_ve_accountant/models/res_currency.py
@@ -1,8 +1,15 @@
 from odoo import models, fields, api, _
+from odoo.exceptions import UserError
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
 class ResCurrency(models.Model):
     _inherit = "res.currency"
 
-    # TDE FIXME: move to l10n_ve_currency_rate_live
+    # Homologación: No permitir eliminar el registro de una moneda, ni modificar, agregar o eliminar sus tasas de cambio, a menos que pertenezca al grupo
     edit_rate = fields.Boolean(
         compute="_compute_edit_rate",
     )
@@ -10,8 +17,13 @@ class ResCurrency(models.Model):
     def _compute_edit_rate(self):
         for record in self:
             record.edit_rate = (
-                record.env.company.currency_provider == "bcv"
-                and record.env.user.has_group(
+                record.env.user.has_group(
                     "l10n_ve_accountant.group_fiscal_config_support"
                 )
             )
+
+    def unlink(self):
+        if not self.env.user.has_group("l10n_ve_accountant.group_fiscal_config_support"):
+            raise UserError(_("It is not possible to delete currency records."))
+        return super(ResCurrency, self).unlink()
+    # Cierre de código homologado. En caso de requerir cambios o ajustes consultar con la Gerencia de Producto

--- a/l10n_ve_accountant/views/res_currency_views.xml
+++ b/l10n_ve_accountant/views/res_currency_views.xml
@@ -4,12 +4,14 @@
     <field name="model">res.currency</field>
     <field name="inherit_id" ref="base.view_currency_form" />
     <field name="arch" type="xml">
+    <!-- Homologación: No permitir eliminar el registro de una moneda, ni modificar, agregar o eliminar sus tasas de cambio, a menos que pertenezca al grupo -->
       <xpath expr="//form[1]/field[1]" position="after">
         <field name="edit_rate" invisible="1" />
       </xpath>
       <xpath expr="//page[1]/field[1]" position="attributes">
         <attribute name="readonly">not edit_rate</attribute>
       </xpath>
+    <!-- Cierre de código homologado. En caso de requerir cambios o ajustes consultar con la Gerencia de Producto -->
     </field>
   </record>
 </odoo>


### PR DESCRIPTION
Restringir eliminación de monedas y edición de tasas al grupo de soporte fiscal

- Se elimina la condición currency_provider == 'bcv' de _compute_edit_rate, ahora solo se valida la pertenencia al grupo group_fiscal_config_support.
- Se agrega override de unlink() en res.currency para impedir la eliminación de monedas por usuarios fuera del grupo group_fiscal_config_support.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13913