### PR TITLE
[FIX] #14075: l10n_ve_stock

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "19.0.1.0.3",
+    "version": "19.0.1.0.4",
     "depends": [
         "stock",
         "product",

--- a/l10n_ve_stock/views/stock_picking_views.xml
+++ b/l10n_ve_stock/views/stock_picking_views.xml
@@ -118,4 +118,14 @@
     <record id="stock.action_scrap" model="ir.actions.server">
         <field name="group_ids" eval="[Command.link(ref('l10n_ve_stock.group_hide_discard_inventory_transfers_button'))]"/>
     </record>
+
+    <record id="stock.action_report_picking" model="ir.actions.report">
+        <field name="binding_model_id" eval="False"/>
+    </record>
+    <record id="stock.action_report_delivery" model="ir.actions.report">
+        <field name="binding_model_id" eval="False"/>
+    </record>
+    <record id="stock.return_label_report" model="ir.actions.report">
+        <field name="binding_model_id" eval="False"/>
+    </record>
 </odoo>


### PR DESCRIPTION
Problema: Los botones nativos "Operaciones de recolección", "Recibo de entrega" y "Devolución" se muestran en el menú Imprimir del engranaje. No deben mostrarse porque la localización venezolana usa reportes alternativos (Guía de Despacho, Nota de Despacho, etiquetas de empaque, etc.).

Solución: Se elimina el binding_model_id de los 3 ir.actions.report nativos (stock.action_report_picking, stock.action_report_delivery, stock.return_label_report) para que tampoco aparezcan en el menú Imprimir de la tuerquita.

Ticket: https://binaural.odoo.com/odoo/my-tickets/14075