### PR TITLE
[FIX] #14296: l10n_ve_invoice

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.6",
+    "version": "19.0.1.0.7",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/security/l10n_ve_invoice_groups.xml
+++ b/l10n_ve_invoice/security/l10n_ve_invoice_groups.xml
@@ -9,9 +9,4 @@
         </record>
 
     </data>
-    <data noupdate="1">
-        <record id="group_edit_invoice_tax_ids" model="res.groups">
-            <field name="name">Edit Taxes on Invoice Lines</field>
-        </record>
-    </data>
 </odoo>

--- a/l10n_ve_invoice/views/account_move.xml
+++ b/l10n_ve_invoice/views/account_move.xml
@@ -205,20 +205,6 @@
             </search>
         </field>
     </record>
-    <record id="view_invoice_line_tree_editable_tax_ids" model="ir.ui.view">
-        <field name="name">Editable Tax IDs for Group</field>
-        <field name="model">account.move</field>
-        <field name="inherit_id" ref="account.view_move_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='tax_ids']" position="attributes">
-                <attribute name="readonly">0</attribute>
-                <attribute name="groups">l10n_ve_invoice.group_edit_invoice_tax_ids</attribute>
-            </xpath>
-            <xpath expr="//field[@name='invoice_line_ids']/list//field[@name='tax_ids']" position="before">
-                <field name="tax_ids" readonly="1" widget="many2many_tags" groups="!l10n_ve_invoice.group_edit_invoice_tax_ids"/>
-            </xpath>        
-        </field>
-    </record>
 
     <record id="l10n_ve_invoice_view_invoice_tree_datetime" model="ir.ui.view">
         <field name="name">account.move.list.l10n.ve.invoice.datetime</field>


### PR DESCRIPTION
Problema: El control de edición de impuestos en líneas de factura reside en l10n_ve_invoice a través del grupo group_edit_invoice_tax_ids y la vista view_invoice_line_tree_editable_tax_ids. Sin embargo, se necesita unificar este comportamiento junto con el de ventas en un solo módulo para mantener consistencia y facilitar la gestión de permisos.

Solución: Se elimina la vista view_invoice_line_tree_editable_tax_ids de views/account_move.xml y se remueve el grupo group_edit_invoice_tax_ids de security/l10n_ve_invoice_groups.xml. La lógica de edición de impuestos se traslada a binaural_operative.

Ticket: https://binaural.odoo.com/odoo/my-tickets/14296