### PR TITLE
[FEAT] #78268: l10n_ve_[stock,stock_account]

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "19.0.1.0.4",
+    "version": "19.0.1.0.5",
     "depends": [
         "stock",
         "product",
@@ -29,6 +29,7 @@
         "views/stock_move_line_views.xml",
         "views/stock_picking_views.xml",
         "views/stock_location_views.xml",
+        "views/stock_warehouse_views.xml",
         "wizard/stock_quantity_history.xml",
     ],
     "application": True,

--- a/l10n_ve_stock/i18n/es_VE.po
+++ b/l10n_ve_stock/i18n/es_VE.po
@@ -292,6 +292,26 @@ msgid "Followers (Partners)"
 msgstr "Seguidores (Contactos)"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__destination_physical_address
+msgid "Destination Address"
+msgstr "Dirección de Destino"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_warehouse__physical_address
+msgid "Physical Address"
+msgstr "Dirección Física"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_warehouse__physical_address
+msgid "Detailed warehouse address (Street, Avenue, Industrial Zone, State, City, etc.)"
+msgstr "Dirección detallada del almacén (Calle, Avenida, Zona Industrial, Estado, Ciudad, etc.)"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__source_physical_address
+msgid "Source Address"
+msgstr "Dirección de Origen"
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
 msgstr "Icono Font awesome, por ejemplo fa-tasks"

--- a/l10n_ve_stock/models/stock_picking.py
+++ b/l10n_ve_stock/models/stock_picking.py
@@ -12,6 +12,18 @@ class StockPicking(models.Model):
 
     package_qty = fields.Integer(default=0)
     reception_date = fields.Date(tracking=True)
+    source_physical_address = fields.Text(
+        string="Source Address",
+        compute="_compute_physical_addresses",
+        store=True,
+        readonly=True,
+    )
+    destination_physical_address = fields.Text(
+        string="Destination Address",
+        compute="_compute_physical_addresses",
+        store=True,
+        readonly=True,
+    )
 
     def _get_action_picking_delivery_type(self, picking_type):
         # action = self.env["ir.actions.actions"]._for_xml_id("stock.action_picking_tree_all")
@@ -147,6 +159,14 @@ class StockPicking(models.Model):
     def _compute_type_delivery_step(self):
         for record in self:
             record.type_delivery_step = record.picking_type_id._get_type_steps()
+
+    @api.depends("location_id", "location_dest_id")
+    def _compute_physical_addresses(self):
+        for record in self:
+            source_wh = record.location_id.warehouse_id
+            dest_wh = record.location_dest_id.warehouse_id
+            record.source_physical_address = source_wh.physical_address if source_wh else False
+            record.destination_physical_address = dest_wh.physical_address if dest_wh else False
 
     change_weight = fields.Boolean(
         related="company_id.change_weight",

--- a/l10n_ve_stock/models/stock_warehouse.py
+++ b/l10n_ve_stock/models/stock_warehouse.py
@@ -4,6 +4,11 @@ from odoo.exceptions import UserError
 class Warehouse(models.Model):
     _inherit = "stock.warehouse"
 
+    physical_address = fields.Text(
+        string="Physical Address",
+        help="Detailed warehouse address (Street, Avenue, Industrial Zone, State, City, etc.)"
+    )
+
     def _get_picking_type_create_values(self, max_sequence):
         """ When a warehouse is created this method return the values needed in
         order to create the new picking types for this warehouse. Every picking

--- a/l10n_ve_stock/tests/test_product_template.py
+++ b/l10n_ve_stock/tests/test_product_template.py
@@ -59,6 +59,7 @@ class TestProductTemplateCheckTaxesId(TransactionCase):
         tmpl = self.env["product.template"].create({
             "name": "No Tax Product",
             "type": "consu",
+            "company_id": self.env.company.id,
             "taxes_id": [(5, 0, 0)],
         })
         self.assertEqual(len(tmpl.taxes_id), 0)
@@ -90,6 +91,7 @@ class TestProductTemplateComputePricesWithTax(TransactionCase):
         tmpl = self.env["product.template"].create({
             "name": "No Tax Price",
             "type": "consu",
+            "company_id": self.env.company.id,
             "list_price": 100,
             "taxes_id": [(5, 0, 0)],
         })

--- a/l10n_ve_stock/tests/test_product_template.py
+++ b/l10n_ve_stock/tests/test_product_template.py
@@ -60,7 +60,7 @@ class TestProductTemplateCheckTaxesId(TransactionCase):
             "name": "No Tax Product",
             "type": "consu",
             "company_id": self.env.company.id,
-            "taxes_id": [(5, 0, 0)],
+            "taxes_id": [(6, 0, [])],
         })
         self.assertEqual(len(tmpl.taxes_id), 0)
 
@@ -93,7 +93,7 @@ class TestProductTemplateComputePricesWithTax(TransactionCase):
             "type": "consu",
             "company_id": self.env.company.id,
             "list_price": 100,
-            "taxes_id": [(5, 0, 0)],
+            "taxes_id": [(6, 0, [])],
         })
         self.assertEqual(tmpl.price_with_tax, 100)
         self.assertEqual(tmpl.price_without_tax, 100)

--- a/l10n_ve_stock/tests/test_stock_picking.py
+++ b/l10n_ve_stock/tests/test_stock_picking.py
@@ -2,6 +2,106 @@ from odoo.tests import TransactionCase, tagged
 from odoo.exceptions import UserError
 from odoo import Command
 
+
+@tagged('post_install', '-at_install', "l10n_ve_stock")
+class TestStockPickingPhysicalAddress(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.warehouse_a = self.env['stock.warehouse'].create({
+            'name': 'Test WH A',
+            'code': 'TWHA',
+            'physical_address': 'Av. Principal, Zona Industrial, Caracas',
+        })
+        self.warehouse_b = self.env['stock.warehouse'].create({
+            'name': 'Test WH B',
+            'code': 'TWHB',
+            'physical_address': 'Calle 5, Urbanización El Viñedo, Valencia',
+        })
+        self.product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'type': 'consu',
+            'is_storable': True,
+        })
+
+    def _get_internal_picking_type(self, warehouse):
+        internal_type = warehouse.int_type_id
+        if not internal_type or not internal_type.exists():
+            internal_type = self.env['stock.picking.type'].search([
+                ('warehouse_id', '=', warehouse.id),
+                ('code', '=', 'internal'),
+            ], limit=1)
+        if not internal_type:
+            internal_type = self.env['stock.picking.type'].create({
+                'name': 'Test Internal Transfers',
+                'code': 'internal',
+                'warehouse_id': warehouse.id,
+            })
+        return internal_type
+
+    def test_physical_addresses_between_warehouses(self):
+        picking_type = self._get_internal_picking_type(self.warehouse_a)
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': picking_type.id,
+            'location_id': self.warehouse_a.lot_stock_id.id,
+            'location_dest_id': self.warehouse_b.lot_stock_id.id,
+            'move_ids': [Command.create({
+                'product_id': self.product.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        self.assertEqual(
+            picking.source_physical_address,
+            'Av. Principal, Zona Industrial, Caracas'
+        )
+        self.assertEqual(
+            picking.destination_physical_address,
+            'Calle 5, Urbanización El Viñedo, Valencia'
+        )
+
+    def test_physical_address_false_for_non_warehouse_location(self):
+        customer_loc = self.env.ref('stock.stock_location_customers')
+        picking_type = self._get_internal_picking_type(self.warehouse_a)
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': picking_type.id,
+            'location_id': self.warehouse_a.lot_stock_id.id,
+            'location_dest_id': customer_loc.id,
+            'move_ids': [Command.create({
+                'product_id': self.product.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        self.assertEqual(
+            picking.source_physical_address,
+            'Av. Principal, Zona Industrial, Caracas'
+        )
+        self.assertFalse(picking.destination_physical_address)
+
+    def test_physical_address_recomputes_on_location_change(self):
+        picking_type = self._get_internal_picking_type(self.warehouse_a)
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': picking_type.id,
+            'location_id': self.warehouse_a.lot_stock_id.id,
+            'location_dest_id': self.warehouse_b.lot_stock_id.id,
+            'move_ids': [Command.create({
+                'product_id': self.product.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        self.assertEqual(
+            picking.source_physical_address,
+            'Av. Principal, Zona Industrial, Caracas'
+        )
+        picking.write({'location_dest_id': self.warehouse_a.lot_stock_id.id})
+        self.assertEqual(
+            picking.destination_physical_address,
+            'Av. Principal, Zona Industrial, Caracas'
+        )
+        self.assertEqual(
+            picking.source_physical_address,
+            'Av. Principal, Zona Industrial, Caracas'
+        )
+
 @tagged('post_install', '-at_install', "l10n_ve_stock")
 class TestStockPickingActionPickingDeliveryType(TransactionCase):
 

--- a/l10n_ve_stock/tests/test_stock_warehouse.py
+++ b/l10n_ve_stock/tests/test_stock_warehouse.py
@@ -17,3 +17,13 @@ class TestStockWarehouse(TransactionCase):
         result = warehouse._get_picking_type_create_values(100)
         self.assertIsNotNone(result)
         self.assertIsInstance(result, tuple)
+
+    def test_physical_address_field(self):
+        warehouse = self.env["stock.warehouse"].create({
+            "name": "Test WH Physical Address",
+            "code": "TWPA",
+            "physical_address": "Av. Principal, Zona Industrial, Caracas",
+        })
+        self.assertEqual(
+            warehouse.physical_address, "Av. Principal, Zona Industrial, Caracas"
+        )

--- a/l10n_ve_stock/views/stock_picking_views.xml
+++ b/l10n_ve_stock/views/stock_picking_views.xml
@@ -67,6 +67,12 @@
             <xpath expr="//field[@name='partner_id']" position="attributes">
                 <attribute name="options">{'no_quick_create': True}</attribute>
             </xpath>
+            <xpath expr="//field[@name='location_id'][@groups='stock.group_stock_multi_locations']" position="after">
+                <field name="source_physical_address" readonly="1" invisible="picking_type_code == 'incoming'"/>
+            </xpath>
+            <xpath expr="//field[@name='location_dest_id'][@groups='stock.group_stock_multi_locations']" position="after">
+                <field name="destination_physical_address" readonly="1" invisible="picking_type_code == 'outgoing'"/>
+            </xpath>
         </field>
     </record>
 

--- a/l10n_ve_stock/views/stock_warehouse_views.xml
+++ b/l10n_ve_stock/views/stock_warehouse_views.xml
@@ -1,0 +1,13 @@
+
+<odoo>
+    <record id="view_warehouse_inherit_l10n_ve_stock" model="ir.ui.view">
+        <field name="name">stock.warehouse.inherit.l10n.ve.stock</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="physical_address" placeholder="e.g. Av. Principal, Zona Industrial, Caracas"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "19.0.2.0.3",
+    "version": "19.0.2.0.4",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/report/dispatch_guide_template.xml
+++ b/l10n_ve_stock_account/report/dispatch_guide_template.xml
@@ -90,13 +90,26 @@
                                 t-out="context_timestamp(o.scheduled_date).strftime('%d/%m/%Y %H:%M') if o.scheduled_date else ''" />
                         </td>
                     </tr>
-                    <tr>
-                        <td class="w-50 pb-0 my-0 pt-1">
-                            <span class="fw-bold">Dirección de entrega:</span>
-                            <span t-out="o.partner_id.contact_address or ''" />
-
-                        </td>
-                    </tr>
+                    <t t-if="o.operation_code == 'internal'">
+                        <tr>
+                            <td class="w-50 pb-0 my-0 pt-1">
+                                <span class="fw-bold">Dirección de origen:</span>
+                                <span t-out="o.source_physical_address or ''" />
+                            </td>
+                            <td class="w-50 pb-0 my-0 pt-1">
+                                <span class="fw-bold">Dirección de destino:</span>
+                                <span t-out="o.destination_physical_address or ''" />
+                            </td>
+                        </tr>
+                    </t>
+                    <t t-else="">
+                        <tr>
+                            <td class="w-50 pb-0 my-0 pt-1">
+                                <span class="fw-bold">Dirección de entrega:</span>
+                                <span t-out="o.partner_id.contact_address or ''" />
+                            </td>
+                        </tr>
+                    </t>
                 </tbody>
             </table>
 


### PR DESCRIPTION
Problema: Los traslados internos entre almacenes no mostraban las direcciones físicas de origen y destino en la vista de picking ni en la guía de despacho PDF. Esto dificultaba identificar las ubicaciones reales involucradas en el movimiento de mercancía.

Solución: Se agrega el campo `physical_address` al modelo `stock.warehouse`. En `stock.picking` se agregan campos computados `source_physical_address` y `destination_physical_address` que resuelven la dirección a través de `location_id.warehouse_id` y `location_dest_id.warehouse_id`. Se incorporan las vistas en formularios de almacén y picking, traducciones es_VE, y tests unitarios. En `l10n_ve_stock_account`, la guía de despacho PDF muestra ambas direcciones en traslados internos (`operation_code == 'internal'`), conservando el comportamiento original (Dirección de entrega del partner) para otros tipos de operación.

Ticket (link): https://binaural.odoo.com/odoo/action-341/78268