### PR TITLE
[FIX] l10n_ve_accountant: ocultar cuenta emisora en recibo pago

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.8", 
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/report/account_report_templates.xml
+++ b/l10n_ve_accountant/report/account_report_templates.xml
@@ -123,11 +123,7 @@
                         <span t-field="o.partner_bank_id"/>
                     </t>
                 </div>
-                <div class="col-6" t-if="o.journal_id.default_account_id">
-                    <strong>Cuenta Emisora: </strong>
-                    <span t-field="o.journal_id.default_account_id"/>
                 </div>
-            </div>
 
             <div class="row">
                 <div class="col-12 my-2">


### PR DESCRIPTION
Elimina el bloque 'Cuenta Emisora' del template QWeb de recibo de pago.

Problema: El PDF del recibo de pago mostraba la cuenta contable interna del diario (default_account_id), exponiendo información sensible de configuración contable al cliente.

Solución: Se elimina el bloque <div> que renderizaba la cuenta emisora en account_report_templates.xml, evitando la exposición de datos internos de contabilidad en el documento entregable.

References:

- Tarea: https://binaural.odoo.com/odoo/action-341/77964