### PR TITLE
[FIX] l10n_ve_pos: Detalles de venta del PdV (KeyError 'name')

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "1.7",
+    "version": "1.8",
     # any module necessary for this one to work correctly
     "depends": [
         "base",
@@ -28,7 +28,7 @@
         "views/res_config_settings.xml",
         "views/pos_payment_views.xml",
         "views/res_partner_views.xml",
-        # "views/report_saledetails.xml",
+        "views/report_saledetails.xml",
         "security/res_group.xml",
         "wizard/payment_report.xml",
         "report/payment_report.xml",

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-sale-details-report-foreign-totals/proposal.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-sale-details-report-foreign-totals/proposal.md
@@ -1,0 +1,80 @@
+# Fix: reporte "Detalles de venta" del PdV (KeyError: 'name') y restauración de los totales en moneda foránea (l10n_ve_pos)
+
+## Why
+
+Al pedir "Detalles de venta" desde la sesión de PdV (icono de tuerca), el
+reporte fallaba con `RPC_ERROR` / `KeyError: 'name'` al renderizar
+`point_of_sale.pos_session_sales_details`, en la línea que hace
+`category['name']`.
+
+Causa raíz: el commit `501a54584` (nov 2025, tarea #59569) comentó
+`"views/report_saledetails.xml"` en el manifiesto de `l10n_ve_pos` como
+fix rápido para un error no relacionado (variantes de producto en Odoo
+19), pero dejó activo `report/report_saledetails.py`, que sobreescribía
+`get_sale_details()` por completo (sin `super()`) con la forma de dato
+"plana" de una versión anterior (v17: `products` = lista plana de
+productos).
+
+Desde entonces la plantilla que realmente se renderiza es la nativa de
+Odoo 19 (`point_of_sale.pos_session_sales_details`), que espera
+`products` como lista de **categorías** (`{'name', 'products', 'qty',
+'total'}`), más `products_info`, `refund_products`, `refund_info`,
+`taxes_info`, `refund_taxes`, `discount_number`, `discount_amount`,
+`invoiceList`, `payments_per_method`, `cash_rounding_total`, etc. — nada
+de eso lo devolvía el override de `l10n_ve_pos`, de ahí el `KeyError`.
+El bug llevaba 9 meses latente porque nadie había vuelto a imprimir este
+reporte desde el fix de nov 2025 hasta ahora (sesión de hoy,
+2026-07-31, BD `pos` del contenedor `proj`).
+
+Además, el override viejo era el único lugar donde se mostraba el total
+pagado en moneda foránea (Bs/USD) de la sesión — funcionalidad relevante
+para la localización VZ (ver `openspec/migration-lessons.md`, sección
+sobre consumidores de `foreign_amount`). Al arreglar el crash, se
+aprovecha para restaurar esa información pero como una **extensión**
+sobre la plantilla nativa (no un reemplazo total), para no perder todo lo
+que Odoo 19 agregó al reporte (reembolsos, descuentos, arqueo de caja,
+facturas).
+
+## What Changes
+
+- `report/report_saledetails.py`: `get_sale_details()` ahora llama a
+  `super()` y usa la estructura nativa de Odoo 19 tal cual. Encima,
+  agrega:
+  - `foreign_currency`: `res.currency` foránea de la compañía
+    (`company.foreign_currency_id`), o vacío si no está configurada.
+  - `foreign_total_paid`: suma de `pos.payment.foreign_amount` de todos
+    los pagos del período/sesión(es) consultados.
+  - `payments[]`: cada pago nativo gana `f_total` (su equivalente
+    foráneo), agrupado por método de pago + sesión vía SQL directo sobre
+    `pos_payment`/`pos_payment_method`.
+  - `payments_per_method`: recalculado para incluir también `f_total`
+    acumulado por método (antes solo tenía `total`).
+- `views/report_saledetails.xml`: en vez de reemplazar por completo el
+  `t-call` a `point_of_sale.pos_session_sales_details` (como hacía antes
+  de nov 2025), ahora hereda esa plantilla nativa vía `inherit_id` y solo
+  inserta 3 columnas nuevas (con `t-if="foreign_currency"`, para no
+  romper nada si la compañía no tiene moneda foránea configurada):
+  monto foráneo por pago, total foráneo de la sesión, y monto foráneo por
+  método de pago agrupado.
+- `__manifest__.py`: se descomenta `"views/report_saledetails.xml"` en
+  `data` y se sube versión `1.7` → `1.8` (requiere `-u l10n_ve_pos` para
+  cargar la vista en base de datos).
+
+## Impact
+
+- **Capability**: `pos-sale-details-foreign-totals` (nueva).
+- **Módulo**: `l10n_ve_pos`, backend (`report/report_saledetails.py`) y
+  vista QWeb (`views/report_saledetails.xml`). Requiere `-u l10n_ve_pos`
+  para que la vista quede registrada (el método Python ya se recarga
+  solo, pero la vista QWeb no existía en absoluto en la BD hasta este
+  cambio).
+- Compañías sin `foreign_currency_id` configurado: sin cambio visible,
+  las columnas nuevas no se renderizan (`t-if="foreign_currency"`).
+- Este mismo archivo está duplicado (repos independientes) en
+  `custom/2doce-market`, `custom/megasoft-2doce` y
+  `custom/19-homologacion-jul-2026-pos` — **no** se tocan en este change;
+  si esos proyectos necesitan el mismo fix, es un change aparte por
+  repo.
+- No se corrieron tests ni `-u` de verificación en este pase (se deja
+  para que el usuario lo pruebe en el navegador tras el upgrade del
+  módulo).

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-sale-details-report-foreign-totals/specs/pos-sale-details-foreign-totals/spec.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-sale-details-report-foreign-totals/specs/pos-sale-details-foreign-totals/spec.md
@@ -1,0 +1,42 @@
+# Spec delta: pos-sale-details-foreign-totals
+
+## ADDED Requirements
+
+### Requirement: El reporte "Detalles de venta" usa la estructura nativa de Odoo 19
+
+El sistema SHALL generar `report.point_of_sale.report_saledetails.get_sale_details()`
+delegando en la implementación nativa de `point_of_sale` (categorías de
+productos, reembolsos, impuestos, descuentos, facturas, arqueo de caja),
+sin reemplazarla por una estructura de datos distinta.
+
+#### Scenario: Sesión con ventas de varias categorías de producto
+
+- **GIVEN** una sesión de PdV cerrada con órdenes de al menos dos
+  categorías de producto distintas
+- **WHEN** se genera el reporte "Detalles de venta" de esa sesión
+- **THEN** el reporte se renderiza sin error, agrupando los productos
+  vendidos por categoría (`products[].name`, `products[].products`)
+
+### Requirement: El reporte agrega los totales en moneda foránea de la compañía
+
+El sistema SHALL agregar a la salida de `get_sale_details()` el total
+pagado en la moneda foránea de la compañía (`company.foreign_currency_id`)
+y su desglose por método de pago, sin alterar ninguno de los campos
+nativos ya presentes.
+
+#### Scenario: Compañía con moneda foránea configurada
+
+- **GIVEN** una compañía con `foreign_currency_id` configurado (p. ej.
+  USD) y una sesión con pagos en uno o más métodos
+- **WHEN** se genera el reporte "Detalles de venta"
+- **THEN** la sección de pagos muestra, junto al monto nativo de cada
+  pago y del total de la sesión, su equivalente en la moneda foránea
+  (`payments[].f_total`, `foreign_total_paid`,
+  `payments_per_method[].f_total`)
+
+#### Scenario: Compañía sin moneda foránea configurada
+
+- **GIVEN** una compañía sin `foreign_currency_id`
+- **WHEN** se genera el reporte "Detalles de venta"
+- **THEN** el reporte se renderiza igual que el nativo de Odoo 19, sin
+  columnas ni valores adicionales de moneda foránea

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-sale-details-report-foreign-totals/tasks.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-sale-details-report-foreign-totals/tasks.md
@@ -1,0 +1,47 @@
+# Tasks
+
+## 1. Diagnóstico
+
+- [x] 1.1 Reproducir el `KeyError: 'name'` a partir del traceback RPC y
+      ubicar la plantilla real que falla (`point_of_sale.pos_session_sales_details`,
+      no la de `l10n_ve_pos`)
+- [x] 1.2 Confirmar en BD (`pos`, contenedor `proj`) que no existe ninguna
+      `ir.ui.view` con `key='l10n_ve_pos.report_saledetails'` — la vista
+      nunca llegó a cargarse
+- [x] 1.3 `git log`/`git blame` sobre `__manifest__.py` → commit
+      `501a54584` (nov 2025, tarea #59569) comentó la vista como fix de
+      un problema no relacionado, sin tocar el método Python
+- [x] 1.4 Confirmar que `report/report_saledetails.py` seguía activo
+      (los `.py` se cargan independientemente de `data` en el manifiesto)
+      y que su forma de retorno (`products` plano) no calza con lo que
+      pide la plantilla nativa de Odoo 19
+
+## 2. Implementación
+
+- [x] 2.1 `report/report_saledetails.py`: `get_sale_details()` delega en
+      `super()` y agrega `foreign_currency`, `foreign_total_paid`,
+      `payments[].f_total`, `payments_per_method[].f_total`
+- [x] 2.2 `views/report_saledetails.xml`: reescrito como `inherit_id` de
+      `point_of_sale.pos_session_sales_details` (antes reemplazaba
+      `point_of_sale.report_saledetails` completo) con 3 xpath aditivos,
+      todos gateados por `t-if="foreign_currency"`
+- [x] 2.3 `__manifest__.py`: descomentar la vista en `data`, subir
+      versión 1.7 → 1.8
+- [x] 2.4 Validar sintaxis Python (`compile()`) y XML (`lxml`), y
+      verificar que los 3 `expr` de xpath matchean exactamente 1
+      elemento contra la plantilla nativa de Odoo 19
+
+## 3. Pendiente (a cargo del usuario)
+
+- [ ] 3.1 `-u l10n_ve_pos` en el contenedor `proj` (u otro ambiente) para
+      registrar la vista nueva en BD
+- [ ] 3.2 Probar en el navegador: "Detalles de venta" desde una sesión de
+      PdV, con y sin `foreign_currency_id` configurado en la compañía
+- [ ] 3.3 Evaluar si el mismo fix debe replicarse en
+      `custom/2doce-market`, `custom/megasoft-2doce` y
+      `custom/19-homologacion-jul-2026-pos` (repos independientes, no
+      tocados en este change)
+
+## 4. OpenSpec
+
+- [x] 4.1 `openspec change validate l10n-ve-pos-sale-details-report-foreign-totals` → válido

--- a/l10n_ve_pos/report/report_saledetails.py
+++ b/l10n_ve_pos/report/report_saledetails.py
@@ -1,8 +1,4 @@
-from datetime import timedelta
-import pytz
-
-from odoo import api, fields, models, _
-from odoo.fields import Domain
+from odoo import api, models
 
 
 class ReportSaleDetails(models.AbstractModel):
@@ -10,164 +6,67 @@ class ReportSaleDetails(models.AbstractModel):
 
     @api.model
     def get_sale_details(
-        self, date_start=False, date_stop=False, config_ids=False, session_ids=False
+        self, date_start=False, date_stop=False, config_ids=False, session_ids=False, **kwargs
     ):
-        """Serialise the orders of the requested time period, configs and sessions.
+        """Extend the native report with the company's foreign currency totals.
 
-        :param date_start: The dateTime to start, default today 00:00:00.
-        :type date_start: str.
-        :param date_stop: The dateTime to stop, default date_start + 23:59:59.
-        :type date_stop: str.
-        :param config_ids: Pos Config id's to include.
-        :type config_ids: list of numbers.
-        :param session_ids: Pos Config id's to include.
-        :type session_ids: list of numbers.
-
-        :returns: dict -- Serialised sales.
+        Delegates the whole native structure (categories, refunds, taxes,
+        discounts, invoices, cash count) to core `point_of_sale`, and only adds
+        the Bs/USD dual amounts on top of the payments section.
         """
-        domain = [("state", "in", ["paid", "invoiced", "done"])]
-
-        if session_ids:
-            domain = Domain.AND([domain, [("session_id", "in", session_ids)]])
-        else:
-            if date_start:
-                date_start = fields.Datetime.from_string(date_start)
-            else:
-                # start by default today 00:00:00
-                user_tz = pytz.timezone(
-                    self.env.context.get("tz") or self.env.user.tz or "UTC"
-                )
-                today = user_tz.localize(
-                    fields.Datetime.from_string(fields.Date.context_today(self))
-                )
-                date_start = today.astimezone(pytz.timezone("UTC"))
-
-            if date_stop:
-                date_stop = fields.Datetime.from_string(date_stop)
-                # avoid a date_stop smaller than date_start
-                if date_stop < date_start:
-                    date_stop = date_start + timedelta(days=1, seconds=-1)
-            else:
-                # stop by default today 23:59:59
-                date_stop = date_start + timedelta(days=1, seconds=-1)
-
-            domain = Domain.AND(
-                [
-                    domain,
-                    [
-                        ("date_order", ">=", fields.Datetime.to_string(date_start)),
-                        ("date_order", "<=", fields.Datetime.to_string(date_stop)),
-                    ],
-                ]
-            )
-
-            if config_ids:
-                domain = Domain.AND([domain, [("config_id", "in", config_ids)]])
-
-        orders = self.env["pos.order"].search(domain)
-
-        user_currency = self.env.company.currency_id
-
-        total = 0.0
-        f_total = 0.0
-        products_sold = {}
-        taxes = {}
-        for order in orders:
-            if user_currency != order.pricelist_id.currency_id:
-                total += order.pricelist_id.currency_id._convert(
-                    order.amount_total,
-                    user_currency,
-                    order.company_id,
-                    order.date_order or fields.Date.today(),
-                )
-                f_total += order.pricelist_id.currency_id._convert(
-                    order.foreign_amount_total,
-                    user_currency,
-                    order.company_id,
-                    order.date_order or fields.Date.today(),
-                )
-            else:
-                total += order.amount_total
-                f_total += order.foreign_amount_total
-            currency = order.session_id.currency_id
-
-            for line in order.lines:
-                key = (line.product_id, line.price_unit, line.discount)
-                products_sold.setdefault(key, 0.0)
-                products_sold[key] += line.qty
-
-                if line.tax_ids_after_fiscal_position:
-                    line_taxes = line.tax_ids_after_fiscal_position.sudo().compute_all(
-                        line.price_unit * (1 - (line.discount or 0.0) / 100.0),
-                        currency,
-                        line.qty,
-                        product=line.product_id,
-                        partner=line.order_id.partner_id or False,
-                    )
-                    for tax in line_taxes["taxes"]:
-                        taxes.setdefault(
-                            tax["id"],
-                            {
-                                "name": tax["name"],
-                                "tax_amount": 0.0,
-                                "base_amount": 0.0,
-                            },
-                        )
-                        taxes[tax["id"]]["tax_amount"] += tax["amount"]
-                        taxes[tax["id"]]["base_amount"] += tax["base"]
-                else:
-                    taxes.setdefault(
-                        0,
-                        {"name": _("No Taxes"), "tax_amount": 0.0, "base_amount": 0.0},
-                    )
-                    taxes[0]["base_amount"] += line.price_subtotal_incl
-
-        payment_ids = (
-            self.env["pos.payment"].search([("pos_order_id", "in", orders.ids)]).ids
+        res = super().get_sale_details(
+            date_start, date_stop, config_ids, session_ids, **kwargs
         )
+
+        foreign_currency = self.env.company.foreign_currency_id
+        res["foreign_currency"] = foreign_currency
+        res["foreign_total_paid"] = 0.0
+        if not foreign_currency:
+            return res
+
+        orders = self.env["pos.order"].search(
+            self._get_domain(date_start, date_stop, config_ids, session_ids)
+        )
+        payment_ids = self.env["pos.payment"].search(
+            [("pos_order_id", "in", orders.ids)]
+        ).ids
+
+        foreign_by_key = {}
         if payment_ids:
             self.env.cr.execute(
                 """
-                SELECT COALESCE(method.name->>%s, method.name->>'en_US') as name, sum(amount) total,sum(foreign_amount) f_total
-                FROM pos_payment AS payment,
-                     pos_payment_method AS method
-                WHERE payment.payment_method_id = method.id
-                    AND payment.id IN %s
-                GROUP BY method.name
-            """,
-                (
-                    self.env.lang,
-                    tuple(payment_ids),
-                ),
+                SELECT method.id AS id, payment.session_id AS session,
+                       sum(payment.foreign_amount) AS f_total
+                FROM pos_payment AS payment
+                JOIN pos_payment_method AS method ON payment.payment_method_id = method.id
+                WHERE payment.id IN %s
+                GROUP BY method.id, payment.session_id
+                """,
+                (tuple(payment_ids),),
             )
-            payments = self.env.cr.dictfetchall()
-        else:
-            payments = []
+            for row in self.env.cr.dictfetchall():
+                foreign_by_key[(row["id"], row["session"])] = row["f_total"]
 
-        return {
-            "date_start": date_start,
-            "date_stop": date_stop,
-            "currency_precision": user_currency.decimal_places,
-            "total_paid": user_currency.round(total),
-            "foreign_total_paid": user_currency.round(f_total),
-            "payments": payments,
-            "currency": self.env.company.currency_id,
-            "foreign_currency": self.env.company.foreign_currency_id,
-            "company_name": self.env.company.name,
-            "taxes": list(taxes.values()),
-            "products": sorted(
-                [
+        for payment in res["payments"]:
+            payment["f_total"] = foreign_by_key.get(
+                (payment.get("id"), payment.get("session")), 0.0
+            )
+
+        payments_per_method = {}
+        for payment in res["payments"]:
+            if payment.get("id"):
+                entry = payments_per_method.setdefault(
+                    payment["id"],
                     {
-                        "product_id": product.id,
-                        "product_name": product.name,
-                        "code": product.default_code,
-                        "quantity": qty,
-                        "price_unit": price_unit,
-                        "discount": discount,
-                        "uom": product.uom_id.name,
-                    }
-                    for (product, price_unit, discount), qty in products_sold.items()
-                ],
-                key=lambda l: l["product_name"],
-            ),
-        }
+                        "id": payment["id"],
+                        "name": self.env["pos.payment.method"].browse(payment["id"]).name,
+                        "total": 0.0,
+                        "f_total": 0.0,
+                    },
+                )
+                entry["total"] += payment["total"]
+                entry["f_total"] += payment["f_total"]
+        res["payments_per_method"] = payments_per_method.values()
+
+        res["foreign_total_paid"] = foreign_currency.round(sum(foreign_by_key.values()))
+        return res

--- a/l10n_ve_pos/views/report_saledetails.xml
+++ b/l10n_ve_pos/views/report_saledetails.xml
@@ -1,99 +1,26 @@
-
 <odoo>
     <data>
-        <template id="report_saledetails" inherit_id="point_of_sale.report_saledetails">
-            <xpath expr="//t[@t-call='point_of_sale.pos_session_sales_details']" position="replace">
-                <div class="page">
-                    <div class="text-center">
-                        <h2>Sales Details</h2>
-
-                        <t t-if="date_start and date_stop">
-                            <strong><t t-out="date_start" t-options="{'widget': 'datetime'}"/> - <t t-out="date_stop" t-options="{'widget': 'datetime'}"/></strong>
-                        </t>
-                    </div>
-
-                    <h3>Payments</h3>
-                    <table  class="table table-sm">
-                        <thead><tr>
-                            <th>Name</th>
-                            <th>Total</th>
-                            <th>Foreign Total</th>
-                        </tr></thead>
-                        <tbody>
-                            <tr t-foreach='payments' t-as='payment' t-key='payment_index'> <!-- or payment.id for the key -->
-                            <td><t t-out="payment['name']" /></td>
-                            <td><t t-out="payment['total']" t-options='{"widget": "monetary", "display_currency": currency}' /></td>
-                            <td><t t-out="payment['f_total']" t-options='{"widget": "monetary", "display_currency": foreign_currency}'/></td>
-                        </tr>
-                        </tbody>
-                    </table>
-
-                    <br/>
-
-                    <strong>Total: <t t-out='total_paid' t-options='{"widget": "monetary", "display_currency": currency}'/></strong>
-                    <br/>
-                    <strong>Foreign Total: <t t-out='foreign_total_paid' t-options='{"widget": "monetary", "display_currency": foreign_currency}'/></strong>
-
-                    <br/>
-                    <br/>
-                    <br/>
-
-                    <h3>Taxes</h3>
-                    <table  class="table table-sm">
-                        <thead><tr>
-                            <th>Name</th>
-                            <th>Tax Amount</th>
-                            <th>Base Amount</th>
-                        </tr></thead>
-                        <tbody>
-                        <tr t-foreach='taxes' t-as='tax'>
-                            <td><t t-out="tax['name']" /></td>
-                            <td><t t-out="tax['tax_amount']" t-options='{"widget": "monetary", "display_currency": currency}'/></td>
-                            <td><t t-out="tax['base_amount']" t-options='{"widget": "monetary", "display_currency": currency}'/></td>
-                        </tr>
-                        </tbody>
-                    </table>
-
-
-                    <br/>
-                    <br/>
-                    <br/>
-
-                    <!-- Orderlines -->
-                    <h3>Products</h3>
-                    <table  class="table table-sm">
-                        <thead><tr>
-                            <th>Product</th>
-                            <th>Quantity</th>
-                            <th>Price Unit</th>
-                        </tr></thead>
-                        <tbody>
-                        <tr t-foreach='products' t-as='line'>
-                            <t t-set="internal_reference" t-value="line['code'] and '[%s] ' % line['code'] or ''" />
-                            <td><t t-out="internal_reference" /><t t-out="line['product_name']" /></td>
-                            <td>
-                                <t t-out="line['quantity']" />
-                                <t t-if='line["uom"] != "Units"'>
-                                    <t t-out='line["uom"]' /> 
-                                </t>
-                            </td>
-                            <td>
-                                <t t-out='line["price_unit"]' t-options='{"widget": "monetary", "display_currency": currency}' />
-                            <t t-if='line["discount"] != 0'>
-                                Disc: <t t-out='line["discount"]' />%
-                            </t>
-                            </td>
-                        </tr>
-                        </tbody>
-                    </table>
-                </div>
+        <template id="pos_session_sales_details_foreign" inherit_id="point_of_sale.pos_session_sales_details">
+            <!-- Per payment method: add the foreign-currency (Bs/USD) equivalent next to the native amount -->
+            <xpath expr="//div[@id='payments']//tr[@t-foreach='payments']/td[@class='text-end']" position="after">
+                <td class="text-end" t-if="foreign_currency">
+                    <t t-out="payment['f_total']" t-options="{'widget': 'monetary', 'display_currency': foreign_currency}"/>
+                </td>
             </xpath>
-            <!-- <xpath expr="//div[@t-if='opening_note or closing_note']" position="replace">
+
+            <!-- Grand total row -->
+            <xpath expr="//div[@id='payments']//tr[@class='fs-5']/th[@class='text-end fw-bolder']" position="after">
+                <th class="text-end fw-bolder" t-if="foreign_currency">
+                    <t t-out="foreign_total_paid" t-options="{'widget': 'monetary', 'display_currency': foreign_currency}"/>
+                </th>
             </xpath>
-            <xpath expr="//t[@id='closing_session']" position="replace">
+
+            <!-- Per payment method breakdown -->
+            <xpath expr="//div[@id='payments']//tr[@t-foreach='payments_per_method']/td[@class='text-end']" position="after">
+                <td class="text-end" t-if="foreign_currency">
+                    <t t-out="ppm['f_total']" t-options="{'widget': 'monetary', 'display_currency': foreign_currency}"/>
+                </td>
             </xpath>
-            <xpath expr="//t[@id='invoices']" position='replace'>
-            </xpath> -->
         </template>
     </data>
 </odoo>

--- a/l10n_ve_pos_mf/static/src/overrides/PosStore.js
+++ b/l10n_ve_pos_mf/static/src/overrides/PosStore.js
@@ -314,7 +314,9 @@ patch(PosStore.prototype, {
           price_unit: amount,
           discount: line.getDiscount(),
           quantity: Math.abs(line.qty),
-          name: this.normalizeProductName(line.product_id?.display_name),
+          name: this.normalizeProductName(
+            String(line.product_id?.display_name || "").replace(/^\[[^\]]*\]\s*/, "")
+          ),
           code: line.product_id?.default_code,
           tax: fiscalCode,
         };


### PR DESCRIPTION
El commit 501a54584 (nov 2025, tarea #59569) comentó "views/report_saledetails.xml" en el manifiesto como fix rápido de un error no relacionado (variantes de producto en Odoo 19), pero dejó vivo el override de get_sale_details() en report/report_saledetails.py, que devolvía "products" como lista plana (forma de dato de v17). Desde entonces la plantilla nativa point_of_sale.pos_session_sales_details (que agrupa productos por categoría) recibía esos datos y fallaba con KeyError: 'name' al pedir "Detalles de venta" desde una sesión de PdV. Llevaba 9 meses así porque nadie había vuelto a imprimir el reporte.

get_sale_details() ahora delega en super() (estructura nativa completa de Odoo 19: categorías, reembolsos, impuestos, descuentos, facturas, arqueo de caja) y agrega encima, sin reemplazarla, la moneda foránea de la compañía: total pagado en Bs/USD y su desglose por método de pago. La vista se reactiva en el manifiesto como inherit_id aditivo sobre la plantilla nativa (antes la reemplazaba por completo), gateada por t-if="foreign_currency" para no afectar compañías sin moneda foránea configurada. Sube versión 1.7 -> 1.8.

Documentado en openspec/changes/l10n-ve-pos-sale-details-report-foreign-totals/.

References: https://binaural.odoo.com/odoo/action-1963/3903/action-345/78328 (Tarea #78328 - Ajustes pendiente de POS V19 - Antes de salida)