### PR TITLE
Colocar Marca de Agua No Fiscal a las Cotizaciones / Pedidos de Venta

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "19.0.1.0.3",
+    "version": "19.0.1.0.4",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/report/report_sale_document.xml
+++ b/l10n_ve_sale/report/report_sale_document.xml
@@ -2,9 +2,9 @@
 <odoo>
   <template id="report_sale_document_l10n_ve_sale" inherit_id="sale.report_saleorder_document">
     <xpath expr="//div[@class='page']" position="inside">
-      <h3 t-if="doc.state == 'draft'"
-        style="position:absolute;left:35px;top:250px;font-size:180px !important;opacity: 0.1;">
-        BORRADOR</h3>
+      <h3 style="position: absolute; left: 0; right: 0; top: 250px; font-size: 180px !important; opacity: 0.1; text-align: center; white-space: nowrap; width: 100%; margin: 0; pointer-events: none;">
+          NO FISCAL
+      </h3>
     </xpath>
     <xpath expr="//div[@class='clearfix'][1]" position="after">
       <div class="row mt-4">


### PR DESCRIPTION
[FIX] l10n_ve_sale : Colocar Marca de Agua No Fiscal a las Cotizaciones / Pedidos de Venta

- Se elimina condicion en el Xml y se sostituye palabra Borrador por No Fiscal

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/14010
- Tarea:
- PR:
- Otros: