### PR TITLE
Error al calcular monto alterno

### DIFF
--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -122,6 +122,7 @@ class AccountMove(models.Model):
         store=True,
         index=True,
         readonly=False,
+        digits=0
     )
 
     manually_set_rate = fields.Boolean(default=False)
@@ -441,8 +442,6 @@ class AccountMove(models.Model):
                     % ({"rate": move.foreign_rate, "last_rate": move.last_foreign_rate})
                 )
             
-
-
             new_journal_id = move.journal_id.id
             if old_journal_id and new_journal_id and old_journal_id != new_journal_id:
                 if move.is_invoice(include_receipts=True) and move.move_type in ('out_invoice', 'out_refund', 'out_receipt'):
@@ -755,8 +754,12 @@ class AccountMove(models.Model):
             date_field = "invoice_date" if move.is_invoice(include_receipts=True) else "date"
             rate_date = getattr(move, date_field) or fields.Date.today()
             rate_values = Rate.compute_rate(move.foreign_currency_id.id, rate_date)
-            move.foreign_rate = rate_values.get("foreign_rate")
-            move.foreign_inverse_rate = rate_values.get("foreign_inverse_rate")
+            raw_rate = rate_values.get("foreign_rate")
+            raw_inverse_rate = rate_values.get("foreign_inverse_rate")
+            move.update({
+                'foreign_inverse_rate': float(raw_inverse_rate) if raw_inverse_rate else 0.0,
+                'foreign_rate': float(raw_rate) if raw_rate else 0.0
+            })
             
 
     @api.depends("tax_totals")
@@ -796,20 +799,6 @@ class AccountMove(models.Model):
     )
     def _compute_tax_totals(self):
         return super()._compute_tax_totals()
-
-    @api.onchange("foreign_rate","invoice_date")
-    def _onchange_foreign_rate(self):
-        """
-        Onchange the foreign rate and compute the foreign inverse rate
-        """
-        if self.invoice_date or self.date:
-            if self.foreign_rate < 0 or self.foreign_inverse_rate < 0:
-                raise ValidationError(_("The rate entered cannot be negative"))
-            Rate = self.env["res.currency.rate"]
-            for move in self:
-                if not move.foreign_rate:
-                    return
-                move.foreign_inverse_rate = Rate.compute_inverse_rate(move.foreign_rate)
 
     @api.onchange("foreign_inverse_rate","invoice_date")
     def _onchange_foreign_inverse_rate(self):

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1030,42 +1030,9 @@ class AccountMove(models.Model):
                         untaxed_amount = untaxed_amount_currency
                         tax_amount = tax_amount_currency
                     else:
-                        tax_amount = (
-                            invoice.foreign_total_billed
-                            - invoice.foreign_taxable_income
-                        ) * sign
-                        untaxed_amount = (invoice.foreign_taxable_income) * sign
-
-                    invoice_payment_terms = (
-                        invoice.invoice_payment_term_id._compute_terms(
-                            date_ref=invoice.invoice_date
-                            or invoice.date
-                            or fields.Date.context_today(invoice),
-                            currency=invoice.foreign_currency_id,
-                            tax_amount_currency=tax_amount,
-                            tax_amount=tax_amount,
-                            untaxed_amount_currency=untaxed_amount,
-                            untaxed_amount=untaxed_amount,
-                            company=invoice.company_id,
-                            sign=sign,
-                        )
-                    )
-
-                    for term in invoice_payment_terms["line_ids"]:
-                        for key in list(invoice.needed_terms.keys()):
-                            if key["date_maturity"] == fields.Date.to_date(
-                                term.get("date")
-                            ):
-                                invoice.needed_terms[key] = {
-                                    **invoice.needed_terms[key],
-                                    "foreign_balance": term["company_amount"],
-                                }
+                        pass
                 else:
