### PR TITLE
Facturas de clientes con apuntes desbalanceados

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.51",
+    "version": "17.0.0.0.52",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1014,70 +1014,7 @@ class AccountMove(models.Model):
             
         return super().action_post()
 
-    @api.depends(
-        "invoice_line_ids.compute_all_tax",
-        "invoice_line_ids.price_subtotal",
-        "foreign_inverse_rate",
-        "foreign_currency_id",
-        "foreign_rate",
-    )
-    def _compute_needed_terms(self):
-        res = super()._compute_needed_terms()
 
-        for invoice in self:
-            is_draft = invoice.id != invoice._origin.id
-            sign = 1 if invoice.is_inbound(include_receipts=True) else -1
-            if invoice.is_invoice(True) and invoice.invoice_line_ids:
-                invoice._compute_tax_totals()
-                if invoice.invoice_payment_term_id:
-                    if is_draft:
-                        tax_amount_currency = 0.0
-                        untaxed_amount_currency = 0.0
-                        for line in invoice.invoice_line_ids:
-                            untaxed_amount_currency += line.foreign_subtotal
-                            tax_amount_currency += (
-                                line.foreign_price_total - line.foreign_subtotal
-                            )
-                        untaxed_amount = untaxed_amount_currency
-                        tax_amount = tax_amount_currency
-                    else:
-                        tax_amount = (
-                            invoice.foreign_total_billed
-                            - invoice.foreign_taxable_income
-                        ) * sign
-                        untaxed_amount = (invoice.foreign_taxable_income) * sign
-
-                    invoice_payment_terms = (
-                        invoice.invoice_payment_term_id._compute_terms(
-                            date_ref=invoice.invoice_date
-                            or invoice.date
-                            or fields.Date.context_today(invoice),
-                            currency=invoice.foreign_currency_id,
-                            tax_amount_currency=tax_amount,
-                            tax_amount=tax_amount,
-                            untaxed_amount_currency=untaxed_amount,
-                            untaxed_amount=untaxed_amount,
-                            company=invoice.company_id,
-                            sign=sign,
-                        )
-                    )
-
-                    for term in invoice_payment_terms["line_ids"]:
-                        for key in list(invoice.needed_terms.keys()):
-                            if key["date_maturity"] == fields.Date.to_date(
-                                term.get("date")
-                            ):
-                                invoice.needed_terms[key] = {
-                                    **invoice.needed_terms[key],
-                                    "foreign_balance": term["company_amount"],
-                                }
-                else:
-                    for key in list(invoice.needed_terms.keys()):
-                        invoice.needed_terms[key] = {
-                            **invoice.needed_terms[key],
-                            "foreign_balance": sign * invoice.foreign_total_billed,
-                        }
-        return res
 
     def button_draft(self):
         for rec in self:

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1014,7 +1014,70 @@ class AccountMove(models.Model):
             
         return super().action_post()
 
+    @api.depends(
+        "invoice_line_ids.compute_all_tax",
+        "invoice_line_ids.price_subtotal",
+        "foreign_inverse_rate",
+        "foreign_currency_id",
+        "foreign_rate",
+    )
+    def _compute_needed_terms(self):
+        res = super()._compute_needed_terms()
 
+        for invoice in self:
+            is_draft = invoice.id != invoice._origin.id
+            sign = 1 if invoice.is_inbound(include_receipts=True) else -1
+            if invoice.is_invoice(True) and invoice.invoice_line_ids:
+                invoice._compute_tax_totals()
+                if invoice.invoice_payment_term_id:
+                    if is_draft:
+                        tax_amount_currency = 0.0
+                        untaxed_amount_currency = 0.0
+                        for line in invoice.invoice_line_ids:
+                            untaxed_amount_currency += line.foreign_subtotal
+                            tax_amount_currency += (
+                                line.foreign_price_total - line.foreign_subtotal
+                            )
+                        untaxed_amount = untaxed_amount_currency
+                        tax_amount = tax_amount_currency
+                    else:
+                        tax_amount = (
+                            invoice.foreign_total_billed
+                            - invoice.foreign_taxable_income
+                        ) * sign
+                        untaxed_amount = (invoice.foreign_taxable_income) * sign
+
+                    invoice_payment_terms = (
+                        invoice.invoice_payment_term_id._compute_terms(
+                            date_ref=invoice.invoice_date
+                            or invoice.date
+                            or fields.Date.context_today(invoice),
+                            currency=invoice.foreign_currency_id,
+                            tax_amount_currency=tax_amount,
+                            tax_amount=tax_amount,
+                            untaxed_amount_currency=untaxed_amount,
+                            untaxed_amount=untaxed_amount,
+                            company=invoice.company_id,
+                            sign=sign,
+                        )
+                    )
+
+                    for term in invoice_payment_terms["line_ids"]:
+                        for key in list(invoice.needed_terms.keys()):
+                            if key["date_maturity"] == fields.Date.to_date(
+                                term.get("date")
+                            ):
+                                invoice.needed_terms[key] = {
+                                    **invoice.needed_terms[key],
+                                    "foreign_balance": term["company_amount"],
+                                }
+                else:
+                    for key in list(invoice.needed_terms.keys()):
+                        invoice.needed_terms[key] = {
+                            **invoice.needed_terms[key],
+                            "foreign_balance": sign * invoice.foreign_total_billed,
+                        }
+        return res
 
     def button_draft(self):
         for rec in self:

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -99,7 +99,7 @@
                     readonly="1"
                     force_save="1"
                     widget="monetary"
-                    options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"
+                    options="{'currency_field': 'foreign_currency_id'}"
                 />
                 <field
                     name="foreign_credit"
@@ -108,11 +108,11 @@
                     readonly="1"
                     force_save="1"
                     widget="monetary"
-                    options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"
+                    options="{'currency_field': 'foreign_currency_id'}"
                 />
                 <field name="foreign_debit_adjustment" optional="hide" force_save="1"/>
                 <field name="foreign_credit_adjustment" optional="hide" force_save="1"/>
-                <field name="foreign_balance" optional="hide" groups="base.group_no_one" force_save="1" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
+                <field name="foreign_balance" optional="hide" groups="base.group_no_one" force_save="1" widget="monetary" options="{'currency_field': 'foreign_currency_id'}"/>
                 <field name="foreign_rate" optional="hide" groups="base.group_no_one" force_save="1"/>
                 <field
                     name="foreign_inverse_rate"

--- a/l10n_ve_accountant/views/account_move_line.xml
+++ b/l10n_ve_accountant/views/account_move_line.xml
@@ -6,14 +6,14 @@
         <field name="arch" type="xml">
             <xpath expr="//notebook/page/group/group[1]" position="after">
                 <group string="Foreign Amount">
-                    <field name="foreign_rate" readonly="1" force_save="1" options="{'precision': 'Tasa'}"/>
+                    <field name="foreign_rate" readonly="1" force_save="1" widget="monetary" options="{'precision': 'Tasa'}"/>
                     <field name="foreign_inverse_rate" invisible="1"/>
                     <field name="foreign_inverse_rate" readonly="1" force_save="1" groups="base.group_no_one"/>
-                    <field name="foreign_debit" readonly="1" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
-                    <field name="foreign_debit_adjustment" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
-                    <field name="foreign_credit_adjustment" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
-                    <field name="foreign_credit" readonly="1" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
-                    <field name="foreign_balance" readonly="1" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
+                    <field name="foreign_debit" readonly="1" force_save="1" widget="monetary"  />
+                    <field name="foreign_debit_adjustment" force_save="1" widget="monetary"  />
+                    <field name="foreign_credit_adjustment" force_save="1" widget="monetary"  />
+                    <field name="foreign_credit" readonly="1" force_save="1" widget="monetary"  />
+                    <field name="foreign_balance" readonly="1" force_save="1" widget="monetary"  />
                 </group>
 	    </xpath>
 	</field>
@@ -26,11 +26,11 @@
 	<field name="arch" type="xml">
 	    <xpath expr="//field[@name='balance']" position="after">
 		<field name="foreign_currency_id" column_invisible="True"/>
-		<field name="foreign_debit" readonly="1" optional="show" sum="Total Foreign Debit" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_debit_adjustment" optional="hide" options="{'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_credit" readonly="1" optional="show" sum="Total Foreign Credit" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_credit_adjustment" optional="hide" options="{'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_balance" readonly="1" optional="hide" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
+		<field name="foreign_debit" readonly="1" optional="show" sum="Total Foreign Debit" widget="monetary" options="{'currency_field': 'foreign_currency_id'}"/>
+		<field name="foreign_debit_adjustment" optional="hide" widget="monetary"  />
+		<field name="foreign_credit" readonly="1" optional="show" sum="Total Foreign Credit" widget="monetary" options="{'currency_field': 'foreign_currency_id'}"/>
+		<field name="foreign_credit_adjustment" optional="hide" widget="monetary"  />
+		<field name="foreign_balance" readonly="1" optional="hide" widget="monetary" options="{'currency_field': 'foreign_currency_id'}"/>
                     
 
 	    </xpath>


### PR DESCRIPTION
[fix] l10n_ve_accountant: Facturas de clientes con apuntes desbalanceados

- Se remueve precision decimal en el widget monetario de los campos credito y debito alterno, para que muestre solamente los valores en precision de la moneda alterna

- Se elimina funcion _compute_needed_terms la cual se encargaba de recalcular el balance alterno cuando existen metodos de pago en la factura, dicha funcion no es necesario porq choca con otras funciones de conversion q realizan lo mismo.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/13402
- Tarea:
- PR:
- Otros: