### PR TITLE
Maint 19.0 feat ti 13943 invoice date display datetime

### DIFF
--- a/l10n_ve_invoice/__init__.py
+++ b/l10n_ve_invoice/__init__.py
@@ -9,6 +9,7 @@ def post_init_hook(env):
     env.cr.execute("""
         UPDATE account_move
         SET invoice_date_display_datetime = invoice_date_display::timestamp
+            + (NOW()::timestamp - NOW()::date::timestamp)
         WHERE invoice_date_display IS NOT NULL
           AND invoice_date_display_datetime IS NULL
     """)

--- a/l10n_ve_invoice/__init__.py
+++ b/l10n_ve_invoice/__init__.py
@@ -5,6 +5,14 @@ from . import wizard
 old_module = "binaural_invoice"
 new_module = "l10n_ve_invoice"
 
+def post_init_hook(env):
+    env.cr.execute("""
+        UPDATE account_move
+        SET invoice_date_display_datetime = invoice_date_display::timestamp
+        WHERE invoice_date_display IS NOT NULL
+          AND invoice_date_display_datetime IS NULL
+    """)
+
 def pre_init_hook(env):
     reassign_xml_invoice_correlative_ids(env.cr)
     reassign_xml_series_invoicing_ids(env.cr)

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.5",
+    "version": "19.0.1.0.6",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
@@ -34,4 +34,5 @@
     "images": ["static/description/icon.png"],
     "application": True,
     "pre_init_hook": "pre_init_hook",
+    "post_init_hook": "post_init_hook",
 }

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -181,6 +181,11 @@ msgid "<strong>Teléfono:</strong>"
 msgstr ""
 
 #. module: l10n_ve_invoice
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.report_freeform_document
+msgid "<strong>Termino de Pago: </strong>"
+msgstr ""
+
+#. module: l10n_ve_invoice
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.document_tax_totals_ve
 msgid "<strong>Total en BS</strong>"
 msgstr ""
@@ -424,7 +429,10 @@ msgstr "Configuración de Facturación"
 
 #. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__invoice_date
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__invoice_date_display_datetime
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__invoice_date
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__invoice_date_display_datetime
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.l10n_ve_invoice_view_invoice_tree_datetime
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -141,6 +141,18 @@ class AccountMove(models.Model):
             elif 'invoice_date_display' in vals and not vals.get('invoice_date_display'):
                 vals['invoice_date_display_datetime'] = False
         moves = super().create(vals_list)
+
+        # Synchronize invoice_date_display_datetime for created invoices
+        # from pickings, sales, POS, or other flows where invoice_date_display
+        # It is applied by default but was not explicitly passed in `vals`.
+        for move in moves:
+            if move.invoice_date_display and not move.invoice_date_display_datetime:
+                date_part = move.invoice_date_display
+                now = fields.Datetime.now()
+                move.invoice_date_display_datetime = now.replace(
+                    year=date_part.year, month=date_part.month, day=date_part.day
+                )
+
         for move in moves:
             if move.is_purchase_international and move.declaration_unique_of_customs and not move.correlative:
                 move.correlative = move.declaration_unique_of_customs

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -131,10 +131,10 @@ class AccountMove(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        now = fields.Datetime.now()
         for vals in vals_list:
             if vals.get('invoice_date_display'):
                 date_part = fields.Date.to_date(vals['invoice_date_display'])
-                now = fields.Datetime.now()
                 vals['invoice_date_display_datetime'] = now.replace(
                     year=date_part.year, month=date_part.month, day=date_part.day
                 )
@@ -142,13 +142,9 @@ class AccountMove(models.Model):
                 vals['invoice_date_display_datetime'] = False
         moves = super().create(vals_list)
 
-        # Synchronize invoice_date_display_datetime for created invoices
-        # from pickings, sales, POS, or other flows where invoice_date_display
-        # It is applied by default but was not explicitly passed in `vals`.
         for move in moves:
             if move.invoice_date_display and not move.invoice_date_display_datetime:
                 date_part = move.invoice_date_display
-                now = fields.Datetime.now()
                 move.invoice_date_display_datetime = now.replace(
                     year=date_part.year, month=date_part.month, day=date_part.day
                 )

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -49,6 +49,11 @@ class AccountMove(models.Model):
         compute="_compute_entry_in_period",
     )
 
+    invoice_date_display_datetime = fields.Datetime(
+        string="Invoice Date",
+        readonly=True,
+        copy=False,
+    )
 
     @api.constrains('invoice_date_display', 'date')
     def _check_invoice_date_display_purchases(self):
@@ -126,6 +131,15 @@ class AccountMove(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('invoice_date_display'):
+                date_part = fields.Date.to_date(vals['invoice_date_display'])
+                now = fields.Datetime.now()
+                vals['invoice_date_display_datetime'] = now.replace(
+                    year=date_part.year, month=date_part.month, day=date_part.day
+                )
+            elif 'invoice_date_display' in vals and not vals.get('invoice_date_display'):
+                vals['invoice_date_display_datetime'] = False
         moves = super().create(vals_list)
         for move in moves:
             if move.is_purchase_international and move.declaration_unique_of_customs and not move.correlative:
@@ -336,6 +350,14 @@ class AccountMove(models.Model):
         return action
 
     def write(self, vals):
+        if vals.get('invoice_date_display'):
+            date_part = fields.Date.to_date(vals['invoice_date_display'])
+            now = fields.Datetime.now()
+            vals['invoice_date_display_datetime'] = now.replace(
+                year=date_part.year, month=date_part.month, day=date_part.day
+            )
+        elif 'invoice_date_display' in vals and not vals.get('invoice_date_display'):
+            vals['invoice_date_display_datetime'] = False
         res = super().write(vals)
         for move in self:
             if move.is_purchase_international and move.declaration_unique_of_customs:

--- a/l10n_ve_invoice/tests/test_tax_action_post.py
+++ b/l10n_ve_invoice/tests/test_tax_action_post.py
@@ -7,6 +7,8 @@ class TestInvoiceTaxConstraint(TransactionCase):
     def setUp(self):
         super(TestInvoiceTaxConstraint, self).setUp()
         self.company = self.env.ref("base.main_company")
+        self.currency_usd = self.env.ref("base.USD")
+        self.company.foreign_currency_id = self.currency_usd
         self.partner = self.env["res.partner"].create({"name": "Test customer"})
         self.journal = self.env["account.journal"].create({
             "name": "Sales Journal",

--- a/l10n_ve_invoice/tests/test_tax_action_post.py
+++ b/l10n_ve_invoice/tests/test_tax_action_post.py
@@ -7,8 +7,8 @@ class TestInvoiceTaxConstraint(TransactionCase):
     def setUp(self):
         super(TestInvoiceTaxConstraint, self).setUp()
         self.company = self.env.ref("base.main_company")
-        self.currency_usd = self.env.ref("base.USD")
-        self.company.foreign_currency_id = self.currency_usd
+        self.currency_foreign = self.env.ref("base.VEF")
+        self.company.foreign_currency_id = self.currency_foreign
         self.partner = self.env["res.partner"].create({"name": "Test customer"})
         self.journal = self.env["account.journal"].create({
             "name": "Sales Journal",

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -220,4 +220,22 @@
         </field>
     </record>
 
+    <record id="l10n_ve_invoice_view_invoice_tree_datetime" model="ir.ui.view">
+        <field name="name">account.move.list.l10n.ve.invoice.datetime</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_invoice_tree" />
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_date_display']" position="attributes">
+                <attribute name="column_invisible">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='invoice_date_display']" position="before">
+                <field name="invoice_date_display_datetime"
+                       optional="show"
+                       string="Invoice Date"
+                       readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
[FIX] #13943: l10n_ve_invoice

Problema:
El campo nativo invoice_date_display de l10n_ve_accountant es de tipo
Date, por lo que en la vista lista de facturas de cliente/proveedor solo se
muestra la fecha sin la hora exacta de creación o modificación, dificultando
identificar el momento preciso en que se estableció la fecha de la factura.

Solución:

Se agrega el campo invoice_date_display_datetime (Datetime,
readonly=True, copy=False) en account.move. En los overrides de create() y
write() se captura la fecha proveniente de invoice_date_display y se le
concatena la hora actual del servidor (fields.Datetime.now()), de modo que
cada vez que el usuario cambia la fecha de la factura queda registrado el
instante exacto del guardado. Se hereda la vista account.view_invoice_tree
para ocultar invoice_date_display nativo (column_invisible) y mostrar el nuevo
campo datetime en su lugar, visible por defecto en todas las listas de
facturas (cliente, proveedor, notas de crédito/débito). Se incluye
post_init_hook para poblar registros existentes en instalaciones nuevas.

Se agrega un loop post-creación dentro de create() que itera los registros
creados y sincroniza invoice_date_display_datetime cuando invoice_date_display
tiene valor pero el campo datetime aún está vacío. Esto cubre todas las vías de
creación programática (pickings, guías de despacho, ventas, POS, tests) sin tener
que modificar cada módulo individualmente.

Ticket (link): https://binaural.odoo.com/odoo/helpdesk/58/tickets/13943
