### PR TITLE
 No permitir descuentos del 100% en las lineas de productos de la factura

### DIFF
--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -1770,3 +1770,17 @@ msgstr "Importe adeudado"
 #: code:addons/l10n_ve_accountant/models/account_move.py:0
 msgid "You cannot delete a journal item that is posted, cancelled, or has been previously posted."
 msgstr "No puede borrar apuntes ya publicados, cancelados o anteriormente publicados."
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/account_move_line.py:0
+msgid ""
+"Product: %(product)s\n"
+"Discount: %(discount)s\n"
+"Discounts of 100%% or higher are not allowed on invoices.\n"
+"Please adjust the discount percentage before saving."
+msgstr ""
+"Producto: %(product)s\n"
+"Descuento: %(discount)s\n"
+"No se permiten descuentos del 100%% o superiores en facturas.\n"
+"Por favor ajuste el porcentaje de descuento antes de guardar."

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -474,3 +474,26 @@ class AccountMoveLine(models.Model):
         move.real_portion_count += 1
 
     
+    @api.constrains("discount")
+    def _check_max_discount(self):
+        """Validates that discount value on invoice lines does not reach or exceed 100%."""
+        for line in self:
+            if not line.product_id:
+                continue
+
+            if line.discount >= 100.0:
+                product_name = line.product_id.display_name
+                discount_val = f"{line.discount}%"
+
+                raise UserError(
+                    _(
+                        "Product: %(product)s\n"
+                        "Discount: %(discount)s\n"
+                        "Discounts of 100%% or higher are not allowed on invoices.\n"
+                        "Please adjust the discount percentage before saving."
+                    )
+                    % {
+                        "product": product_name,
+                        "discount": discount_val,
+                    }
+                )


### PR DESCRIPTION
[fix] l10n_ve_accountant: No permitir descuentos del 100% en las lineas de productos de la factura

-Se agrega constraint para el campo discount en las lineas de facturas con validacion  para evitar que se agreguen descuentos del 100% o superior

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/14050?debug=1
- Tarea:
- PR:
- Otros: