### PR TITLE
FIX: privilege_id invalido en res.groups rompe instalacion en Odoo 19 {res.groups} [l10n_ve_pos]

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "1.1",
+    "version": "1.2",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/data/res_group.xml
+++ b/l10n_ve_pos/data/res_group.xml
@@ -3,8 +3,6 @@
     <data>
         <record model="res.groups" id="group_authorized_discount_pos">
             <field name="name">Authorized discount pos</field>
-            <field name="privilege_id" ref="base.module_category_hidden"/>
-
         </record>
     </data>
 </odoo>

--- a/l10n_ve_pos/security/res_group.xml
+++ b/l10n_ve_pos/security/res_group.xml
@@ -4,12 +4,10 @@
 
     <record id="group_change_qty_on_pos_order" model="res.groups">
         <field name="name">Change quantity on POS order</field>
-        <field name="privilege_id" ref="base.module_category_hidden"/>
     </record>
 
     <record id="group_change_price_on_pos_order" model="res.groups">
         <field name="name">Change price on POS order</field>
-        <field name="privilege_id" ref="base.module_category_hidden"/>
     </record>
 
 </data>


### PR DESCRIPTION
## Por que?

Al instalar o actualizar cualquier modulo que dependa de `l10n_ve_pos` en Odoo 19, la carga de datos falla con:

```
psycopg2.errors.ForeignKeyViolation: insert or update on table "res_groups" violates foreign key constraint "res_groups_privilege_id_fkey"
DETAIL:  Key (privilege_id)=(18) is not present in table "res_groups_privilege".
```

Reportado en produccion en `binaural-dev-2doce-market.odoo.com` al intentar instalar un modulo dependiente de `l10n_ve_pos` (ver traceback completo en el reporte del consultor, referenciando `l10n_ve_pos/data/res_group.xml:4`).

Causa raiz: 3 registros `res.groups` (`group_authorized_discount_pos`, `group_change_qty_on_pos_order`, `group_change_price_on_pos_order`) seteaban `privilege_id` apuntando a `base.module_category_hidden`. Ese xmlid es valido, pero pertenece al modelo `ir.module.category`, no a `res.groups.privilege` (el modelo que Odoo 19 realmente espera en ese campo). Todo indica que viene de una migracion mecanica del viejo campo `category_id` (Many2one a `ir.module.category`, usado en versiones previas para agrupar grupos visualmente) a `privilege_id` (concepto nuevo en 19), donde se renombro el campo pero no se actualizo el valor referenciado.

## Que cambia?

Se quitan las 3 referencias invalidas a `privilege_id`. `privilege_id` es un campo opcional (`required=False`) que solo afecta el agrupamiento visual de grupos en Ajustes > Usuarios y Compañias > Grupos, no la logica de permisos — no hay ningun `res.groups.privilege` equivalente al viejo "Hidden" en el core de Odoo 19 (solo existen `Export` y `Contact` por defecto), asi que no corresponde inventar uno nuevo solo para este fix.

Archivos modificados:
- `l10n_ve_pos/data/res_group.xml`
- `l10n_ve_pos/security/res_group.xml`

## Como se probo?

Reproducido y corregido localmente contra un Odoo 19 real (contenedor docker, instancia con el mismo error). Instalacion de modulos dependientes de `l10n_ve_pos` (ej. `binaural_scale`) completada sin errores tras el fix, en una base de datos en blanco.

## References

Reportado por el consultor via error de produccion en `binaural-dev-2doce-market.odoo.com`, `ir.module.module`, 2026-07-28.