### PR TITLE
[FIX] #14131: l10n_ve_sale

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "19.0.1.0.4",
+    "version": "19.0.1.0.5",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -354,6 +354,12 @@ class SaleOrder(models.Model):
         Compute the vat of the partner and add the prefix to it if it exists in the partner record
         """
         for rec in self:
+            vat = ""
+
+            if not rec.partner_id:
+                rec.vat = vat
+                continue
+
             if rec.partner_id.prefix_vat and rec.partner_id.vat:
                 vat = str(rec.partner_id.prefix_vat) + str(rec.partner_id.vat)
             else:

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -348,7 +348,7 @@ class SaleOrder(models.Model):
     def _compute_tax_totals_base(self):
         return super()._compute_tax_totals()
 
-    @api.depends("partner_id")
+    @api.depends("partner_id", "partner_id.vat", "partner_id.prefix_vat")
     def _compute_vat(self):
         """
         Compute the vat of the partner and add the prefix to it if it exists in the partner record
@@ -361,9 +361,9 @@ class SaleOrder(models.Model):
                 continue
 
             if rec.partner_id.prefix_vat and rec.partner_id.vat:
-                vat = str(rec.partner_id.prefix_vat) + str(rec.partner_id.vat)
+                vat = (rec.partner_id.prefix_vat or "") + (rec.partner_id.vat or "")
             else:
-                vat = str(rec.partner_id.vat)
+                vat = rec.partner_id.vat or ""
             rec.vat = vat.upper()
 
     @api.onchange("name")

--- a/l10n_ve_sale/tests/__init__.py
+++ b/l10n_ve_sale/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_pricelist
 from . import test_sale_order_rate
+from . import test_sale_order_vat
 #from . import test_sale_order_invoice_status

--- a/l10n_ve_sale/tests/test_sale_order_vat.py
+++ b/l10n_ve_sale/tests/test_sale_order_vat.py
@@ -1,0 +1,40 @@
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install", "l10n_ve_sale")
+class TestSaleOrderVat(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.partner_no_vat = self.env["res.partner"].create({
+            "name": "Partner Sin VAT",
+        })
+        self.partner_with_vat = self.env["res.partner"].create({
+            "name": "Partner Con VAT",
+            "vat": "123456789",
+            "prefix_vat": False,
+        })
+        self.partner_with_prefix_vat = self.env["res.partner"].create({
+            "name": "Partner Con Prefix VAT",
+            "prefix_vat": "J",
+            "vat": "123456789",
+        })
+
+    def test_vat_empty_when_partner_has_no_vat(self):
+        so = self.env["sale.order"].create({
+            "partner_id": self.partner_no_vat.id,
+        })
+        self.assertEqual(so.vat, "")
+
+    def test_vat_computed_from_partner_without_prefix(self):
+        so = self.env["sale.order"].create({
+            "partner_id": self.partner_with_vat.id,
+        })
+        self.assertEqual(so.vat, "123456789")
+
+    def test_vat_computed_from_partner_with_prefix(self):
+        so = self.env["sale.order"].create({
+            "partner_id": self.partner_with_prefix_vat.id,
+        })
+        self.assertEqual(so.vat, "J123456789")


### PR DESCRIPTION
Problema: Cuando el valor del partner_id esta vacio, el vat sale en "FALSE".

Solucion: Se agrega condicional para cuando el partner_id esta vacio que le setea "" al vat que se asigna al vat de la vista, el problema era que cuando el partner id no estaba asignado, al vat le llegaba false y al momento de hacer el upper resultaba en un "FALSE".

Ticket (link): https://binaural.odoo.com/odoo/my-tickets/14131