### PR TITLE
Al realizar un pago con IGTF no se muestra la base imponible

### DIFF
--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -19,7 +19,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "19.0.1.2.10",
+    "version": "19.0.1.2.11",
 
     "depends": [
         "base",

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -733,6 +733,11 @@ class AccountMove(models.Model):
     @api.depends('amount_residual')
     def compute_bi_igtf(self):
         for rec in self:
+            rec.igtf_top_aply = 0.0
+            rec.alter_bi_igtf = 0.0
+            rec.foreign_bi_igtf = 0.0
+            rec.bi_igtf = 0.0
+            
             if abs(rec.amount_residual) > 0 or rec.payment_state in ['paid','in_payment']: 
                 rec.igtf_top_aply = abs(rec.amount_total_signed) * (self.company_id.igtf_percentage / 100)
                 receivable_payable_lines = rec.line_ids.filtered(lambda line: line.account_id.reconcile)


### PR DESCRIPTION
[fix]l10n_ve_igtf: Al realizar un pago con IGTF no se muestra la base imponible

- se setean los valores computados en el compute_bi_igtf ya que al ignorarse originalmente no se existian.

References:
- Ticket: https://binaural.odoo.com/odoo/all-tickets/13517
- Tarea:
- PR:
- Otros: