### PR TITLE
19.0 fix l10n ve pos payment fields contract

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "1.6",
+    "version": "1.7",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/models/pos_payment.py
+++ b/l10n_ve_pos/models/pos_payment.py
@@ -42,10 +42,22 @@ class PosPayment(models.Model):
         """Keep Odoo 19 core payment contract and extend it with Venezuelan
         foreign-currency fields.
 
-        Important: returning only custom fields breaks frontend invariants
-        (`pos_order_id` is needed by PosPayment.setAmount).
+        Important: `pos.load.mixin._load_pos_data_fields` returns `[]` for
+        pos.payment in core, which is a special value meaning "load every
+        field" (see `_load_pos_data_read`: `records.read(fields, ...)` with
+        an empty list reads all fields). Turning that `[]` into an explicit
+        whitelist — even one padded with our own required fields — silently
+        breaks every OTHER module's pos.payment field (e.g. an analytic
+        account added by a subsidiary/cost-center module): anything not in
+        this hardcoded list stops reaching the frontend, and the client's
+        `related_models` engine rejects it with "field does not exist" the
+        moment something tries to set it. Only build the whitelist if some
+        ancestor already narrowed it; otherwise, keep passing "all fields"
+        through untouched.
         """
-        res = super()._load_pos_data_fields(config) or []
+        res = super()._load_pos_data_fields(config)
+        if not res:
+            return res
         required = list(self._POS_PAYMENT_CORE_FIELDS) + [
             "foreign_rate",
             "foreign_amount",

--- a/l10n_ve_pos/models/pos_payment.py
+++ b/l10n_ve_pos/models/pos_payment.py
@@ -19,6 +19,9 @@ class PosPayment(models.Model):
         "is_change",
         "pos_order_id",
         "currency_id",
+        # Required by core's DevicesSynchronisation.constructOrdersDomain,
+        # which calls record.write_date.plus(...) on every dynamic model.
+        "write_date",
     )
 
     foreign_rate = fields.Float(

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-payment-fields-contract-fix/README.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-payment-fields-contract-fix/README.md
@@ -1,0 +1,3 @@
+# l10n-ve-pos-payment-fields-contract-fix
+
+pos.payment._load_pos_data_fields no debe reemplazar el contrato core [] (todos los campos) por un whitelist explícito

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-payment-fields-contract-fix/proposal.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-payment-fields-contract-fix/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+`pos.payment._load_pos_data_fields` (core Odoo 19) returns `[]`, y el mixin
+`pos.load.mixin` trata una lista vacía como "cargar todos los campos"
+(`_load_pos_data_read` hace `records.read(fields, load=False)`, y el ORM
+interpreta `fields=[]` como "todos"). `l10n_ve_pos/models/pos_payment.py`
+rompía ese contrato: hacía `res = super()._load_pos_data_fields(config) or
+[]` y luego construía una lista explícita (`_POS_PAYMENT_CORE_FIELDS` +
+campos foráneos), convirtiendo el "todos los campos" del core en un
+whitelist fijo.
+
+Efecto real (db `2doce`, 2026-07-30): al instalar `binaural_subsidiary_pos`
+(que depende de `sh_pos_analytic_tags`, un módulo que añade
+`sh_analytic_account` a `pos.payment`), el PdV rompía al pulsar un método de
+pago: *"The field 'sh_analytic_account' does not exist in model
+'pos.payment'"*. El campo existe y se lee bien desde el backend — el
+problema es que el whitelist de `l10n_ve_pos` no lo incluye, así que el
+motor `related_models` del cliente lo rechaza al hacer `.update()`.
+
+Ya hubo un incidente hermano con el mismo síntoma raíz: el whitelist se creó
+originalmente sin `write_date`, lo que colgaba el PdV al abrir
+(`constructOrdersDomain` → `record.write_date.plus(...)`) — corregido en
+`2b6c958aa` añadiendo `write_date` al whitelist, pero sin cuestionar si
+narrowear la lista era necesario en primer lugar. Este change corrige la
+causa raíz en vez de seguir parchando síntomas campo por campo.
+
+## What Changes
+
+- `models/pos_payment.py::_load_pos_data_fields`: si `super()` ya devuelve
+  una lista vacía (contrato "todos los campos"), se respeta tal cual — no se
+  construye un whitelist. Solo se añade `_POS_PAYMENT_CORE_FIELDS` +
+  `foreign_rate`/`foreign_amount`/`foreign_currency_id` cuando algún
+  ancestro en la cadena YA haya devuelto una lista no vacía.
+- Test `test_pos_payment_load_pos_data_fields_includes_foreign_amount_and_rate`
+  actualizado al mismo idiom que `test_dynamic_models_expose_write_date`
+  (`not fields or "campo" in fields`), en vez de `assertIn` estricto —
+  el assertIn estricto es justo lo que hacía pasar el bug desapercibido.
+
+## Capabilities
+
+### New Capabilities
+
+- `pos-payment-fields-contract`: `pos.payment._load_pos_data_fields` respeta
+  el contrato "lista vacía = todos los campos" del core en vez de
+  reemplazarlo por un whitelist propio (nota: existe un capability
+  relacionado `pos-odoo19-data-loading` dentro de
+  `openspec/changes/l10n-ve-pos-migration-plan/specs/`, pero ese change aún
+  no está archivado/mergeado a `openspec/specs/`, así que no hay un spec
+  canónico del que partir un delta MODIFIED todavía).
+
+## Impact
+
+- `src/odoo-venezuela/l10n_ve_pos/models/pos_payment.py`
+- `src/odoo-venezuela/l10n_ve_pos/tests/test_pos_serialization.py`
+- Desbloquea `binaural_subsidiary_pos` (y cualquier módulo futuro que añada
+  un campo a `pos.payment`) sin tener que tocar `l10n_ve_pos` de nuevo cada
+  vez.

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-payment-fields-contract-fix/specs/pos-payment-fields-contract/spec.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-payment-fields-contract-fix/specs/pos-payment-fields-contract/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: pos.payment field contract respects the "empty list = all fields" core convention
+`pos.payment._load_pos_data_fields` SHALL return the value from `super()`
+unmodified when it is empty, instead of replacing it with an explicit
+whitelist, so that fields added to `pos.payment` by other modules keep
+reaching the PoS frontend.
+
+#### Scenario: Core contract is untouched (no ancestor narrowed the list)
+- **WHEN** no module up the `pos.payment` inheritance chain overrides
+  `_load_pos_data_fields` with a non-empty explicit list
+- **THEN** `l10n_ve_pos`'s `_load_pos_data_fields` returns an empty list too,
+  and every stored field on `pos.payment` (core or added by any other
+  module) reaches the PoS frontend and is a valid target for client-side
+  `.update()` calls
+
+#### Scenario: Ancestor already narrowed the list
+- **WHEN** some module up the chain already returns a non-empty explicit
+  field list
+- **THEN** `l10n_ve_pos`'s `_load_pos_data_fields` extends that list with
+  `_POS_PAYMENT_CORE_FIELDS` and the Venezuelan foreign-currency fields
+  (`foreign_rate`, `foreign_amount`, `foreign_currency_id`), without
+  dropping any field already present

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-payment-fields-contract-fix/tasks.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-payment-fields-contract-fix/tasks.md
@@ -1,0 +1,18 @@
+## 1. Fix
+
+- [x] 1.1 `models/pos_payment.py::_load_pos_data_fields`: no construir el
+      whitelist si `super()` ya devuelve una lista vacía; solo extender si
+      ya viene no-vacía.
+- [x] 1.2 Actualizar `test_pos_payment_load_pos_data_fields_includes_foreign_amount_and_rate`
+      al idiom `not fields or "campo" in fields` (igual que
+      `test_dynamic_models_expose_write_date`).
+
+## 2. Verificación
+
+- [ ] 2.1 Correr `test_pos_serialization.py` completo (no roto por el
+      cambio de idiom del test 1.2, ni por el resto de tests de
+      `pos.order`/`pos.order.line` que no se tocaron).
+- [ ] 2.2 Reinstalar/actualizar `binaural_subsidiary_pos` en `2doce` y
+      confirmar que el error *"The field 'sh_analytic_account' does not
+      exist in model 'pos.payment'"* ya no ocurre al pulsar un método de
+      pago.

--- a/l10n_ve_pos/tests/test_pos_serialization.py
+++ b/l10n_ve_pos/tests/test_pos_serialization.py
@@ -651,3 +651,53 @@ class TestPosSerialization(TransactionCase):
             "pos.payment._export_for_ui was removed in Odoo 19; the l10n_ve_pos "
             "override must be deleted, not left as dead code.",
         )
+
+    # ------------------------------------------------------------------
+    # Regression — write_date MUST survive in every dynamicModel's field
+    #       contract, or the POS frontend crashes on open.
+    # ------------------------------------------------------------------
+    def test_dynamic_models_expose_write_date(self):
+        """Odoo 19's ``DevicesSynchronisation.constructOrdersDomain``
+        (``point_of_sale/static/src/app/utils/devices_synchronisation.js``)
+        calls ``record.write_date.plus(...)`` on every record of every
+        "dynamic model" (``pos.order``, ``pos.order.line``, ``pos.payment``,
+        ``pos.pack.operation.lot``, ``product.attribute.custom.value``)
+        every time the POS opens or syncs. If any of these models'
+        ``_load_pos_data_fields`` returns an explicit list that forgets
+        ``write_date``, the frontend crashes with
+        ``TypeError: Cannot read properties of undefined (reading 'plus')``
+        — it does NOT fail server-side, so nothing short of a test like
+        this one catches it before a cashier hits it in production.
+
+        Convention: an EMPTY list means "load every stored field" (see
+        ``pos.load.mixin._load_pos_data_read``, which calls
+        ``records.read(fields, load=False)`` and Odoo's ORM treats an
+        empty field list as "all fields") — that case is safe too, since
+        ``write_date`` is always present. Only a NON-empty list that
+        omits ``write_date`` is the bug.
+
+        Real incident: ``pos.payment._load_pos_data_fields`` replaced the
+        core empty-list contract with an explicit
+        ``_POS_PAYMENT_CORE_FIELDS`` tuple that did not include
+        ``write_date`` (db ``2doce``, 2026-07-29). ``l10n_ve_pos_mf`` has
+        a defensive JS patch for the symptom, but it is not installed on
+        every database, so this Python-level test is the only guard that
+        applies everywhere ``l10n_ve_pos`` is installed.
+        """
+        dynamic_models = (
+            "pos.order",
+            "pos.order.line",
+            "pos.payment",
+            "pos.pack.operation.lot",
+            "product.attribute.custom.value",
+        )
+        for model_name in dynamic_models:
+            model_fields = self.env[model_name]._load_pos_data_fields(self.config)
+            self.assertTrue(
+                not model_fields or "write_date" in model_fields,
+                f"{model_name}._load_pos_data_fields must either return an "
+                "empty list (= load all fields) or explicitly include "
+                "'write_date', otherwise constructOrdersDomain crashes the "
+                "POS frontend with \"Cannot read properties of undefined "
+                "(reading 'plus')\" on open.",
+            )

--- a/l10n_ve_pos/tests/test_pos_serialization.py
+++ b/l10n_ve_pos/tests/test_pos_serialization.py
@@ -390,16 +390,19 @@ class TestPosSerialization(TransactionCase):
     # ------------------------------------------------------------------
     def test_pos_payment_load_pos_data_fields_includes_foreign_amount_and_rate(self):
         """B.2 / B.4 / Spec: payment read-back payload MUST include
-        ``foreign_amount`` and ``foreign_rate``."""
+        ``foreign_amount`` and ``foreign_rate`` — either explicitly, or
+        implicitly via the empty-list "load all fields" convention (see
+        ``test_dynamic_models_expose_write_date``: pos.payment's core
+        contract is ``[]``, and turning it into an explicit whitelist here
+        would silently drop any field OTHER modules add to pos.payment,
+        e.g. an analytic account from a subsidiary module)."""
         fields = self.env["pos.payment"]._load_pos_data_fields(self.config)
-        self.assertIn(
-            "foreign_amount",
-            fields,
+        self.assertTrue(
+            not fields or "foreign_amount" in fields,
             "pos.payment._load_pos_data_fields must expose foreign_amount",
         )
-        self.assertIn(
-            "foreign_rate",
-            fields,
+        self.assertTrue(
+            not fields or "foreign_rate" in fields,
             "pos.payment._load_pos_data_fields must expose foreign_rate",
         )
 


### PR DESCRIPTION
_POS_PAYMENT_CORE_FIELDS reemplazaba el contrato de campos de
pos.payment sin incluir write_date, que Odoo 19 usa en
DevicesSynchronisation.constructOrdersDomain (record.write_date.plus)
al abrir/sincronizar el PdV. Sin él, el frontend crashea con
"Cannot read properties of undefined (reading 'plus')" (detectado en
db 2doce).

Añade test de regresión que verifica que los 5 dynamicModels de
constructOrdersDomain (pos.order, pos.order.line, pos.payment,
pos.pack.operation.lot, product.attribute.custom.value) sigan
exponiendo write_date en su _load_pos_data_fields.

https://binaural.odoo.com/odoo/action-341/77221