### PR TITLE
Asientos de Retenciones (IVA/ISLR) se generan con tasa cero y no reflejan montos en moneda alterna.

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.9",
+    "version": "19.0.1.0.10",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -184,9 +184,9 @@ class AccountMoveLine(models.Model):
         if balance and len(currency_lines) == 1:
             return -balance
 
-        # Third currency (neither base nor alternate)
+        # others currency (neither base nor alternate)
         cur = self.currency_id
-        if cur and cur != self.company_id.foreign_currency_id and cur != self.company_id.currency_id:
+        if cur and cur != self.company_id.foreign_currency_id :
             return self.company_id.currency_id._convert(
                 self.debit - self.credit,
 
@@ -196,7 +196,8 @@ class AccountMoveLine(models.Model):
             )
 
         # Standard rate
-        return (self.debit - self.credit) * self.foreign_inverse_rate if cur != self.company_id.currency_id else (self.debit - self.credit) / self.foreign_inverse_rate 
+        
+        return (self.debit - self.credit) * self.foreign_inverse_rate 
 
     def _get_foreign_value(self):
         """Return the foreign value (signed) for this line, or None."""

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -196,7 +196,7 @@ class AccountMoveLine(models.Model):
             )
 
         # Standard rate
-        return (self.debit - self.credit) * self.foreign_inverse_rate
+        return (self.debit - self.credit) * self.foreign_inverse_rate if cur != self.company_id.currency_id else (self.debit - self.credit) / self.foreign_inverse_rate 
 
     def _get_foreign_value(self):
         """Return the foreign value (signed) for this line, or None."""

--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -28,48 +28,13 @@ class AccountPayment(models.Model):
         "res.currency", default=default_alternate_currency
     )
 
-    def default_rate(self):
-        """
-        This method is used to get the rate of the payment.
-
-        Returns
-        -------
-        type = float
-            The rate of the payment
-        """
-        rate_values = self.env["res.currency.rate"].compute_rate(
-            self.foreign_currency_id.id or self.company_id.currency_id,
-            self.date or fields.Date.today(),
-        )
-        rate = rate_values.get("foreign_rate", 0)
-        return rate
-
-    def default_inverse_rate(self):
-        """
-        This method is used to get the inverse rate of the payment.
-
-        Returns
-        -------
-        type = float
-            The inverse rate of the payment
-        """
-        rate_values = self.env["res.currency.rate"].compute_rate(
-            self.foreign_currency_id.id or self.company_id.currency_id,
-            self.date or fields.Date.today(),
-        )
-        rate = rate_values.get("foreign_inverse_rate", 0)
-        return rate
-
-
     foreign_rate = fields.Float(
         compute="_compute_rate",
-        default=default_rate,
         digits="Tasa",
         store=True,
         readonly=False,
     )
     foreign_inverse_rate = fields.Float(
-        default=default_inverse_rate,
         help="Rate that will be used as factor to multiply of the foreign currency for this move.",
         compute="_compute_rate",
         digits=(16, 15),

--- a/l10n_ve_accountant/tests/test_account_payment_rate.py
+++ b/l10n_ve_accountant/tests/test_account_payment_rate.py
@@ -156,7 +156,7 @@ class TestAccountPaymentRate(TransactionCase):
         expected_other_rate = 45.0
         expected_other_inverse_rate = 1.0 / 45.0
 
-        self.assertEqual(payment.foreign_rate, 0.0, "Foreign Rate should be 0.0 for Third Currency (EUR)")
+        self.assertAlmostEqual(payment.foreign_rate, 40.0, places=2, msg="Foreign Rate should be the USD (company foreign currency) rate for any payment")
 
         _logger.info(f"Payment EUR Rates: Other Rate={payment.other_rate}, Other Inverse Rate={payment.other_rate_inverse}")
         

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.21",
+    "version": "19.0.2.0.22",
     "depends": [
         "base",
         "account",
@@ -53,7 +53,6 @@
         "views/account_payment.xml",
         "views/res_partner.xml",
         "views/account_move.xml",
-        "wizard/account_payment_register.xml",
         "wizard/arcv_report.xml",
         "wizard/municipal_retention_xlsx_report.xml",
         "wizard/municipal_retention_patent_report.xml",

--- a/l10n_ve_payment_extension/models/account_payment.py
+++ b/l10n_ve_payment_extension/models/account_payment.py
@@ -49,11 +49,6 @@ class AccountPayment(models.Model):
         compute="_compute_retention_foreign_amount", store=True, copy=False
     )
 
-    @api.depends("date")
-    def _compute_rate(self):
-        to_compute = self.filtered(lambda p: not (p.is_retention and p.foreign_rate))
-        super(AccountPayment, to_compute)._compute_rate()
-
     def _synchronize_to_moves(self, changed_fields):
         """
         Override the original method to change the name of the move based on the retention type

--- a/l10n_ve_payment_extension/tests/test_payment_retention.py
+++ b/l10n_ve_payment_extension/tests/test_payment_retention.py
@@ -35,11 +35,26 @@ class TestPaymentRetention(RetentionTestCommon):
         retention.action_post()
         return retention
 
-    def test_01_compute_rate_skips_retention(self):
+    def test_01_compute_rate_retention(self):
         retention = self._create_retention_with_payment()
         for payment in retention.payment_ids:
             payment._compute_rate()
-        _logger.info("========= test_01_compute_rate_skips_retention passed =========")
+        _logger.info("========= test_01_compute_rate_retention passed =========")
+
+    def test_rate_computed_on_payment(self):
+        retention = self._create_retention_with_payment()
+        payment = retention.payment_ids[0]
+        _logger.info(
+            "PAYMENT foreign_rate=%s foreign_inverse_rate=%s foreign_currency_id=%s date=%s rate_table=%s",
+            payment.foreign_rate,
+            payment.foreign_inverse_rate,
+            payment.foreign_currency_id.name,
+            payment.date,
+            self.rate,
+        )
+        self.assertTrue(payment.foreign_rate > 0)
+        self.assertAlmostEqual(payment.foreign_rate, self.rate, places=2)
+        _logger.info("========= test_rate_computed_on_payment passed =========")
 
     def test_02_synchronize_to_moves_municipal(self):
         invoice = self._create_invoice_reten_iva(

--- a/l10n_ve_payment_extension/wizard/account_payment_register.py
+++ b/l10n_ve_payment_extension/wizard/account_payment_register.py
@@ -155,8 +155,6 @@ class AccountPaymentRegister(models.TransientModel):
             ]
             payment.journal_id = self.env.company.iva_customer_retention_journal_id.id
             payment.compute_retention_amount_from_retention_lines()
-            payment.foreign_rate = vals["to_reconcile"].move_id.foreign_rate
-            payment.foreign_inverse_rate = vals["to_reconcile"].move_id.foreign_inverse_rate
         retention = self._create_retention(payments)
         retention.action_post()
         return payments


### PR DESCRIPTION
[FIX] #14380: l10n_ve_accountant, l10n_ve_payment_extension
Problema: Los montos alternos (foreign_rate/foreign_inverse_rate) en los pagos generados desde retenciones quedaban en 0. foreign_rate y foreign_inverse_rate son campos computados almacenados que tenían default=; al crear el pago el ORM inyecta ese default en los vals del create, por lo que los marca como protected y los excluye del recompute de _compute_rate. Además, un override en l10n_ve_payment_extension salteaba el cálculo para retenciones y el wizard forzaba la tasa de la factura.

Solución: Se eliminan los defaults de foreign_rate y foreign_inverse_rate para que la tasa se compute automáticamente desde res.currency.rate según la fecha del pago; se quita el override de _compute_rate y el forzado de la tasa de la factura en el wizard; se corrige el monto alterno en _get_non_invoice_foreign_value cuando la línea está en la moneda de la compañía; y se elimina del manifest la vista del wizard de retención que ya no se usa. Se añade test de regresión test_rate_computed_on_payment.

Ticket: https://www.binauraldev.com/odoo/helpdesk/58/tickets/14380