### PR TITLE
[FIX] #13828: l10n_ve_accountant - regresión de validación de impuestos en producto

### DIFF
--- a/l10n_ve_accountant/models/product_template.py
+++ b/l10n_ve_accountant/models/product_template.py
@@ -1,5 +1,5 @@
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 
 class ProductTemplate(models.Model):
@@ -39,11 +39,15 @@ class ProductTemplate(models.Model):
             # 1. Determine the baseline tax IDs of the record (if updating)
             current_ids = set(records[field_name].ids) if records else set()
 
-            if field_name in vals and vals[field_name]:
+            if field_name in vals:
                 raw_value = vals[field_name]
-                
+
+                if not raw_value:
+                    # False/None/0/[] means the ORM clears the relation entirely
+                    current_ids = set()
+
                 # Case A: Direct integer list [ID, ID]
-                if isinstance(raw_value, list) and all(isinstance(x, int) for x in raw_value):
+                elif isinstance(raw_value, list) and all(isinstance(x, int) for x in raw_value):
                     current_ids = set(raw_value)
                 
                 # Case B: Odoo M2M standard command structure
@@ -69,7 +73,7 @@ class ProductTemplate(models.Model):
                     vals[field_name] = [fields.Command.set([default_tax.id])]
                 else:
                     errors.append(_("- %s: No tax is assigned and the company has no default fiscal configuration.") % label)
-            elif len(tax_ids) > 1:
+            elif len(tax_ids) > 1 and company.unique_tax:
                 errors.append(_("- %s: Has %s taxes assigned (exactly one tax is required due to local fiscal policies).") % (label, len(tax_ids)))
 
         if errors:
@@ -81,4 +85,4 @@ class ProductTemplate(models.Model):
                 + "\n".join(errors)
                 + _("\n\nPlease correct these fields before saving your changes.")
             )
-            raise UserError(error_msg)
+            raise ValidationError(error_msg)

--- a/l10n_ve_accountant/tests/test_product_template.py
+++ b/l10n_ve_accountant/tests/test_product_template.py
@@ -30,6 +30,9 @@ class TestProductTemplate(TransactionCase):
             "type_tax_use": "purchase", "company_id": self.company.id,
             "tax_group_id": self.tax_group.id,
         })
+        # The "more than one tax" rule only applies to companies that opted
+        # into it; the "zero taxes with no default" rule is unconditional.
+        self.company.unique_tax = True
 
     # ═══════════════════════════════════════════════════════════════
     # Positive tests — product creation / write should succeed
@@ -202,3 +205,39 @@ class TestProductTemplate(TransactionCase):
         })
         with self.assertRaises(UserError):
             product.write({"taxes_id": [(3, self.tax_sale_1.id)]})
+
+    # ═══════════════════════════════════════════════════════════════
+    # Regression tests — unique_tax gating and False/None write bypass
+    # ═══════════════════════════════════════════════════════════════
+
+    def test_14_two_sale_taxes_allowed_when_unique_tax_disabled(self):
+        """Sin unique_tax, 2 sale taxes distintos -> OK (no bloquea a companias que no usan la opcion)"""
+        self.company.unique_tax = False
+        product = self.env["product.product"].create({
+            "name": "Test Two Sale Taxes Allowed",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
+            "supplier_taxes_id": [(6, 0, [self.tax_purchase.id])],
+        })
+        self.assertEqual(len(product.taxes_id), 2)
+
+    def test_15_write_false_does_not_bypass_validation(self):
+        """write({'taxes_id': False}) debe re-evaluarse contra el estado vacio resultante, no contra el estado previo"""
+        self.company.write({
+            "account_sale_tax_id": self.tax_sale_1.id,
+        })
+        product = self.env["product.product"].create({
+            "name": "Test Write False",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        product.write({"taxes_id": False})
+        # With a company default configured, clearing the field auto-fills it
+        # instead of silently leaving the product without a sales tax.
+        self.assertEqual(len(product.taxes_id), 1)
+        self.assertEqual(product.taxes_id.id, self.tax_sale_1.id)
+
+        self.company.write({"account_sale_tax_id": False})
+        with self.assertRaises(UserError):
+            product.write({"taxes_id": False})


### PR DESCRIPTION
## Problema

PR #1084 (ticket #13828) reescribió `l10n_ve_accountant/models/product_template.py` y se mergeó a `maintenance-19.0` con una review "Request changes" abierta (dos reviewers, `christopherBinaural` y `manuelgc1201`) que señalaba dos puntos:

1. Mislabel de `invoice_date_display` en `account_move.py` — **sí se corrigió** antes del merge.
2. Bypass de validación vía `product.write({'taxes_id': False})` — **no se corrigió**, confirmado por inspección de código.

Además, el merge introdujo una regresión no señalada en la review:

- `_enforce_single_tax_vals` corre en `create()`/`write()` de forma incondicional (sin mirar `company.unique_tax`) y lanza `UserError` antes de que el `@api.constrains` de `binaural_purchase` (gateado por `unique_tax`, lanza `ValidationError`) llegue a ejecutarse.
- Esto rompió `TestPurchaseOrder.test_product_template_tax_constraint` en `binaural_purchase` (integra-addons), que espera `ValidationError` y ahora recibe `UserError` — bloqueó el CI de integra-addons#2453 (ticket #14131), ya mergeado, sin relación con ese cambio.
- También bloquea a **cualquier compañía** (incluso con `unique_tax=False`) que tenga 2+ impuestos en un producto — antes esta restricción solo aplicaba con `unique_tax=True`, igual que los checks equivalentes en `account_move.py` y `l10n_ve_sale/sale_order.py`.

## Cambios

- `_enforce_single_tax_vals` ahora lanza `ValidationError` en vez de `UserError`. En Odoo, `ValidationError` es subclase de `UserError`, así que esto arregla el test de `binaural_purchase` sin romper los 13 tests existentes de `l10n_ve_accountant` (usan `assertRaises(UserError)`), y alinea con `account_move.py`/`sale_order.py`.
- El check de "más de 1 impuesto" ahora respeta `company.unique_tax`, igual que sus siblings. El check de "0 impuestos sin default" queda incondicional (alcance real del ticket #13828).
- Corregido el bypass: `write({'taxes_id': False})` (o `None`/`0`/`[]`) ahora se interpreta como vaciar la relación, en vez de validar contra el estado previo del registro.
- Se agregan 2 tests nuevos en `l10n_ve_accountant/tests/test_product_template.py` cubriendo ambos fixes, y se ajusta el `setUp` para activar `unique_tax=True` (necesario ahora que el check de "+1 impuesto" depende de ese flag).

## Test plan

- [ ] `l10n_ve_accountant` test suite completa (15 tests: 13 existentes + 2 nuevos) en verde.
- [ ] `binaural_purchase.tests.test_purchase_order.TestPurchaseOrder.test_product_template_tax_constraint` (integra-addons) vuelve a pasar sin modificar el test.
- [ ] Verificado por simulación directa de la lógica parcheada contra los 18 escenarios relevantes (13 tests existentes + 3 nuevos/de regresión + el escenario exacto del traceback de CI) — todos con el resultado esperado.

Ref: ticket https://binaural.odoo.com/odoo/my-tickets/13828