-                    for key in list(invoice.needed_terms.keys()):
-                        invoice.needed_terms[key] = {
-                            **invoice.needed_terms[key],
-                            "foreign_balance": sign * invoice.foreign_total_billed,
-                        }
+                    pass
         return res
 
     def button_draft(self):

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -22,7 +22,7 @@ class AccountMoveLine(models.Model):
     )
     foreign_rate = fields.Float(related="move_id.foreign_rate", store=True)
     foreign_inverse_rate = fields.Float(
-        related="move_id.foreign_inverse_rate", store=True, index=True
+        related="move_id.foreign_inverse_rate", store=True, index=True, digits=0
     )
 
     foreign_price = fields.Monetary(

--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -34,7 +34,7 @@ class AccountPayment(models.Model):
     foreign_inverse_rate = fields.Float(
         help="Rate that will be used as factor to multiply of the foreign currency for this move.",
         compute="_compute_rate",
-        default=0.0,
+        digits=0,
         store=True,
         readonly=False,
     )

--- a/l10n_ve_accountant/views/account_move.xml
+++ b/l10n_ve_accountant/views/account_move.xml
@@ -99,7 +99,7 @@
                     readonly="1"
                     force_save="1"
                     widget="monetary"
-                    options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"
+                    options="{'currency_field': 'foreign_currency_id'}"
                 />
                 <field
                     name="foreign_credit"
@@ -108,11 +108,11 @@
                     readonly="1"
                     force_save="1"
                     widget="monetary"
-                    options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"
+                    options="{'currency_field': 'foreign_currency_id'}"
                 />
                 <field name="foreign_debit_adjustment" optional="hide" force_save="1"/>
                 <field name="foreign_credit_adjustment" optional="hide" force_save="1"/>
-                <field name="foreign_balance" optional="hide" groups="base.group_no_one" force_save="1" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
+                <field name="foreign_balance" optional="hide" groups="base.group_no_one" force_save="1" widget="monetary" options="{'currency_field': 'foreign_currency_id'}"/>
                 <field name="foreign_rate" optional="hide" groups="base.group_no_one" force_save="1"/>
                 <field
                     name="foreign_inverse_rate"

--- a/l10n_ve_accountant/views/account_move_line.xml
+++ b/l10n_ve_accountant/views/account_move_line.xml
@@ -6,14 +6,14 @@
         <field name="arch" type="xml">
             <xpath expr="//notebook/page/group/group[1]" position="after">
                 <group string="Foreign Amount">
-                    <field name="foreign_rate" readonly="1" force_save="1" options="{'precision': 'Tasa'}"/>
+                    <field name="foreign_rate" readonly="1" force_save="1" widget="monetary" options="{'precision': 'Tasa'}"/>
                     <field name="foreign_inverse_rate" invisible="1"/>
                     <field name="foreign_inverse_rate" readonly="1" force_save="1" groups="base.group_no_one"/>
-                    <field name="foreign_debit" readonly="1" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
-                    <field name="foreign_debit_adjustment" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
-                    <field name="foreign_credit_adjustment" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
-                    <field name="foreign_credit" readonly="1" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
-                    <field name="foreign_balance" readonly="1" force_save="1" options="{'precision': 'Foreign Product Price'}"/>
+                    <field name="foreign_debit" readonly="1" force_save="1" widget="monetary"  />
+                    <field name="foreign_debit_adjustment" force_save="1" widget="monetary"  />
+                    <field name="foreign_credit_adjustment" force_save="1" widget="monetary"  />
+                    <field name="foreign_credit" readonly="1" force_save="1" widget="monetary"  />
+                    <field name="foreign_balance" readonly="1" force_save="1" widget="monetary"  />
                 </group>
 	    </xpath>
 	</field>
@@ -26,11 +26,11 @@
 	<field name="arch" type="xml">
 	    <xpath expr="//field[@name='balance']" position="after">
 		<field name="foreign_currency_id" column_invisible="True"/>
-		<field name="foreign_debit" readonly="1" optional="show" sum="Total Foreign Debit" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_debit_adjustment" optional="hide" options="{'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_credit" readonly="1" optional="show" sum="Total Foreign Credit" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_credit_adjustment" optional="hide" options="{'precision': 'Foreign Product Price'}"/>
-		<field name="foreign_balance" readonly="1" optional="hide" widget="monetary" options="{'currency_field': 'foreign_currency_id', 'precision': 'Foreign Product Price'}"/>
+		<field name="foreign_debit" readonly="1" optional="show" sum="Total Foreign Debit" widget="monetary" options="{'currency_field': 'foreign_currency_id'}"/>
+		<field name="foreign_debit_adjustment" optional="hide" widget="monetary"  />
+		<field name="foreign_credit" readonly="1" optional="show" sum="Total Foreign Credit" widget="monetary" options="{'currency_field': 'foreign_currency_id'}"/>
+		<field name="foreign_credit_adjustment" optional="hide" widget="monetary"  />
+		<field name="foreign_balance" readonly="1" optional="hide" widget="monetary" options="{'currency_field': 'foreign_currency_id'}"/>
                     
 
 	    </xpath>

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -37,6 +37,7 @@ class AccountPaymentRegister(models.TransientModel):
             "Rate that will be used as factor to multiply of the foreign currency for the payment "
             "and the moves created by the wizard."
         ),
+        digits=0
     )
     base_currency_is_vef = fields.Boolean(
         default=lambda self: self.env.company.currency_id == self.env.ref("base.VEF")

--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "17.0.1.1.23",
+    "version": "17.0.1.1.24",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -51,6 +51,7 @@ class SaleOrder(models.Model):
         compute="_compute_rate",
         store=True,
         readonly=False,
+        digits=0
     )
 
     last_foreign_rate = fields.Float(copy=False)


### PR DESCRIPTION
[lfix] l10n_ve_accountant , l10n_ve_sale: Error al calcular monto alterno

- El error con que existia con el calculo de los montos alterno venia dado a una la tasa, esta a pesar de no tener digits en ciertas ocaciones redondeaba la tasa cuando la base era VEF a 2 decimales, como la misma omitia los 2 decimales siguientes el calcula era erroneo, se establece digits a 0 para que el sistema evite el redondeo y mantenga la precision, se establecio en los modelos account_payment. account_move,account_move_line y en sale.order y wizard de pagos

- Se modifica funcion  _compute_rate_for_documents para guardar correctamente los datos de las tasas

- se elimina _onchange_foreign_rate el cual recalculaba sin necesidad

References:
- Ticket:  https://binaural.odoo.com/odoo/my-tickets/14067 , https://binaural.odoo.com/odoo/my-tickets/13402
- Tarea:
- PR:
- Otros: