### PR TITLE
No permitir agregar productos a las Notas de créditos distintos a la factura y botones nativos

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.7",
+    "version": "19.0.1.0.8",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.6",
+    "version": "19.0.1.0.7",
     "depends": [
         "base",
         "web",
@@ -55,7 +55,10 @@
     ],
     "images": ["static/description/icon.png"],
     "assets": {
-        "web.assets_backend": ["l10n_ve_accountant/static/src/components/**/*"],
+        "web.assets_backend": [
+            "l10n_ve_accountant/static/src/components/**/*",
+            "l10n_ve_accountant/static/src/views/**/*",
+        ],
     },
     "application": True,
     "pre_init_hook": "pre_init_hook",

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -1770,3 +1770,10 @@ msgstr "Importe adeudado"
 #: code:addons/l10n_ve_accountant/models/account_move.py:0
 msgid "You cannot delete a journal item that is posted, cancelled, or has been previously posted."
 msgstr "No puede borrar apuntes ya publicados, cancelados o anteriormente publicados."
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/account_move.py:0
+#, python-format
+msgid "The credit note amount (%s) cannot exceed the original invoice amount (%s)."
+msgstr "El monto de la nota de crédito (%s) no puede exceder el monto de la factura original (%s)."

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1091,6 +1091,15 @@ class AccountMove(models.Model):
                         line.account_id = move.journal_id.default_account_id
 
     def action_post(self):
+        if not self.env.user.has_group('l10n_ve_accountant.group_fiscal_config_support'):
+            for move in self:
+                if move.move_type == 'out_refund' and move.reversed_entry_id:
+                    if abs(move.amount_total) > abs(move.reversed_entry_id.amount_total):
+                        raise ValidationError(_(
+                            "The credit note amount (%s) cannot exceed the original invoice amount (%s).",
+                            formatLang(self.env, abs(move.amount_total), currency_obj=move.currency_id),
+                            formatLang(self.env, abs(move.reversed_entry_id.amount_total), currency_obj=move.reversed_entry_id.currency_id),
+                        ))
         if not self.env.context.get("move_action_post_alert"):
             for move in self:
                 if move.move_type in ("out_invoice", "out_refund"):

--- a/l10n_ve_accountant/static/src/views/account_move_kanban/account_move_kanban_controller.js
+++ b/l10n_ve_accountant/static/src/views/account_move_kanban/account_move_kanban_controller.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import { AccountMoveKanbanController } from '@account/views/account_move_kanban/account_move_kanban_controller';
+import { patch } from '@web/core/utils/patch';
+
+patch(AccountMoveKanbanController.prototype, {
+    setup() {
+        super.setup();
+        if (this.props.context?.no_upload) {
+            this.showUploadButton = false;
+        }
+    },
+});

--- a/l10n_ve_accountant/static/src/views/account_move_list/account_move_list_controller.js
+++ b/l10n_ve_accountant/static/src/views/account_move_list/account_move_list_controller.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import { AccountMoveListController } from '@account/views/account_move_list/account_move_list_controller';
+import { patch } from '@web/core/utils/patch';
+
+patch(AccountMoveListController.prototype, {
+    setup() {
+        super.setup();
+        if (this.props.context?.no_upload) {
+            this.showUploadButton = false;
+        }
+    },
+});

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -4,19 +4,40 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <xpath expr="//header" position="after">
-                <!-- <field name="foreign_balance" invisible="1" />
-                <div class="alert alert-warning mb-0" role="alert" invisible="foreign_balance == 0">
-                    Warning: This account move has a foreign balance of <field
-                        name="foreign_balance" />. </div> -->
+
+            <xpath expr="//field[@name='invoice_line_ids']//list/control/create[@name='add_line_control']" position="attributes">
+                <attribute name="invisible">
+                    parent.move_type in ('out_refund', 'in_refund')
+                </attribute>
             </xpath>
+
+            <xpath expr="//field[@name='invoice_line_ids']//list/control/create[@name='add_section_control']" position="attributes">
+                <attribute name="invisible">
+                    parent.move_type in ('out_refund', 'in_refund') 
+                </attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='invoice_line_ids']//list/control/create[@name='add_note_control']" position="attributes">
+                <attribute name="invisible">
+                    parent.move_type in ('out_refund', 'in_refund')
+                </attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='invoice_line_ids']//list/control/button[@name='action_add_from_catalog']" position="attributes">
+                <attribute name="invisible">
+                    parent.move_type in ('out_refund', 'in_refund')
+                </attribute>
+            </xpath>
+
             <xpath expr="//field[@name='invoice_date']" position="attributes">
                 <attribute name="readonly">state != 'draft' or move_type in ('out_invoice', 'out_refund', 'out_receipt')</attribute>
                 <attribute name="force_save">1</attribute>
             </xpath>
+
             <xpath expr="//field[@name='invoice_date']" position="after">
                 <field name="invoice_date_display" readonly="state != 'draft'" invisible="move_type == 'entry'" required="move_type in ('in_invoice', 'out_invoice', 'in_refund', 'out_refund')"/>
             </xpath>
+
             <xpath expr="//div[@name='currency_div']" position="replace">
                 <div name="currency_div"
                     groups="base.group_multi_currency"
@@ -272,4 +293,19 @@
             </xpath>
         </field>
     </record>
+
+    <record id="account.action_move_out_refund_type_non_legacy" model="ir.actions.act_window">
+        <field name="context">{'search_default_out_refund': 1, 'default_move_type': 'out_refund', 'create': False, 'display_account_trust': True, 'no_upload': True}</field>
+    </record>
+
+    <record id="account.action_move_out_refund_type" model="ir.actions.act_window">
+        <field name="context">{'search_default_out_refund': 1, 'default_move_type': 'out_refund', 'create': False, 'display_account_trust': True, 'no_upload': True}</field>
+    </record>
+
+    <record id="account.action_move_in_refund_type" model="ir.actions.act_window">
+        <field name="context">{'search_default_in_refund': 1, 'default_move_type': 'in_refund', 'create': False, 'no_upload': True}</field>
+    </record>
+
+   
+
 </odoo>


### PR DESCRIPTION
[FEAT] l10n_ve_accountant: No permitir agregar productos a las Notas de créditos distintos a la factura y botones nativos

- Se agrega a los controladores de las vistas kamban y List una  propiedad para ocultar el boton de Subir / Upload  llamado no_upload que se pasa por contexto de la accion de vista. esto permite ocultar el boton en cualquier vista q se requiera

- Se paso en el mismo contexto el valor create: False para las vistas de notas de credito ya que no se requiere que se pueda crear desde dichas vistas.

References:
- Ticket:  https://binaural.odoo.com/odoo/helpdesk/58/tickets/13931?debug=1
- Tarea:
- PR:
- Otros: