### PR TITLE
[FIX] l10n_ve_payment_extension: actualizar referencia legal en compr…

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.18",
+    "version": "19.0.2.0.20",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/i18n/es_VE.po
+++ b/l10n_ve_payment_extension/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 19.0+e-20260313\n"
+"Project-Id-Version: Odoo Server 19.0+e-20260707\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-24 14:09+0000\n"
-"PO-Revision-Date: 2026-03-24 14:09+0000\n"
+"POT-Creation-Date: 2026-07-09 01:37+0000\n"
+"PO-Revision-Date: 2026-07-09 01:37+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,14 +23,11 @@ msgstr ""
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer
 msgid ""
-"\"Decreto con Rango, Valor y Fuerza de Ley de Reforma de la Ley del Impuesto al Valor agregado\n"
-"                        Nro 1.436 del 17 de Noviembre del 2014\"\n"
-"                        Articulo 11: La Administracion Tributaria podra Designar como Responsable del Pago del\n"
-"                        Impuesto, en calidad de Agentes de Retencion a quienes por sus\n"
-"                        Funciones Publicas o por Razón de sus Actividades Privadas intervengan en operaciones\n"
-"                        Gravadas con el Impuesto Establecido en este Decreto con Rango,\n"
-"                        Valor y Fuerza de Ley."
+"\"Este comprobante se emite según lo establecido en el artículo 16 de la Providencia\n"
+"                        Administrativa snat/2025/000054 de fecha 02/07/2025 publicada en Gaceta Oficial número\n"
+"                        43.171 de fecha 16 de julio de 2025."
 msgstr ""
+
 
 #. module: l10n_ve_payment_extension
 #: model_terms:ir.ui.view,arch_db:l10n_ve_payment_extension.report_iva_customer

--- a/l10n_ve_payment_extension/report/retention_voucher_templates.xml
+++ b/l10n_ve_payment_extension/report/retention_voucher_templates.xml
@@ -15,13 +15,9 @@
                 <h3 t-if="retention.state == 'cancel'" style="position:absolute;left:65px;top:250px;font-size:260px !important;opacity: 0.1;">ANULADA</h3>
                 <div class="col-8" style="text-align: left;">
                     <h6>COMPROBANTE DE RETENCIÓN DEL IMPUESTO AL VALOR AGREGADO</h6>
-                    <p>"Decreto con Rango, Valor y Fuerza de Ley de Reforma de la Ley del Impuesto al Valor agregado
-                        Nro 1.436 del 17 de Noviembre del 2014"
-                        Articulo 11: La Administracion Tributaria podra Designar como Responsable del Pago del
-                        Impuesto, en calidad de Agentes de Retencion a quienes por sus
-                        Funciones Publicas o por Razón de sus Actividades Privadas intervengan en operaciones
-                        Gravadas con el Impuesto Establecido en este Decreto con Rango,
-                        Valor y Fuerza de Ley.
+                    <p>"Este comprobante se emite según lo establecido en el artículo 16 de la Providencia
+                        Administrativa snat/2025/000054 de fecha 02/07/2025 publicada en Gaceta Oficial número
+                        43.171 de fecha 16 de julio de 2025.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
…obante de retención de IVA

- Reemplazar el texto del decreto de 2014 por la referencia a la providencia de 2025.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/58/tickets/13955