### PR TITLE
Al crear facturas con COGS el sistema genera diferencias en los alternos cuando se confirman .

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.9",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1384,7 +1384,7 @@ class AccountMove(models.Model):
                     return item.get('amount_currency', 0)
             return None
 
-        def _foreign_fallback(balance):
+        def _foreign_fallback(balance): 
             rate_date = move.invoice_date if move.is_invoice(include_receipts=True) else move.date
             return move.company_id.currency_id._convert(
                 balance, move.foreign_currency_id, move.company_id,
@@ -1523,7 +1523,7 @@ class AccountMove(models.Model):
             if not pt_lines:
                 continue
             other = lines.filtered(
-                lambda l: l.display_type != "payment_term"
+                lambda l: l.display_type not in ("payment_term", "cogs")
             )
             fc = move.company_id.foreign_currency_id
             if not fc:
@@ -1627,7 +1627,7 @@ class AccountMove(models.Model):
                 tax_line.balance = correct_balance
 
         non_pt = move.line_ids.filtered(
-            lambda l: l.display_type != 'payment_term'
+            lambda l: l.display_type not in ('payment_term', 'cogs')
         )
         if not non_pt:
             return


### PR DESCRIPTION
[FIX] l10n_ve_accountant:  Al crear facturas con COGS el sistema genera diferencias en los alternos cuando se confirman .

- Para evitar este error de la forma menos invasiva posible se procedo excluir el calculo de los COGS de la porcion real ya que dicho problema se daba en el momento en que se publicaba el asiento sucediendo este ajuste de las en el metodo privador _post() del asiento contable, ya el ajuste existia previamente y al agregar las nuevas lineas al no existir antes del ajuste no se contemplaban lo q creaba un desbalance a nivel de los alternos.

- al excluirlo del ajuste de la porcion real los mismos entran en el codigo q los calcula individualmente lo cual no afecta el resultado final

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/14150
- Tarea:
- PR:
- Otros: