### PR TITLE
 Corregir error en producto al validar impuestos

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.9",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -828,8 +828,8 @@ msgstr "Es Compra Internacional"
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__invoice_date_display
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__invoice_date_display
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.l10n_ve_accountant_view_account_invoice_filter
-msgid "Invoice Date"
-msgstr "Fecha de factura"
+msgid "Invoice rate"
+msgstr "Fecha de Tasa"
 
 #. module: l10n_ve_accountant
 #. odoo-python
@@ -1770,3 +1770,49 @@ msgstr "Importe adeudado"
 #: code:addons/l10n_ve_accountant/models/account_move.py:0
 msgid "You cannot delete a journal item that is posted, cancelled, or has been previously posted."
 msgstr "No puede borrar apuntes ya publicados, cancelados o anteriormente publicados."
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/product_template.py:0
+#, python-format
+msgid ""
+"- %s: No tax is assigned and the company has no default fiscal "
+"configuration."
+msgstr ""
+"- %s: No tiene impuesto asignado y la compañía no tiene "
+"configuración fiscal predeterminada."
+
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/product_template.py:0
+#, python-format
+msgid ""
+"- %s: Has %s taxes assigned (exactly one tax is required due to local fiscal"
+" policies)."
+msgstr ""
+"- %s: Tiene %s impuestos asignados (se requiere exactamente uno "
+"debido a políticas fiscales locales)."
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/product_template.py:0
+#, python-format
+msgid ""
+"Fiscal inconsistencies were found in product: '%s':\n"
+"\n"
+msgstr ""
+"Se encontraron inconsistencias fiscales en el producto: '%s':\n"
+"\n"
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/product_template.py:0
+msgid ""
+"\n"
+"\n"
+"Please correct these fields before saving your changes."
+msgstr ""
+"\n"
+"\n"
+"Por favor corrija estos campos antes de guardar los cambios."

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -828,8 +828,8 @@ msgstr "Es Compra Internacional"
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__invoice_date_display
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__invoice_date_display
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.l10n_ve_accountant_view_account_invoice_filter
-msgid "Invoice rate"
-msgstr "Fecha de Tasa"
+msgid "Invoice Date"
+msgstr "Fecha de factura"
 
 #. module: l10n_ve_accountant
 #. odoo-python

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -1816,6 +1816,8 @@ msgstr ""
 "\n"
 "\n"
 "Por favor corrija estos campos antes de guardar los cambios."
+
+#. module: l10n_ve_accountant
 #: model:ir.model.fields,help:l10n_ve_accountant.field_res_company__index_payment_in_wizard
 #: model:ir.model.fields,help:l10n_ve_accountant.field_res_config_settings__index_payment_in_wizard
 msgid "Apply Indexacion to payment from wizard of invoice"

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -18,7 +18,7 @@ _logger = logging.getLogger(__name__)
 class AccountMove(models.Model):
     _inherit = "account.move"
     
-    invoice_date_display = fields.Date(string="Invoice Date", default=fields.Date.today)
+    invoice_date_display = fields.Date(string="Invoice rate", default=fields.Date.today)
     is_purchase_international = fields.Boolean(related="journal_id.is_purchase_international")
 
     @api.depends('invoice_date_display')

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -18,7 +18,7 @@ _logger = logging.getLogger(__name__)
 class AccountMove(models.Model):
     _inherit = "account.move"
     
-    invoice_date_display = fields.Date(string="Invoice rate", default=fields.Date.today)
+    invoice_date_display = fields.Date(string="Invoice Date", default=fields.Date.today)
     is_purchase_international = fields.Boolean(related="journal_id.is_purchase_international")
 
     @api.depends('invoice_date_display')

--- a/l10n_ve_accountant/models/product_template.py
+++ b/l10n_ve_accountant/models/product_template.py
@@ -18,7 +18,8 @@ class ProductTemplate(models.Model):
             return super(ProductTemplate, self).write(vals)
 
         # Enforce tax validation on any write operation to correct legacy records
-        self._enforce_single_tax_vals(vals, records=self)
+        if 'taxes_id' in vals or 'supplier_taxes_id' in vals:
+            self._enforce_single_tax_vals(vals, records=self)
             
         return super(ProductTemplate, self).write(vals)
 

--- a/l10n_ve_accountant/models/product_template.py
+++ b/l10n_ve_accountant/models/product_template.py
@@ -1,33 +1,83 @@
-from odoo import _, api, models, fields
-import logging
-
-_logger = logging.getLogger(__name__)
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-
     @api.model_create_multi
     def create(self, vals_list):
-        records = super(ProductTemplate, self).create(vals_list)
-        records._enforce_single_tax()
-        return records
+        # Context to silence internal/automated cascade writes during creation
+        ctx = dict(self.env.context, skip_tax_validation_on_write=True)
+        for vals in vals_list:
+            self.with_context(ctx)._enforce_single_tax_vals(vals)
+        return super(ProductTemplate, self.with_context(ctx)).create(vals_list)
 
     def write(self, vals):
-        res = super(ProductTemplate, self).write(vals)
-        self._enforce_single_tax()
-        return res
+        if self.env.context.get('skip_tax_validation_on_write'):
+            return super(ProductTemplate, self).write(vals)
 
-    def _enforce_single_tax(self):
-        for rec in self:
-            # Sales Taxes logic
-            if not rec.taxes_id:
-                sale_tax = self.env.company.account_sale_tax_id or self.env.company.root_id.sudo().account_sale_tax_id
-                if sale_tax:
-                    rec.taxes_id = [(6, 0, [sale_tax.id])]
-            # Purchase Taxes logic
-            if not rec.supplier_taxes_id:
-                purchase_tax = self.env.company.account_purchase_tax_id or self.env.company.root_id.sudo().account_purchase_tax_id
-                if purchase_tax:
-                    rec.supplier_taxes_id = [(6, 0, [purchase_tax.id])]
+        # Enforce tax validation on any write operation to correct legacy records
+        self._enforce_single_tax_vals(vals, records=self)
+            
+        return super(ProductTemplate, self).write(vals)
+
+    def _enforce_single_tax_vals(self, vals, records=None):
+        """Validates and ensures exactly one tax is assigned by calculating 
+
+        the net final state of the Odoo M2M commands.
+        """
+        errors = []
+        company = self.env['res.company'].browse(vals.get('company_id')) if vals.get('company_id') else (records.company_id if records else self.env.company)
+
+        for field_name, comp_field in [
+            ('taxes_id', 'account_sale_tax_id'),
+            ('supplier_taxes_id', 'account_purchase_tax_id')
+        ]:
+            label = self._fields[field_name].string
+            # 1. Determine the baseline tax IDs of the record (if updating)
+            current_ids = set(records[field_name].ids) if records else set()
+
+            if field_name in vals and vals[field_name]:
+                raw_value = vals[field_name]
+                
+                # Case A: Direct integer list [ID, ID]
+                if isinstance(raw_value, list) and all(isinstance(x, int) for x in raw_value):
+                    current_ids = set(raw_value)
+                
+                # Case B: Odoo M2M standard command structure
+                elif isinstance(raw_value, list):
+                    for cmd in raw_value:
+                        if isinstance(cmd, (list, tuple)):
+                            code = cmd[0]
+                            if code == 6:     # Replace entire relation
+                                current_ids = set(cmd[2])
+                            elif code == 4:   # Link individual record
+                                current_ids.add(cmd[1])
+                            elif code == 3:   # Unlink individual record
+                                current_ids.discard(cmd[1])
+                            elif code == 5:   # Unlink all records
+                                current_ids.clear()
+
+            tax_ids = list(current_ids)
+
+            # --- Fiscal Policy Rules Validation ---
+            if not tax_ids:
+                default_tax = company[comp_field] or company.root_id.sudo()[comp_field]
+                if default_tax and default_tax.id:
+                    vals[field_name] = [fields.Command.set([default_tax.id])]
+                else:
+                    errors.append(_("- %s: No tax is assigned and the company has no default fiscal configuration.") % label)
+            elif len(tax_ids) > 1:
+                errors.append(_("- %s: Has %s taxes assigned (exactly one tax is required due to local fiscal policies).") % (label, len(tax_ids)))
+
+        if errors:
+            name = vals.get('name') or (records.name if records else '')
+            
+            # Consolidated multi-error message formatting
+            error_msg = (
+                _("Fiscal inconsistencies were found in product: '%s':\n\n") % name
+                + "\n".join(errors)
+                + _("\n\nPlease correct these fields before saving your changes.")
+            )
+            raise UserError(error_msg)

--- a/l10n_ve_accountant/tests/__init__.py
+++ b/l10n_ve_accountant/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_real_portion
 from . import test_account_move_core
 from . import test_account_tax_foreign
 from . import test_coverage_gaps
+from . import test_product_template

--- a/l10n_ve_accountant/tests/test_product_template.py
+++ b/l10n_ve_accountant/tests/test_product_template.py
@@ -1,0 +1,204 @@
+import logging
+from odoo.tests import TransactionCase, tagged
+from odoo import fields
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install", "l10n_ve_accountant_core")
+class TestProductTemplate(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.ref("base.main_company")
+        self.tax_group = self.env['account.tax.group'].create({
+            'name': 'Test Tax Group', 'company_id': self.company.id,
+        })
+        self.tax_sale_1 = self.env["account.tax"].with_company(self.company).create({
+            "name": "Sale Tax 16%", "amount": 16, "amount_type": "percent",
+            "type_tax_use": "sale", "company_id": self.company.id,
+            "tax_group_id": self.tax_group.id,
+        })
+        self.tax_sale_2 = self.env["account.tax"].with_company(self.company).create({
+            "name": "Sale Tax 8%", "amount": 8, "amount_type": "percent",
+            "type_tax_use": "sale", "company_id": self.company.id,
+            "tax_group_id": self.tax_group.id,
+        })
+        self.tax_purchase = self.env["account.tax"].with_company(self.company).create({
+            "name": "Purchase Tax 8%", "amount": 8, "amount_type": "percent",
+            "type_tax_use": "purchase", "company_id": self.company.id,
+            "tax_group_id": self.tax_group.id,
+        })
+
+    # ═══════════════════════════════════════════════════════════════
+    # Positive tests — product creation / write should succeed
+    # ═══════════════════════════════════════════════════════════════
+
+    def test_01_create_one_sale_tax(self):
+        """Crear producto con 1 sale tax -> OK"""
+        product = self.env["product.product"].create({
+            "name": "Test Sale Only",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        self.assertEqual(len(product.taxes_id), 1)
+        self.assertEqual(product.taxes_id.id, self.tax_sale_1.id)
+
+    def test_02_create_one_purchase_tax(self):
+        """Crear producto con 1 purchase tax -> OK"""
+        product = self.env["product.product"].create({
+            "name": "Test Purchase Only",
+            "type": "service",
+            "taxes_id": [(6, 0, [])],
+            "supplier_taxes_id": [(6, 0, [self.tax_purchase.id])],
+        })
+        self.assertEqual(len(product.supplier_taxes_id), 1)
+        self.assertEqual(product.supplier_taxes_id.id, self.tax_purchase.id)
+
+    def test_03_create_one_sale_one_purchase(self):
+        """Crear producto con 1 sale + 1 purchase tax -> OK"""
+        product = self.env["product.product"].create({
+            "name": "Test Both",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [self.tax_purchase.id])],
+        })
+        self.assertEqual(len(product.taxes_id), 1)
+        self.assertEqual(len(product.supplier_taxes_id), 1)
+
+    def test_04_create_with_company_defaults(self):
+        """Company tiene defaults, producto sin taxes -> se asignan automáticamente"""
+        self.company.write({
+            "account_sale_tax_id": self.tax_sale_1.id,
+            "account_purchase_tax_id": self.tax_purchase.id,
+        })
+        product = self.env["product.product"].create({
+            "name": "Test Defaults",
+            "type": "service",
+            "taxes_id": [(5, 0, 0)],
+            "supplier_taxes_id": [(5, 0, 0)],
+        })
+        self.assertEqual(len(product.taxes_id), 1)
+        self.assertEqual(product.taxes_id.id, self.tax_sale_1.id)
+        self.assertEqual(len(product.supplier_taxes_id), 1)
+        self.assertEqual(product.supplier_taxes_id.id, self.tax_purchase.id)
+
+    def test_05_write_sale_tax(self):
+        """Write con 1 sale tax sobre producto existente -> OK"""
+        product = self.env["product.product"].create({
+            "name": "Test Write",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        product.write({"taxes_id": [(6, 0, [self.tax_sale_1.id])]})
+        self.assertEqual(len(product.taxes_id), 1)
+
+    def test_06_write_non_tax_field(self):
+        """Write solo de name -> no ejecuta validacion -> OK"""
+        product = self.env["product.product"].create({
+            "name": "Original Name",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        product.write({"name": "Updated Name"})
+        self.assertEqual(product.name, "Updated Name")
+
+    def test_07_write_command_6_replace_one(self):
+        """Command 6 reemplaza con 1 tax -> OK"""
+        product = self.env["product.product"].create({
+            "name": "Test Cmd6",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        product.write({"taxes_id": [(6, 0, [self.tax_sale_1.id])]})
+        self.assertEqual(product.taxes_id.id, self.tax_sale_1.id)
+
+    def test_08_write_command_5_clear_then_4_one(self):
+        """Command 5 + Command 4 con company defaults -> net 1 -> OK"""
+        self.company.write({
+            "account_sale_tax_id": self.tax_sale_1.id,
+        })
+        product = self.env["product.product"].create({
+            "name": "Test Cmd5and4",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        product.write({
+            "taxes_id": [
+                (5, 0, 0),
+                (4, self.tax_sale_1.id),
+            ]
+        })
+        self.assertEqual(len(product.taxes_id), 1)
+
+    # ═══════════════════════════════════════════════════════════════
+    # Negative tests — product creation / write should raise UserError
+    # ═══════════════════════════════════════════════════════════════
+
+    def test_09_create_two_sale_taxes(self):
+        """2 sale taxes distintos -> UserError"""
+        with self.assertRaises(UserError):
+            self.env["product.product"].create({
+                "name": "Test Two Sale Taxes",
+                "type": "service",
+                "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
+                "supplier_taxes_id": [(6, 0, [])],
+            })
+
+    def test_10_create_no_taxes_no_default(self):
+        """Sin taxes, company sin defaults -> UserError"""
+        self.company.write({
+            "account_sale_tax_id": False,
+            "account_purchase_tax_id": False,
+        })
+        with self.assertRaises(UserError):
+            self.env["product.product"].create({
+                "name": "Test No Tax",
+                "type": "service",
+                "taxes_id": [(5, 0, 0)],
+                "supplier_taxes_id": [(5, 0, 0)],
+            })
+
+    def test_11_write_two_sale_taxes(self):
+        """Escribir 2 sale taxes distintos -> UserError"""
+        product = self.env["product.product"].create({
+            "name": "Test Write Two",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        with self.assertRaises(UserError):
+            product.write({
+                "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
+            })
+
+    def test_12_write_command_4_add_second(self):
+        """Command 4 agrega segundo tax distinto -> UserError"""
+        product = self.env["product.product"].create({
+            "name": "Test Cmd4 Second",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        with self.assertRaises(UserError):
+            product.write({"taxes_id": [(4, self.tax_sale_2.id)]})
+
+    def test_13_write_command_3_to_zero_no_default(self):
+        """Command 3 remueve ultimo tax, no hay default -> UserError"""
+        self.company.write({
+            "account_sale_tax_id": False,
+        })
+        product = self.env["product.product"].create({
+            "name": "Test Cmd3 To Zero",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        with self.assertRaises(UserError):
+            product.write({"taxes_id": [(3, self.tax_sale_1.id)]})


### PR DESCRIPTION
[FIX] l10n_ve_accountant: Corregir error en producto al validar impuestos

-Anteriormente al validarse un producto con impuesto si no existia un impuesto configurado por defecto generaba un error de recursion al guardar

- Se mejoro la logica y aplicaron nuevas traducciones para los mensajes de validacion y mejorar la experiencia de usuario.

References:
- Ticket:  https://binaural.odoo.com/odoo/my-tickets/13828
- Tarea:
- PR:
- Otros: