### PR TITLE
[FIX] #13921: l10n_ve_iot_mf

### DIFF
--- a/l10n_ve_iot_mf/__manifest__.py
+++ b/l10n_ve_iot_mf/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "license": "LGPL-3",
     "category": "Accounting",
-    "version": "17.0.0.2.1",
+    "version": "17.0.0.2.2",
     "author": "binaural-dev",
     "website": "https://binauraldev.com",
     "depends": [

--- a/l10n_ve_iot_mf/i18n/es_VE.po
+++ b/l10n_ve_iot_mf/i18n/es_VE.po
@@ -356,7 +356,7 @@ msgstr "Dispositivo IoT"
 #. module: l10n_ve_iot_mf
 #: model:ir.model.fields,field_description:l10n_ve_iot_mf.field_wizard_accounting_reports__all_documents
 msgid "Include all issued documents"
-msgstr "Incluir todos los documentos emitidos"
+msgstr "Incluir todos los documentos emitidos (Fact contingencia)"
 
 #. module: l10n_ve_iot_mf
 #: model:ir.model.fields.selection,name:l10n_ve_iot_mf.selection__iot_device__reprint_type_date__rf


### PR DESCRIPTION
Problema: El campo "all_documents" del wizard de reportes mostraba la etiqueta "Incluir todos los documentos emitidos", pero no reflejaba que incluye también los documentos de contingencia, lo que generaba confusión en el usuario.

Solución: Se actualiza la traducción (es_VE.po) del string del campo all_documents para que indique explícitamente que incluye facturas de contingencia, sin modificar el msgid en inglés.

Ticket (link): https://binaural.odoo.com/odoo/helpdesk.ticket/13921