### PR TITLE
Cambiar flujo de IGTF actual y Anticipo de IGTF por nota de Credito y Debito

### DIFF
--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -19,7 +19,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "19.0.1.2.12",
+    "version": "19.0.1.2.13",
 
     "depends": [
         "base",

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -769,7 +769,13 @@ class AccountMove(models.Model):
         partial_reconcile.write({'origin_payment_advanced_payment_id': False})
         origin_payment_id.write({'advanced_move_ids': [(3, partial_reconcile.id)]})
 
-    @api.depends('amount_residual')
+    @api.depends(
+        'amount_residual',
+        'debit_note_ids.origin_payment_to_pay_igtf',
+        'debit_note_ids.state',
+        'debit_note_ids.payment_state',
+        'debit_note_ids.amount_total_signed',
+    )
     def compute_bi_igtf(self):
         for rec in self:
             rec.igtf_top_aply = 0.0
@@ -794,6 +800,14 @@ class AccountMove(models.Model):
                 partial_amount = 0.0
 
                 partner_context = rec.partner_id.with_company(rec.company_id)
+                igtf_debit_notes = rec.debit_note_ids.filtered(
+                    lambda dn: dn.origin_payment_to_pay_igtf
+                    and dn.state == 'posted'
+                    and dn.payment_state != 'reversed'
+                )
+                debit_note_by_payment = {
+                    dn.origin_payment_to_pay_igtf.id: dn for dn in igtf_debit_notes
+                }
                 for payment_move in final_payment_moves:
                     if rec.move_type in ['out_invoice', 'out_refund']:
                         target_account = partner_context.property_account_receivable_id
@@ -801,6 +815,8 @@ class AccountMove(models.Model):
                         target_account = partner_context.property_account_payable_id
 
                     igtf_line = payment_move.line_ids.filtered(lambda line: line.account_id.id in account)
+                    igtf_debit_note = debit_note_by_payment.get(payment_move.id)
+                    has_igtf = bool(igtf_line) or bool(igtf_debit_note)
                     partner_line = payment_move.line_ids.filtered(lambda l: l.account_id.id == target_account.id)
                     bank_line = payment_move.line_ids.filtered(lambda line: line.account_id.id not in partner_line.mapped('account_id').ids and line.account_id.id not in igtf_line.mapped('account_id').ids)
                     
@@ -820,17 +836,20 @@ class AccountMove(models.Model):
                         if partial:
                             partial_amount = abs(sum(partial.mapped('amount')))
                         
-                        if igtf_line and partial:
-                        
-                            igtf_amount = abs(igtf_line[0].balance)
-                            igtf_amount_currency = abs(igtf_line[0].amount_currency)
+                        if has_igtf and partial:
+                            if igtf_debit_note:
+                                igtf_amount = abs(igtf_debit_note.amount_total_signed)
+                                igtf_amount_currency = abs(igtf_debit_note.amount_total)
+                            else:
+                                igtf_amount = abs(igtf_line[0].balance)
+                                igtf_amount_currency = abs(igtf_line[0].amount_currency)
                             partial_amount = abs(sum(partial.mapped('amount')))
                         
-                        if not igtf_line and bank_line and partial:
+                        if not has_igtf and bank_line and partial:
                             igtf_top += partial_amount
                             
                         
-                        if igtf_line and bank_line and partial:
+                        if has_igtf and bank_line and partial:
 
                             if payment_move.origin_payment_id and payment_move.origin_payment_id.reconciled_invoices_count > 1:
 
@@ -854,7 +873,7 @@ class AccountMove(models.Model):
                                     amount_base_payment = partial_amount
                                     igtf_amount = igtf_amount 
 
-                        if igtf_line and partial:
+                        if has_igtf and partial:
                             alter_bi_igtf += igtf_amount
 
                     conversion_date = False
@@ -913,102 +932,65 @@ class AccountMove(models.Model):
             )
         )[:1]
 
-        
         if not payment_move:
+            _logger.error("IGTF: remove_igtf — no payment_move found for partial_id=%s", partial_id)
             return False
         if payment_move.currency_id == self.env.ref("base.VEF") and not payment_move.origin_payment_advanced_payment_id:
+            _logger.info("IGTF: remove_igtf — skipping VEF payment %s (id=%s)", payment_move.name, payment_move.id)
             return 
         
-
+        _logger.info("IGTF: remove_igtf — processing payment_move=%s (id=%s), calling create_note_credit_igtf", 
+                     payment_move.name, payment_move.id)
         self.create_note_credit_igtf(partial_id)
 
         try:
             payment_move.button_draft()
-            
         except Exception:
             return False
-        
         
         igtf_line = payment_move.line_ids.filtered(lambda line: line.account_id.id in igtf_account_ids)
         receivable_payable_line = payment_move.line_ids.filtered(
             lambda line: line.account_id.id in [payment_move.partner_id.property_account_payable_id.id,payment_move.partner_id.property_account_receivable_id.id ]
         )[:1]
         if igtf_line and receivable_payable_line:
-            
             igtf_line_balance = igtf_line.balance
 
-            current_debit = receivable_payable_line.debit
-            current_credit = receivable_payable_line.credit
-            new_lines_commands = []
+            if igtf_line_balance > 0:
+                new_debit = receivable_payable_line.debit + igtf_line_balance
+                new_credit = 0.0
+            else:
+                new_credit = receivable_payable_line.credit + abs(igtf_line_balance)
+                new_debit = 0.0
+
+            advance_account = payment_move.partner_id.default_advance_customer_account_id.id if receivable_payable_line.credit > 0 else payment_move.partner_id.default_advance_supplier_account_id.id
             
-            for line in payment_move.line_ids:
-
-                if line.id == igtf_line.id:
-                    new_lines_commands.append((2, line.id, False))
-                    
-                elif line.id == receivable_payable_line.id:
-                    
-                    current_debit = line.debit
-                    current_credit = line.credit
-                    current_balance = line.balance
-                    current_f_balance = line.foreign_balance
-                    current_amount_currency = line.amount_currency
-                    current_f_debit = line.foreign_debit
-                    current_f_credit = line.foreign_credit
-                    
-                    if igtf_line_balance > 0: # IGTF DÉBIT
-                        new_debit = current_debit + igtf_line_balance
-                        new_credit = 0.0
-                        new_balance = current_balance + igtf_line.balance
-                        new_f_balance = current_f_balance + igtf_line.foreign_balance
-                        new_amount_currency = current_amount_currency + igtf_line.amount_currency
-                        new_f_debit = current_f_debit + igtf_line.foreign_debit
-                        new_f_credit = current_f_credit + igtf_line.foreign_credit
-                      
-                    else: # IGTF CRÉDIT
-                        new_credit = current_credit + abs(igtf_line_balance)
-                        new_debit = 0.0
-                        new_balance = current_balance + igtf_line.balance
-                        new_f_balance = current_f_balance + igtf_line.foreign_balance
-                        new_amount_currency = current_amount_currency + igtf_line.amount_currency
-                        new_f_debit = current_f_debit + igtf_line.foreign_debit
-                        new_f_credit = current_f_credit + igtf_line.foreign_credit
-                    
-                    advance_account = payment_move.partner_id.default_advance_customer_account_id.id if current_credit > 0 else  payment_move.partner_id.default_advance_supplier_account_id.id
-                    
-                    line_vals = {
-                        'debit': new_debit,
-                        'credit': new_credit,
-                        'balance': new_balance,
-                        'amount_currency': new_amount_currency,
-                        'foreign_balance':new_f_balance,
-                        'foreign_debit':new_f_debit,
-                        'foreign_credit':new_f_credit,
-                        'account_id': advance_account if not payment_move.origin_payment_id.destination_account_id.is_advance_account else payment_move.origin_payment_id.destination_account_id.id,
-                        'name': line.name,
-                    }
-
-                    new_lines_commands.append((1, line.id, line_vals))
-                else:
-                    new_lines_commands.append((1, line.id, {}))
+            line_vals = {
+                'debit': new_debit,
+                'credit': new_credit,
+                'balance': receivable_payable_line.balance + igtf_line.balance,
+                'amount_currency': receivable_payable_line.amount_currency + igtf_line.amount_currency,
+                'foreign_balance': receivable_payable_line.foreign_balance + igtf_line.foreign_balance,
+                'foreign_debit': receivable_payable_line.foreign_debit + igtf_line.foreign_debit,
+                'foreign_credit': receivable_payable_line.foreign_credit + igtf_line.foreign_credit,
+                'account_id': advance_account if not payment_move.origin_payment_id.destination_account_id.is_advance_account else payment_move.origin_payment_id.destination_account_id.id,
+                'name': receivable_payable_line.name,
+            }
 
             payment_move.write({
-                'line_ids': new_lines_commands
+                'line_ids': [
+                    (2, igtf_line.id, False),
+                    (1, receivable_payable_line.id, line_vals),
+                ]
             })
 
             if 'is_advance_payment' in payment_move.origin_payment_id._fields:
-
                 if payment_move.origin_payment_id and not payment_move.origin_payment_id.is_advance_payment:
-
                     payment_move.origin_payment_id.write({
                         'is_advance_payment':True,
                         'igtf_amount': 0.0
                     })
-            
 
-            
         try:
-
             if payment_move.origin_payment_advanced_payment_id:
                 payment_move.origin_payment_advanced_payment_id.write({'advanced_move_ids': [(3, payment_move.id)]})
                 payment_move.button_cancel()
@@ -1088,7 +1070,7 @@ class AccountMove(models.Model):
         }
 
         write_vals = {
-            'origin_payment_to_pay_igtf': payment.id, 
+            'origin_payment_to_pay_igtf': payment.move_id.id, 
             'invoice_line_ids': [(0, 0, igtf_line_vals)]
         }
 
@@ -1105,33 +1087,25 @@ class AccountMove(models.Model):
         return debit_note
 
     def _unreconcile_and_cancel_advance(self, line):
-        """
-        Desconcilia las líneas del asiento y cancela el anticipo asociado si existe.
-        """
         partials = line.matched_debit_ids + line.matched_credit_ids
-        for partial in partials:
-            # Determinamos cuál es el movimiento contraparte de la línea
-            counterpart_move = (
-                partial.credit_move_id.move_id 
-                if partial.debit_move_id == line 
-                else partial.debit_move_id.move_id
-            )
-            
-            # Desconciliamos las líneas
-            line.remove_move_reconcile()
-            
-            # Si proviene de un anticipo registrado
-            if counterpart_move.origin_payment_advanced_payment_id:
-                advance_payment = counterpart_move.origin_payment_advanced_payment_id
-                counterpart_move.button_draft()
-                counterpart_move.write({'origin_payment_advanced_payment_id': False})
-                counterpart_move.with_context(
-                    move_action_cancel_advance_payment=True
-                ).button_cancel()
-                advance_payment.write({'advanced_move_ids': [(3, counterpart_move.id)]})
-            
-            return True
-        return False
+        if not partials:
+            return False
+        partial = partials[0]
+        counterpart_move = (
+            partial.credit_move_id.move_id 
+            if partial.debit_move_id == line 
+            else partial.debit_move_id.move_id
+        )
+        line.remove_move_reconcile()
+        if counterpart_move.origin_payment_advanced_payment_id:
+            advance_payment = counterpart_move.origin_payment_advanced_payment_id
+            counterpart_move.button_draft()
+            counterpart_move.write({'origin_payment_advanced_payment_id': False})
+            counterpart_move.with_context(
+                move_action_cancel_advance_payment=True
+            ).button_cancel()
+            advance_payment.write({'advanced_move_ids': [(3, counterpart_move.id)]})
+        return True
 
     def create_note_credit_igtf(self, partial_id):
         """
@@ -1145,7 +1119,6 @@ class AccountMove(models.Model):
         invoice_move = None
         payment_move = None
 
-        # 1. Identificar la Factura Origen y el Pago asociado
         if credit_move.move_type == 'out_invoice':
             invoice_move = credit_move
             payment_move = debit_move
@@ -1153,49 +1126,54 @@ class AccountMove(models.Model):
             invoice_move = debit_move
             payment_move = credit_move
 
-        # Validaciones de entrada
-        if not (invoice_move and invoice_move.debit_note_ids and invoice_move.check_payment_term_conditions()):
+        if not (invoice_move and invoice_move.debit_note_ids):
+            _logger.error(
+                "IGTF: create_note_credit_igtf — no debit_note_ids on invoice %s (id=%s)",
+                invoice_move.name if invoice_move else 'None', invoice_move.id if invoice_move else 'None')
             return
 
-        target_debit_note = None
+        target_debit_note = invoice_move.debit_note_ids.filtered(
+            lambda dn: (
+                dn.origin_payment_to_pay_igtf
+                and dn.state == 'posted'
+                and dn.payment_state != 'reversed'
+                and (dn.origin_payment_to_pay_igtf.id == payment_move.id
+                     or dn.origin_payment_to_pay_igtf.state == 'cancel')
+            )
+        )[:1]
 
-        # 2. Iterar sobre las notas de débito buscando la coincidencia con el IGTF
-        for debit_note in invoice_move.debit_note_ids:
-            igtf_payment = debit_note.origin_payment_to_pay_igtf
-            
-            # Validar que la nota de débito de IGTF esté activa y publicada
-            if not (igtf_payment and debit_note.state == 'posted' and debit_note.payment_state != 'reversed'):
-                continue
+        if not target_debit_note:
+            _logger.error(
+                "IGTF: create_note_credit_igtf — no matching debit note for payment_move=%s (id=%s), invoice=%s (id=%s)",
+                payment_move.name if payment_move else 'None', payment_move.id if payment_move else 'None',
+                invoice_move.name, invoice_move.id)
+            return
 
-            # Condición unificada: El pago coincide O el pago origen fue cancelado
-            if payment_move.id == igtf_payment.id or igtf_payment.state == 'cancel':
-                reconciled_lines = debit_note.line_ids.filtered(
-                    lambda l: l.account_type in ('asset_receivable', 'liability_payable')
-                )
+        reconciled_line = target_debit_note.line_ids.filtered(
+            lambda l: l.account_type in ('asset_receivable', 'liability_payable')
+        )[:1]
+        if reconciled_line:
+            self._unreconcile_and_cancel_advance(reconciled_line)
 
-                # Desconciliar las líneas asociadas
-                for line in reconciled_lines:
-                    if self._unreconcile_and_cancel_advance(line):
-                        break
+        target_debit_note.origin_payment_to_pay_igtf = False
 
-                target_debit_note = debit_note
-                break  # Encontrada la nota correspondida, salimos del bucle principal
+        move_reversal = self.env['account.move.reversal'].with_context(
+            active_model="account.move",
+            active_ids=target_debit_note.ids
+        ).create({
+            'date': fields.Date.context_today(self),
+            'journal_id': target_debit_note.journal_id.id,
+        })
 
-        # 3. Generar y publicar la Nota de Crédito sobre la Nota de Débito
-        if target_debit_note and target_debit_note.state == 'posted':
-            target_debit_note.origin_payment_to_pay_igtf = False
-
-            move_reversal = self.env['account.move.reversal'].with_context(
-                active_model="account.move",
-                active_ids=target_debit_note.ids
-            ).create({
-                'date': fields.Date.context_today(self),
-                'journal_id': target_debit_note.journal_id.id,
-            })
-
+        try:
             reversal_action = move_reversal.refund_moves()
-
             reversal_move = self.env['account.move'].browse(reversal_action['res_id'])
-            # Actualizado para Odoo 19: origin_payment_id en lugar de payment_id
             reversal_move.origin_payment_id = False
             reversal_move._post(soft=False)
+            _logger.info(
+                "IGTF: credit note %s (id=%s) created and posted for debit note %s (id=%s)",
+                reversal_move.name, reversal_move.id, target_debit_note.name, target_debit_note.id)
+        except Exception as e:
+            _logger.error(
+                "IGTF: failed to create/post credit note for debit note %s (id=%s): %s",
+                target_debit_note.name, target_debit_note.id, e)

--- a/l10n_ve_igtf/models/account_move.py
+++ b/l10n_ve_igtf/models/account_move.py
@@ -41,6 +41,30 @@ class AccountMove(models.Model):
         compute="_compute_payments_widget_to_reconcile_info_advance_payment",
     )
     origin_payment_advanced_payment_id = fields.Many2one("account.payment",copy=False)
+
+    origin_payment_to_pay_igtf = fields.Many2one('account.move', string="Origin Payment to Pay IGTF",copy=False)
+
+    has_pending_igtf_debit_note = fields.Boolean(
+        compute='_compute_has_pending_igtf_debit_note',
+        store=False # No se guarda en BD para que se calcule en tiempo real al abrir el form
+    )
+
+    @api.depends('debit_note_ids', 'debit_note_ids.state', 'debit_note_ids.payment_state', 'amount_residual')
+    def _compute_has_pending_igtf_debit_note(self):
+        for move in self:
+            move.has_pending_igtf_debit_note = False
+            
+            # Verificamos si la factura tiene notas de débito en su relación 'debit_note_ids'
+            if move.debit_note_ids:
+                # Filtramos las notas de débito asociadas que estén publicadas y no pagadas
+                pending_igtf_notes = move.debit_note_ids.filtered(
+                    lambda dn: dn.state == 'posted' and 
+                               dn.payment_state not in ('paid', 'reversed') and
+                               any(line.product_id.name == 'Igtf Percibido' for line in dn.invoice_line_ids)
+                )
+                
+                if pending_igtf_notes:
+                    move.has_pending_igtf_debit_note = True
  
 
     @api.depends('invoice_outstanding_credits_debits_widget', 'invoice_outstanding_credits_debits_widget_advance_payment')
@@ -421,21 +445,21 @@ class AccountMove(models.Model):
             igtf_amount = abs(payment.calculate_igtf_for_payment(self, applied_payment_curr,  payment.currency_id ,conversion_date))
 
         #raise UserError(igtf_amount)
-        if is_igtf_journal:
-            igtf_in_invoice_curr = payment.currency_id._convert(igtf_amount, self.currency_id, self.company_id, conversion_date)
-            if (base_amount_applied + igtf_in_invoice_curr) < advance_amount: ## include igtf in base
-                base_amount_applied = self.currency_id.round(base_amount_applied + igtf_in_invoice_curr)
-                if advance_amount > 0:
-                    applied_payment_curr = payment.currency_id.round(
-                        advance_amount_payment_curr * (base_amount_applied / advance_amount))
+        #if is_igtf_journal:
+        #igtf_in_invoice_curr = payment.currency_id._convert(igtf_amount, self.currency_id, self.company_id, conversion_date)
+        #if (base_amount_applied + igtf_in_invoice_curr) < advance_amount: ## include igtf in base
+        #    base_amount_applied = self.currency_id.round(base_amount_applied + igtf_in_invoice_curr)
+        #    if advance_amount > 0:
+        #        applied_payment_curr = payment.currency_id.round(
+        #            advance_amount_payment_curr * (base_amount_applied / advance_amount))
                 
 
         # --- Forzar balance cuando el cruce cubre exactamente el residual ---
         factura_line = receivable_payable_line
-        if is_igtf_journal:
-            total_in_invoice_curr = base_amount_applied + igtf_in_invoice_curr
-        else:
-            total_in_invoice_curr = base_amount_applied
+        #if is_igtf_journal:
+        #    total_in_invoice_curr = base_amount_applied + igtf_in_invoice_curr
+        #else:
+        total_in_invoice_curr = base_amount_applied
 
         force_balance = None
         if (abs(total_in_invoice_curr - advance_amount_residual) <= self.currency_id.rounding
@@ -451,9 +475,10 @@ class AccountMove(models.Model):
         
         if is_igtf_journal and igtf_amount > 0.0:
 
-            line_vals = self.prepare_igtf_payment_vals(
-                line_vals, payment, igtf_amount, igtf_account, conversion_date, common_vals
-            )
+            #line_vals = self.prepare_igtf_payment_vals(
+            #    line_vals, payment, igtf_amount, igtf_account, conversion_date, common_vals
+            #)
+            self.prepare_igtf_payment_debit_note(self, igtf_amount, self, payment)
                
         # --- Entry Creation ---
         advance_journal = self.env.company.advance_payment_igtf_journal_id
@@ -895,7 +920,8 @@ class AccountMove(models.Model):
             return 
         
 
-    
+        self.create_note_credit_igtf(partial_id)
+
         try:
             payment_move.button_draft()
             
@@ -999,3 +1025,177 @@ class AccountMove(models.Model):
         self.line_ids.analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
         self.mapped('line_ids').remove_move_reconcile()
         return super().button_draft()
+
+    def prepare_igtf_payment_debit_note(self, igtf_amount, invoice, payment):
+        """
+        Crea una nota de débito por el monto de IGTF utilizando el asistente account.debit.note.Expand commentComment on lines R1008 to R1010
+        Se asegura de que solo se añade la línea de IGTF y se postea.
+        """
+        self.ensure_one()
+
+        is_customer = invoice.move_type in ["out_invoice", "in_refund"]
+        debit_journal = False
+        if is_customer:
+        
+            debit_journal= self.env['account.journal'].search([('is_debit', '=', True),('type','=','sale')], limit=1)
+        else:
+            debit_journal= self.env['account.journal'].search([('is_debit', '=', True),('type','=','purchase')], limit=1)
+
+        product = invoice.company_id.igtf_product_id
+
+        if not product:
+            raise UserError(_('No se encontró un producto con Igtf Percivido.'))
+
+        account = product.property_account_income_id
+        if not account:
+            raise UserError(_('No se encontró cuenta de ingreso para el producto IGTF.'))
+        
+        
+        if is_customer:
+            partner_account = invoice.partner_id.property_account_receivable_id
+            if not partner_account:
+                raise UserError(_('El cliente no tiene una cuenta por cobrar configurada.'))
+        
+        else:
+
+            partner_account = invoice.partner_id.property_account_payable_id
+            if not partner_account:
+                raise UserError(_('El cliente no tiene una cuenta por pagar configurada.'))
+            
+
+        debit_note_wizard_vals = {
+            'date': fields.Date.context_today(self),
+            'reason': 'IGTF Percibido por concepto de Pago en Divisas',
+            'journal_id': debit_journal.id,
+            'move_ids': [(4, invoice.id)],
+        }
+        
+        move_debit_note_wiz = self.env['account.debit.note'].with_context(active_model = 'account.move',active_ids = invoice.ids).create(debit_note_wizard_vals)
+        
+        res = move_debit_note_wiz.create_debit() 
+        
+        debit_note_id = res.get('res_id')
+        if not debit_note_id:
+            raise UserError(_('El asistente de nota de débito no devolvió un ID válido.'))
+            
+        debit_note = self.env['account.move'].browse(debit_note_id)
+        
+        igtf_line_vals = {
+            'product_id': product.id,
+            'quantity': 1.0,
+            'price_unit': igtf_amount,
+            'date_maturity':fields.Date.today(self),
+        }
+
+        write_vals = {
+            'origin_payment_to_pay_igtf': payment.id, 
+            'invoice_line_ids': [(0, 0, igtf_line_vals)]
+        }
+
+        if is_customer:
+            # Agrega la clave al diccionario existente
+            write_vals['pricelist_id'] = 1
+        else:
+            # Agrega la clave al diccionario existente
+            write_vals['currency_id'] = invoice.company_id.currency_id.id
+
+
+        debit_note.write(write_vals)
+        
+        return debit_note
+
+    def _unreconcile_and_cancel_advance(self, line):
+        """
+        Desconcilia las líneas del asiento y cancela el anticipo asociado si existe.
+        """
+        partials = line.matched_debit_ids + line.matched_credit_ids
+        for partial in partials:
+            # Determinamos cuál es el movimiento contraparte de la línea
+            counterpart_move = (
+                partial.credit_move_id.move_id 
+                if partial.debit_move_id == line 
+                else partial.debit_move_id.move_id
+            )
+            
+            # Desconciliamos las líneas
+            line.remove_move_reconcile()
+            
+            # Si proviene de un anticipo registrado
+            if counterpart_move.origin_payment_advanced_payment_id:
+                advance_payment = counterpart_move.origin_payment_advanced_payment_id
+                counterpart_move.button_draft()
+                counterpart_move.write({'origin_payment_advanced_payment_id': False})
+                counterpart_move.with_context(
+                    move_action_cancel_advance_payment=True
+                ).button_cancel()
+                advance_payment.write({'advanced_move_ids': [(3, counterpart_move.id)]})
+            
+            return True
+        return False
+
+    def create_note_credit_igtf(self, partial_id):
+        """
+        Crea y publica la Nota de Crédito correspondiente para reversar el IGTF 
+        cuando el pago asociado se desconcilia o cancela.
+        """
+        partial_reconcile = self.env["account.partial.reconcile"].browse(partial_id)
+        credit_move = partial_reconcile.credit_move_id.move_id
+        debit_move = partial_reconcile.debit_move_id.move_id
+
+        invoice_move = None
+        payment_move = None
+
+        # 1. Identificar la Factura Origen y el Pago asociado
+        if credit_move.move_type == 'out_invoice':
+            invoice_move = credit_move
+            payment_move = debit_move
+        elif debit_move.move_type == 'out_invoice':
+            invoice_move = debit_move
+            payment_move = credit_move
+
+        # Validaciones de entrada
+        if not (invoice_move and invoice_move.debit_note_ids and invoice_move.check_payment_term_conditions()):
+            return
+
+        target_debit_note = None
+
+        # 2. Iterar sobre las notas de débito buscando la coincidencia con el IGTF
+        for debit_note in invoice_move.debit_note_ids:
+            igtf_payment = debit_note.origin_payment_to_pay_igtf
+            
+            # Validar que la nota de débito de IGTF esté activa y publicada
+            if not (igtf_payment and debit_note.state == 'posted' and debit_note.payment_state != 'reversed'):
+                continue
+
+            # Condición unificada: El pago coincide O el pago origen fue cancelado
+            if payment_move.id == igtf_payment.id or igtf_payment.state == 'cancel':
+                reconciled_lines = debit_note.line_ids.filtered(
+                    lambda l: l.account_type in ('asset_receivable', 'liability_payable')
+                )
+
+                # Desconciliar las líneas asociadas
+                for line in reconciled_lines:
+                    if self._unreconcile_and_cancel_advance(line):
+                        break
+
+                target_debit_note = debit_note
+                break  # Encontrada la nota correspondida, salimos del bucle principal
+
+        # 3. Generar y publicar la Nota de Crédito sobre la Nota de Débito
+        if target_debit_note and target_debit_note.state == 'posted':
+            target_debit_note.origin_payment_to_pay_igtf = False
+
+            move_reversal = self.env['account.move.reversal'].with_context(
+                active_model="account.move",
+                active_ids=target_debit_note.ids
+            ).create({
+                'date': fields.Date.context_today(self),
+                'journal_id': target_debit_note.journal_id.id,
+            })
+
+            reversal_action = move_reversal.refund_moves()
+
+            reversal_move = self.env['account.move'].browse(reversal_action['res_id'])
+            # Actualizado para Odoo 19: origin_payment_id en lugar de payment_id
+            reversal_move.origin_payment_id = False
+            reversal_move._post(soft=False)

--- a/l10n_ve_igtf/models/account_payment.py
+++ b/l10n_ve_igtf/models/account_payment.py
@@ -166,8 +166,8 @@ class AccountPaymentAndIgtf(models.Model):
                     is_international = any(
                         m.journal_id.is_purchase_international for m in move_ids
                     )
-                    if not is_international:
-                        rec._create_igtf_moves_in_payments(vals, write_off_line_vals)
+                    #if not is_international:
+                        #rec._create_igtf_moves_in_payments(vals, write_off_line_vals)
                 if rec.igtf_amount <= 0.0: #Nativo
                     total_base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual_signed')))
                     if write_off_line_vals:

--- a/l10n_ve_igtf/models/account_tax.py
+++ b/l10n_ve_igtf/models/account_tax.py
@@ -1,6 +1,7 @@
 from odoo import models, api, _
 from odoo.tools.misc import formatLang
 from odoo.tools.float_utils import float_round, float_is_zero
+from odoo.exceptions import UserError
 
 
 import logging
@@ -38,13 +39,7 @@ class AccountTax(models.Model):
         res = super()._get_tax_totals_summary(base_lines, currency, company, cash_rounding)
 
         invoice = self.env["account.move"]
-        order = False
-        apply_igtf = False
-        type_model = ""
-        base_igtf = 0
-        foreign_base_igtf = 0
-        is_igtf_suggested = False
-      
+
         for base_line in base_lines:
             type_model = base_line["record"]._name
             if base_line["record"]._name == "account.move.line":
@@ -52,92 +47,157 @@ class AccountTax(models.Model):
             if base_line["record"]._name == "sale.order.line":
                 order = base_line["record"].order_id
 
-        foreign_currency = self.env.company.foreign_currency_id
-        rate = 0
+        if invoice.move_type in ('out_refund', 'in_refund'):
+            res["igtf"] = {
+                "apply_igtf": False,
+                "igtf_show": False,
+                "name": "",
+                "igtf_base_amount": 0,
+                "igtf_amount": 0,
+                "foreign_igtf_base_amount": 0,
+                "foreign_igtf_amount": 0,
+                "formatted_igtf_base_amount": "",
+                "formatted_igtf_amount": "",
+                "formatted_foreign_igtf_base_amount": "",
+                "formatted_foreign_igtf_amount": "",
+            }
+            return res
 
-        if type_model == "account.move.line":
-            rate = invoice.foreign_inverse_rate
-        if type_model == "sale.order.line":
-            rate = order.foreign_inverse_rate
 
+        apply_igtf = False
+        igtf_show = False
+        base_igtf = 0
+        foreign_base_igtf = 0
+
+        foreign_currency = invoice.company_id.currency_id
+        
         float_igtf_percentage = self.env.company.igtf_percentage
+        show_igtf_suggested_account_move =  self.env.company.show_igtf_suggested_account_move
 
         igtf_percentage = (float_igtf_percentage or 0) / 100
-
-        if (
-            type_model == "account.move.line"
-            and self.env.company.show_igtf_suggested_account_move
-            and invoice.payment_state == "not_paid"
-        ):
-            is_igtf_suggested = True
-            base_igtf = res.get("amount_total", 0)
-            foreign_base_igtf = res.get("foreign_amount_total", 0)
-        if (
-            type_model == "sale.order.line"
-            and self.env.company.show_igtf_suggested_sale_order
-        ):
-            is_igtf_suggested = True
-            base_igtf = res.get("amount_total", 0)
-            foreign_base_igtf = res.get("foreign_amount_total", 0)
-
-        if invoice.bi_igtf:
+        
+        if invoice.bi_igtf > 0.0:
+            apply_igtf = True
             if invoice.currency_id.id != invoice.company_id.currency_id.id:
-                base_igtf = invoice.foreign_bi_igtf
-                foreign_base_igtf = invoice.bi_igtf
+                base_igtf = abs(invoice.foreign_bi_igtf)
+                foreign_base_igtf = abs(invoice.bi_igtf)
             else:
-                base_igtf = invoice.bi_igtf
-                foreign_base_igtf = invoice.foreign_bi_igtf
+                base_igtf = abs(invoice.bi_igtf)
+                foreign_base_igtf = abs(invoice.foreign_bi_igtf)
+        else:
+            if invoice.move_type == "out_invoice" and invoice.payment_state == "not_paid":
+                igtf_show = True
+
+            if invoice.currency_id.id != invoice.company_id.currency_id.id:
+                base_igtf = invoice.amount_total
+                foreign_base_igtf = abs(invoice.amount_total_signed)
+            else:
+                base_igtf = abs(invoice.amount_total_signed)
+                foreign_base_igtf = invoice.amount_total
+                if invoice.move_type == "out_invoice":
+                    igtf_show = True
+
+        base_igtf_free = 0.0
+        foreign_base_igtf_free = 0.0
+        if invoice.move_type == "out_invoice":
+            if invoice.currency_id.id != invoice.company_id.currency_id.id:
+                base_igtf_free = invoice.amount_total
+                foreign_base_igtf_free = abs(invoice.amount_total_signed)
+            else:
+                base_igtf_free = abs(invoice.amount_total_signed)
+                foreign_base_igtf_free = invoice.amount_total
+
 
         igtf_base_amount = base_igtf 
         igtf_foreign_base_amount = foreign_base_igtf 
 
-        if (
-            igtf_base_amount > 0
-        ):
-            
-            apply_igtf = True
+        igtf_amount = igtf_base_amount * igtf_percentage 
+        foreign_igtf_base_amount = igtf_foreign_base_amount * igtf_percentage 
 
-        foreign_igtf_base_amount = igtf_foreign_base_amount 
 
-        igtf_amount = igtf_base_amount * igtf_percentage
+        igtf_base_amount_free = base_igtf_free 
+        igtf_foreign_base_amount_free = foreign_base_igtf_free 
 
-        foreign_igtf_amount = igtf_foreign_base_amount * igtf_percentage
-            
+        igtf_amount_free = igtf_base_amount_free * igtf_percentage 
+        foreign_igtf_base_amount_free = igtf_foreign_base_amount_free * igtf_percentage 
+        
+
+        if invoice.move_type in ('out_refund', 'in_refund'):
+            apply_igtf = False
+            igtf_show = False
+
+        if invoice.bi_igtf <= 0.0 and invoice.payment_state not in ('not_paid',):
+            igtf_show = False
 
         res["igtf"] = {}
         res["igtf"]["apply_igtf"] = apply_igtf
+        res["igtf"]["igtf_show"] = igtf_show
         res["igtf"]["name"] = f"{float_igtf_percentage} %"
 
-        res["igtf"]["igtf_base_amount"] = igtf_base_amount
-        res["igtf"]["formatted_igtf_base_amount"] = formatLang(
+        res["igtf"]["igtf_base_amount"] = igtf_base_amount 
+        res["igtf"]["formatted_igtf_base_amount"] = formatLang( 
             self.env, igtf_base_amount, currency_obj=currency
         )
-        res["igtf"]["foreign_igtf_base_amount"] = foreign_igtf_base_amount
-        res["igtf"]["formatted_foreign_igtf_base_amount"] = formatLang(
+        res["igtf"]["foreign_igtf_base_amount"] = igtf_foreign_base_amount 
+        res["igtf"]["formatted_foreign_igtf_base_amount"] = formatLang( 
+            self.env, igtf_foreign_base_amount, currency_obj=foreign_currency
+        )
+
+        res["igtf"]["igtf_amount"] = igtf_amount 
+        res["igtf"]["formatted_igtf_amount"] = formatLang( 
+             self.env, igtf_amount, currency_obj=currency
+         )
+
+        res["igtf"]["foreign_igtf_amount"] = foreign_igtf_base_amount 
+        res["igtf"]["formatted_foreign_igtf_amount"] = formatLang( 
             self.env, foreign_igtf_base_amount, currency_obj=foreign_currency
         )
 
-        res["igtf"]["igtf_amount"] = igtf_amount
-        res["igtf"]["formatted_igtf_amount"] = formatLang(
-            self.env, igtf_amount, currency_obj=currency
-        )
-
-        res["igtf"]["foreign_igtf_amount"] = foreign_igtf_amount
-        res["igtf"]["formatted_foreign_igtf_amount"] = formatLang(
-            self.env, foreign_igtf_amount, currency_obj=foreign_currency
-        )
-        
-
-        res["amount_total_igtf"] = res["total_amount_currency"] + igtf_amount
-        
+        res["amount_total_igtf"] = invoice.amount_total + igtf_amount
         res["formatted_amount_total_igtf"] = formatLang(
             self.env, res["amount_total_igtf"], currency_obj=currency
         )
-        res["foreign_amount_total_igtf"] = res["total_amount_currency"] + foreign_igtf_amount
-        
+
+        res["foreign_amount_total_igtf"] = invoice.amount_total_signed + foreign_igtf_base_amount
         res["formatted_foreign_amount_total_igtf"] = formatLang(
             self.env, res["foreign_amount_total_igtf"], currency_obj=foreign_currency
         )
-        res["igtf"]["is_igtf_suggested"] = is_igtf_suggested
+
+        # Free-Form Values
+        if invoice.move_type == "out_invoice": 
+            res["igtf_free_form"] = {}
+            res["igtf_free_form"]["show_igtf_suggested_account_move"] = show_igtf_suggested_account_move
+            res["igtf_free_form"]["name"] = f"{float_igtf_percentage} %"
+
+            res["igtf_free_form"]["igtf_base_amount_free"] = igtf_base_amount_free 
+            res["igtf_free_form"]["formatted_igtf_base_amount_free"] = formatLang( 
+                self.env, igtf_base_amount_free, currency_obj=currency
+            )
+            res["igtf_free_form"]["foreign_igtf_base_amount_free"] = igtf_foreign_base_amount_free 
+            res["igtf_free_form"]["formatted_foreign_igtf_base_amount_free"] = formatLang( 
+                self.env, igtf_foreign_base_amount_free, currency_obj=foreign_currency
+            )
+
+            res["igtf_free_form"]["igtf_amount_free"] = igtf_amount_free 
+            res["igtf_free_form"]["formatted_igtf_amount_free"] = formatLang( 
+                self.env, igtf_amount_free, currency_obj=currency
+            )
+
+            res["igtf_free_form"]["foreign_igtf_amount_free"] = foreign_igtf_base_amount_free 
+            res["igtf_free_form"]["formatted_foreign_igtf_amount_free"] = formatLang( 
+                self.env, foreign_igtf_base_amount_free, currency_obj=foreign_currency
+            )
+
+            res["igtf_free_form"]["amount_total_igtf_free"] = invoice.amount_total + igtf_amount_free
+            res["igtf_free_form"]["formatted_amount_total_igtf_free"] = formatLang(
+                self.env, res["igtf_free_form"]["amount_total_igtf_free"], currency_obj=currency
+            )
+
+            res["igtf_free_form"]["foreign_amount_total_igtf_free"] = invoice.amount_total_signed + foreign_igtf_base_amount_free
+            res["igtf_free_form"]["formatted_foreign_amount_total_igtf_free"] = formatLang(
+                self.env, res["igtf_free_form"]["foreign_amount_total_igtf_free"], currency_obj=foreign_currency
+            )
+
+        
 
         return res

--- a/l10n_ve_igtf/models/res_company.py
+++ b/l10n_ve_igtf/models/res_company.py
@@ -1,6 +1,6 @@
 from odoo import fields, models, api, _
 from odoo.exceptions import UserError
-
+import json
 class ResCompany(models.Model):
     _inherit = "res.company"
 
@@ -53,4 +53,48 @@ class ResCompany(models.Model):
             if rec.advance_supplier_account_id and not rec.advance_supplier_account_id.is_advance_account:
                 raise UserError(_("The account for Advance Supplier Account must be type asset_current, is_advance_account and reconciliable"))
 
-    
+    # Campo Char computado que almacena la cadena JSON del dominio
+    igtf_product_domain = fields.Char(
+        compute="_compute_igtf_product_domain",
+        readonly=True
+    )
+
+    igtf_product_id = fields.Many2one(
+        "product.product",
+        string="Producto IGTF"
+    )
+
+    @api.depends(
+        'customer_account_igtf_id',
+        'supplier_account_igtf_id',
+        'exent_aliquot_sale',
+        'exent_aliquot_purchase'
+    )
+    def _compute_igtf_product_domain(self):
+        """
+        Genera el dominio dinámico en formato JSON.
+        Requiere obligatoriamente los 4 campos configurados; de lo contrario, 
+        no permite seleccionar ningún producto.
+        """
+        for company in self:
+            # Requisito estricto: los 4 campos deben estar presentes
+            if not (
+                company.customer_account_igtf_id and 
+                company.supplier_account_igtf_id and 
+                company.exent_aliquot_sale and 
+                company.exent_aliquot_purchase
+            ):
+                # Si falta alguno, bloqueamos la selección retornando un ID falso
+                company.igtf_product_domain = json.dumps([('id', '=', False)])
+                continue
+
+            # Si los 4 campos existen, aplicamos todos los filtros obligatorios
+            domain = [
+                ('type', '=', 'service'),
+                ('taxes_id', 'in', [company.exent_aliquot_sale.id]),
+                ('supplier_taxes_id', 'in', [company.exent_aliquot_purchase.id]),
+                ('property_account_income_id', '=', [company.customer_account_igtf_id.id]),
+                ('property_account_expense_id', '=', [company.supplier_account_igtf_id.id]),
+            ]
+
+            company.igtf_product_domain = json.dumps(domain)

--- a/l10n_ve_igtf/models/res_config_settings.py
+++ b/l10n_ve_igtf/models/res_config_settings.py
@@ -52,3 +52,12 @@ class ResConfigSettings(models.TransientModel):
     not_show_igtf_purchase_order = fields.Boolean(
         related="company_id.not_show_igtf_purchase_order", readonly=False
     )
+
+    igtf_product_domain = fields.Char(
+        related="company_id.igtf_product_domain"
+    )
+
+    igtf_product_id = fields.Many2one(
+        related="company_id.igtf_product_id",
+        readonly=False
+    )

--- a/l10n_ve_igtf/static/src/components/tax_totals.xml
+++ b/l10n_ve_igtf/static/src/components/tax_totals.xml
@@ -8,7 +8,7 @@
         owl="1">
         
         <xpath expr="//t[@t-foreach='totals.subtotals']" position="after">
-            <t t-if="totals.igtf &amp;&amp; totals.igtf.apply_igtf &amp;&amp; !totals.igtf.is_igtf_suggested">
+            <t t-if="totals.igtf.apply_igtf">
                 <tr>
                     <td class="o_td_label">
                         <label class="o_form_label o_tax_total_label">BI IGTF</label>
@@ -35,28 +35,13 @@
         </xpath>
 
         <xpath expr="//tbody" position="inside">
-            <t t-if="totals.igtf.apply_igtf &amp;&amp; !!totals.igtf.is_igtf_suggested">
-                <tr>
-                    <td class="o_td_label">
-                        <label class="o_form_label o_tax_total_label">
-                            <t t-if="totals.igtf.is_igtf_suggested">
-                                (Suggested)
-                            </t>
-                                BI IGTF</label>
-                    </td>
-                    <td>
-                        <span class="o_tax_group_amount_value">
-                            <t t-out="totals.igtf.formatted_igtf_base_amount"/>
-                        </span>
-                    </td>
-                </tr>
+            <t t-if="totals.igtf.igtf_show">
+                
                 <tr>
                     <td class="o_td_label">
                         <label class="o_form_label o_tax_total_label" >
-                            <t t-if="totals.igtf.is_igtf_suggested">
-                                (Suggested)
-                            </t>
-                            IGTF <t t-esc="totals.igtf.name"/>
+                            
+                            IGTF (sugerido)
                         </label>
                     </td>
                     <td>
@@ -66,7 +51,19 @@
                     </td>
                 </tr>
             </t>
-            <tr>
+            <tr t-if="totals.igtf.igtf_show">
+                <td class="o_td_label">
+                    <label class="o_form_label o_tax_total_label">Total con IGTF(sugerido)</label>
+                </td>
+                <td>
+                    <span
+                        name="amount_total_igtf"
+                        class="o_tax_group_amount_value"
+                        t-out="totals.formatted_amount_total_igtf"
+                    />
+                </td>
+            </tr>
+            <tr t-if="totals.igtf.apply_igtf ">
                 <td class="o_td_label">
                     <label class="o_form_label o_tax_total_label">Total with IGTF</label>
                 </td>
@@ -75,6 +72,85 @@
                         name="amount_total_igtf"
                         class="o_tax_group_amount_value"
                         t-out="totals.formatted_amount_total_igtf"
+                    />
+                </td>
+            </tr>
+        </xpath>
+    </t>
+
+
+
+    <t 
+        t-name="TaxVesTotalsField" 
+        t-inherit="l10n_ve_accountant.TaxVesTotalsField" 
+        t-inherit-mode="extension" 
+        owl="1">
+        
+        <xpath expr="//t[@t-foreach='totals.subtotals']" position="after">
+            <t t-if="totals.igtf.apply_igtf">
+                <tr>
+                    <td class="o_td_label">
+                        <label class="o_form_label o_tax_total_label">BI IGTF</label>
+                    </td>
+                    <td class="o_list_monetary">
+                        <span class="o_tax_group_amount_value">
+                            <t t-out="totals.igtf.formatted_foreign_igtf_base_amount"/>
+                        </span>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="o_td_label">
+                        <label class="o_form_label o_tax_total_label">
+                            IGTF <t t-esc="totals.igtf.name"/>
+                        </label>
+                    </td>
+                    <td class="o_list_monetary">
+                        <span class="o_tax_group_amount_value">
+                            <t t-out="totals.igtf.formatted_foreign_igtf_amount"/>
+                        </span>
+                    </td>
+                </tr>
+            </t>
+        </xpath>
+
+        <xpath expr="//tbody" position="inside">
+            <t t-if="totals.igtf.igtf_show">
+                
+                <tr>
+                    <td class="o_td_label">
+                        <label class="o_form_label o_tax_total_label" >
+                            
+                            IGTF (sugerido)
+                        </label>
+                    </td>
+                    <td>
+                        <span class="o_tax_group_amount_value">
+                            <t t-out="totals.igtf.formatted_foreign_igtf_base_amount"/>
+                        </span>
+                    </td>
+                </tr>
+            </t>
+            <tr t-if="totals.igtf.igtf_show">
+                <td class="o_td_label">
+                    <label class="o_form_label o_tax_total_label">Total con IGTF(sugerido)</label>
+                </td>
+                <td>
+                    <span
+                        name="amount_total_igtf"
+                        class="o_tax_group_amount_value"
+                        t-out="totals.formatted_foreign_amount_total_igtf"
+                    />
+                </td>
+            </tr>
+            <tr t-if="totals.igtf.apply_igtf ">
+                <td class="o_td_label">
+                    <label class="o_form_label o_tax_total_label">Total with IGTF</label>
+                </td>
+                <td>
+                    <span
+                        name="amount_total_igtf"
+                        class="o_tax_group_amount_value"
+                        t-out="totals.formatted_foreign_amount_total_igtf"
                     />
                 </td>
             </tr>

--- a/l10n_ve_igtf/views/account_move.xml
+++ b/l10n_ve_igtf/views/account_move.xml
@@ -15,6 +15,15 @@
                 <field name="origin_payment_advanced_payment_id" readonly="1" />
             </xpath>
 
+            <xpath expr="//div[hasclass('alert', 'alert-info')][3]" position="after">
+                <field name="has_pending_igtf_debit_note" invisible="1"/>
+                <div groups="account.group_account_invoice,account.group_account_readonly"
+                         class="alert alert-info" role="alert"
+                         invisible="not has_pending_igtf_debit_note">
+                        <a class="alert-link" href="#outstanding" role="button">Tienes notas pendientes a pagar de IGTF</a>.
+                    </div>
+            </xpath>
+
 
             <xpath expr="//div[hasclass('alert', 'alert-info')][1]" position="replace">
                 <div groups="account.group_account_invoice,account.group_account_readonly"

--- a/l10n_ve_igtf/views/res_config_settings.xml
+++ b/l10n_ve_igtf/views/res_config_settings.xml
@@ -41,6 +41,13 @@
                         <setting string="Supplier IGTF Account">
                             <field name="supplier_account_igtf_id" />
                         </setting>
+
+                        <setting string="IGTF Product">
+                            <field name="igtf_product_domain" invisible="1"/>
+
+                            <field name="igtf_product_id" domain="igtf_product_domain" invisible="not customer_account_igtf_id or not supplier_account_igtf_id"/>
+                        </setting>
+
                     
                 </block>
 

--- a/l10n_ve_igtf/wizard/account_payment_register.py
+++ b/l10n_ve_igtf/wizard/account_payment_register.py
@@ -470,8 +470,7 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
                     lambda l: l.account_type in ('asset_receivable', 'liability_payable') and not l.reconciled
                 )
 
-                if debit_note_reconcilable_lines and reconcilable_lines:
-
+                if debit_note_reconcilable_lines and reconcilable_lines and abs(reconcilable_lines.amount_residual) > 0.01:
                     debit_note.js_assign_outstanding_line(reconcilable_lines.id)
 
                    

--- a/l10n_ve_igtf/wizard/account_payment_register.py
+++ b/l10n_ve_igtf/wizard/account_payment_register.py
@@ -433,51 +433,48 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
         
         payments = super(AccountPaymentRegisterIgtf, self.with_context(skip_account_move_reversal=True))._create_payments()
         
-        ignore_gtf = self.env.context.get("ignore_igtf", False)
+        move_id = (
+            self.env.context.get("active_id", False)
+        )
 
-        
-        is_provider =  self.partner_type == 'supplier'
+        invoice = self.env['account.move'].browse(move_id)
 
-        due_currency_id = self.source_currency_id
-        
-        due_amount = due_currency_id._convert(self.source_amount_currency,self.currency_id,company=self.company_id,date=self.payment_date)
-       
         for payment in payments:
-            
-            if payment.igtf_amount:
+            company_currency = payment.company_id.currency_id
+            payment_currency = payment.currency_id
+            reconcilable_lines = payment.move_id.line_ids.filtered(
+                lambda l: l.account_type in ('asset_receivable', 'liability_payable')
+            )
+            payment_total_base = payment.move_id.amount_total_signed
+            payment_residual_base = reconcilable_lines.amount_residual
 
-                amount = payment.amount
-            
-                if not ignore_gtf:
-                    
-                    due_amount += payment.igtf_amount 
 
 
-                self.group_payment = False
+            if payment.igtf_amount > 0 and invoice:
                 
-                if (
-                    float_compare(amount, due_amount, precision_rounding=self.currency_id.rounding) == 1
-                    and payment.igtf_amount 
-                    and self.payment_difference_handling != 'reconcile' 
-                    and not self.group_payment
-                ):
-                    difference = amount - due_amount
+                igtf_base = payment.currency_id._convert(
+                    payment.igtf_amount, company_currency, payment.company_id, payment.date,
+                )
+
+                if  abs(payment_residual_base) > 0: #hay residual en el pago
+                    supposted_fact_amount = payment_currency.round((abs(payment_total_base) - abs(igtf_base))) #supuesta base de la factura sin igtf
+                    #detectamos si lo q queda es el equivalente al igtf o es un apgo mayor
                     
-                    move_to_reconcile_with_payment_difference = (
-                        self._create_move_to_reconcile_with_payment_difference(payment,difference,due_currency_id)
-                    )
-                    if move_to_reconcile_with_payment_difference:
-                        move_to_reconcile_with_payment_difference.action_post()
-                    
-                        if is_provider:
-                            self._reconcile_payment_provider_and_move_lines(
-                                payment, move_to_reconcile_with_payment_difference
-                            )
-                        else:
-                            self._reconcile_payment_and_move_lines(
-                                payment, move_to_reconcile_with_payment_difference
-                            )
-                        payment.write({"advanced_move_ids": [(4, move_to_reconcile_with_payment_difference.id)]})
+                    if abs(supposted_fact_amount) - abs(invoice.amount_total_signed) <= 0.1: #comparacion si existe una diferencia de decimales por conversion
+                        igtf_base = abs(payment_residual_base)
+                                                
+                debit_note= invoice.prepare_igtf_payment_debit_note(igtf_base, invoice, payment)
+                debit_note.with_context(move_action_post_alert=True).action_post()
+
+                debit_note_reconcilable_lines = debit_note.line_ids.filtered(
+                    lambda l: l.account_type in ('asset_receivable', 'liability_payable') and not l.reconciled
+                )
+
+                if debit_note_reconcilable_lines and reconcilable_lines:
+
+                    debit_note.js_assign_outstanding_line(reconcilable_lines.id)
+
+                   
         return payments
 
     def _create_move_to_reconcile_with_payment_difference(self, payment, diff,due_currency_id):

--- a/l10n_ve_igtf/wizard/account_payment_register.xml
+++ b/l10n_ve_igtf/wizard/account_payment_register.xml
@@ -32,7 +32,13 @@
                     </group>
                 </xpath>
 
-                
+                <xpath expr="//field[@name='missing_account_partners']" position="after">
+                    <field name="is_igtf" readonly="1" invisible="1" />
+                    <div role="alert" class="alert alert-warning" invisible="not is_igtf">
+                        <span class="fw-bold">Este pago generara una Nota de Debito Automatica por el monto de IGTF percibido en la transaccion</span>
+                    </div>
+                </xpath>
+
 
                 <xpath expr="//label[@for='amount']" position="attributes">
                     <attribute name="invisible"/> 

--- a/l10n_ve_igtf/wizard/account_payment_register.xml
+++ b/l10n_ve_igtf/wizard/account_payment_register.xml
@@ -60,6 +60,10 @@
                     <attribute name="invisible">0</attribute>
                     <attribute name="force_save">1</attribute>
                 </xpath>
+
+                <xpath expr="//button[@name='action_create_payments']" position="attributes">
+                    <attribute name="confirm">¿Está seguro que desea realizar el pago con los montos registrados?</attribute>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
[FIX] l10n_ve_igtf: Cambiar flujo de IGTF actual y Anticipo de IGTF por nota de Credito y Debito

- Se agrega campo de Producto IGTF a usar en las notas de credito

- Se Cambia el flujo de IGTF en lugar de agregar la linea de IGTf en el Pago se crea una nota de debito

- Al intentar desconciar el pago q orgino la nota de la factura se desconcilia totalmente los pagos de la nota y se emite nota de credito para anular ese incremento.

- Se colocan avisos para de que existen notas de debitos por igtf pendientes de pagar en la factura y en el wizard de pago se coloca un aiso de q se emitira una nota de debito por concepto de igtf

References:
- Ticket:  https://binaural.odoo.com/odoo/helpdesk/action-389/14015
- Tarea:
- PR:
- Otros: