### PR TITLE
[FIX] l10n_ve_pos: el PdV no cargaba las listas de precios encadenadas más allá del primer nivel

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "1.8",
+    "version": "1.9",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/models/__init__.py
+++ b/l10n_ve_pos/models/__init__.py
@@ -11,6 +11,7 @@ from . import pos_payment
 from . import account_move
 from . import stock_picking
 from . import product_product
+from . import product_pricelist
 from . import res_currency
 from . import account_tax
 from . import product_category

--- a/l10n_ve_pos/models/pos_session.py
+++ b/l10n_ve_pos/models/pos_session.py
@@ -25,6 +25,89 @@ class PosSession(models.Model):
         """
         return super().load_data(models_to_load)
 
+    def get_pos_ui_product_pricelist_item_by_product(
+        self, product_tmpl_ids, product_ids, config_id
+    ):
+        """Agrega los items de las listas BASE de la cadena.
+
+        El core restringe el dominio a ``config._get_available_pricelists()``
+        (ver ``point_of_sale/models/pos_session.py``). Las listas base de la
+        cadena no están entre las disponibles — no pueden estarlo, porque
+        ``pos.config`` exige que toda lista disponible tenga la moneda del PdV
+        (constraint en ``pos_config.py``) y las listas base están justamente en
+        otra moneda. Resultado: los productos que entran por búsqueda
+        on-demand llegan sin los items donde viven los precios fijos, y
+        ``getPrice()`` cae a ``list_price``.
+
+        Se llama al core y se le suman los items faltantes, en vez de
+        reimplementar el método, para no heredar su mantenimiento.
+
+        KEEP IN SYNC WITH:
+          ``models/product_pricelist.py`` :: ``_load_pos_data_domain``
+          (la carga inicial debe cubrir las mismas listas que esta).
+        """
+        res = super().get_pos_ui_product_pricelist_item_by_product(
+            product_tmpl_ids, product_ids, config_id
+        )
+
+        pos_config = self.env["pos.config"].browse(config_id)
+        available_ids = set(pos_config._get_available_pricelists().ids)
+        chain_ids = self.env["product.pricelist"]._pos_expand_base_pricelists(
+            available_ids
+        )
+        missing_ids = chain_ids - available_ids
+        if not missing_ids:
+            return res
+
+        item_model = self.env["product.pricelist.item"]
+        today = fields.Date.today()
+        # Espejo del dominio del core, cambiando solo el conjunto de listas.
+        item_domain = [
+            "&",
+            ("pricelist_id", "in", list(missing_ids)),
+            *item_model._check_company_domain(self.company_id),
+            "|",
+            "&",
+            ("product_id", "=", False),
+            ("product_tmpl_id", "in", product_tmpl_ids),
+            ("product_id", "in", product_ids),
+            "|",
+            ("date_start", "=", False),
+            ("date_start", "<=", today),
+            "|",
+            ("date_end", "=", False),
+            ("date_end", ">=", today),
+        ]
+        extra_items = item_model.search(item_domain)
+        if not extra_items:
+            return res
+
+        # Dedup por id: si el core alguna vez amplía su propio conjunto de
+        # listas, no queremos entregar el mismo item dos veces.
+        known_item_ids = {item["id"] for item in res.get("product.pricelist.item", [])}
+        extra_items = extra_items.filtered(lambda item: item.id not in known_item_ids)
+        if not extra_items:
+            return res
+
+        item_fields = item_model._load_pos_data_fields(pos_config)
+        res["product.pricelist.item"] += extra_items.read(item_fields, load=False)
+
+        # Las listas base también tienen que viajar: sin el registro de la
+        # lista, el many2one ``base_pricelist_id`` del item no resuelve en el
+        # navegador y volvemos al mismo fallback silencioso.
+        pricelist_model = self.env["product.pricelist"]
+        known_pricelist_ids = {p["id"] for p in res.get("product.pricelist", [])}
+        extra_pricelists = extra_items.pricelist_id.filtered(
+            lambda pricelist: pricelist.id not in known_pricelist_ids
+        )
+        if extra_pricelists:
+            pricelist_fields = pricelist_model._load_pos_data_fields(pos_config)
+            res["product.pricelist"] += extra_pricelists.read(
+                pricelist_fields, load=False
+            )
+
+        return res
+
     def _validate_cross_move(self):
         """Create the moves that clear each foreign-currency payment method's
         transitory account into its real ``cross_journal`` account.

--- a/l10n_ve_pos/models/product_pricelist.py
+++ b/l10n_ve_pos/models/product_pricelist.py
@@ -1,0 +1,144 @@
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+# Campos de ``product.pricelist.item`` cuyo valor es un monto ABSOLUTO en la
+# moneda de la lista (a diferencia de los porcentuales, que son invariantes de
+# escala). Ver ``_pos_warn_absolute_amounts_in_chain``.
+_ABSOLUTE_AMOUNT_FIELDS = (
+    "price_surcharge",
+    "price_round",
+    "price_min_margin",
+    "price_max_margin",
+)
+
+
+class ProductPricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    # -----------------------------------------------------------------------
+    # Carga de listas de precios ENCADENADAS en el PdV (Venezuela)
+    # -----------------------------------------------------------------------
+    #
+    # PROBLEMA QUE RESUELVE:
+    #   El core (``point_of_sale/models/product_pricelist.py`` ::
+    #   ``_load_pos_data_domain``) resuelve las listas base UN SOLO NIVEL:
+    #   busca los items con ``base='pricelist'`` de las listas *disponibles*
+    #   en la caja y agrega sus ``base_pricelist_id``. Si esa lista base a su
+    #   vez se ancla en otra, el tercer eslabón nunca se carga.
+    #
+    #   El patrón venezolano habitual es exactamente una cadena de 2+ niveles:
+    #   la lista operativa en Bs se ancla a una lista de referencia en divisa
+    #   (a veces con una intermedia), y los precios fijos viven SOLO en la
+    #   lista en divisa. Es la forma de no reescribir el catálogo cada vez que
+    #   se mueve la tasa BCV.
+    #
+    #   Cuando falta un eslabón, ``rule.base_pricelist_id`` llega vacío al
+    #   navegador y ``getPrice()``
+    #   (``point_of_sale/static/src/app/models/accounting/product_template_accounting.js``)
+    #   cae a ``list_price`` sin avisar: el ``if (rule.base_pricelist_id)``
+    #   interno corta antes de llamar a la recursión, así que tampoco salta el
+    #   alert "Make sure all pricelists are available in the POS" del core.
+    #   El cajero ve el precio del producto en vez del precio de la lista, y
+    #   como suele ser el mismo placeholder en todo el catálogo, se ve un
+    #   precio uniforme y obviamente equivocado.
+    #
+    #   OJO: el cálculo del core en JS es correcto — convierte hacia la moneda
+    #   de la lista antes de aplicar la regla y de vuelta a la moneda del PdV
+    #   después, así que las cadenas entre monedas dan el mismo número que el
+    #   servidor. El defecto está únicamente en QUÉ se carga, no en cómo se
+    #   calcula. No parchear ``getPrice``.
+    #
+    # KEEP IN SYNC WITH:
+    #   ``models/pos_session.py`` ::
+    #   ``get_pos_ui_product_pricelist_item_by_product`` — la carga on-demand
+    #   de productos debe cubrir las mismas listas que la carga inicial, o los
+    #   productos que entran por búsqueda se quedan sin precio fijo.
+
+    @api.model
+    def _pos_expand_base_pricelists(self, pricelist_ids):
+        """Cierre transitivo de ``pricelist_ids`` siguiendo ``base='pricelist'``.
+
+        Devuelve un ``set`` que incluye las listas de entrada más todas las
+        listas base alcanzables, a cualquier profundidad.
+
+        El guard ``seen`` es defensa en profundidad: ``product.pricelist.item``
+        ya impide ciclos con ``_check_pricelist_recursion``, así que un ciclo no
+        debería existir en base. Pero si llegara uno (datos cargados por SQL
+        saltándose el ORM), el bucle termina en vez de colgar la apertura de la
+        caja.
+        """
+        seen = set(pricelist_ids)
+        pending = set(seen)
+        item_model = self.env["product.pricelist.item"]
+        while pending:
+            found = item_model.search(
+                [
+                    ("pricelist_id", "in", list(pending)),
+                    ("base", "=", "pricelist"),
+                    ("base_pricelist_id", "!=", False),
+                ]
+            ).base_pricelist_id.ids
+            pending = set(found) - seen
+            seen |= pending
+        return seen
+
+    @api.model
+    def _load_pos_data_domain(self, data, config):
+        """Extiende el dominio del core al cierre transitivo de la cadena.
+
+        Se ejecuta el dominio del core con ``search`` en vez de inspeccionar su
+        forma: así seguimos siendo correctos si el core cambia cómo arma la
+        semilla (listas disponibles, presets, etc.).
+        """
+        domain = super()._load_pos_data_domain(data, config)
+        seed = self.search(domain).ids
+        chain = self._pos_expand_base_pricelists(seed)
+        self._pos_warn_absolute_amounts_in_chain(set(chain) - set(seed))
+        return [("id", "in", list(chain))]
+
+    @api.model
+    def _pos_warn_absolute_amounts_in_chain(self, base_pricelist_ids):
+        """Avisa si una lista base usa montos absolutos en su moneda.
+
+        ``models/res_currency.py`` restringe a propósito las monedas que viajan
+        al PdV (compañía + moneda del PdV + divisa), así que la moneda de una
+        lista intermedia normalmente NO se carga. En ``getPrice()`` eso hace
+        que ``needsCurrencyConversion`` sea falso y se salten AMBAS
+        conversiones de ese nivel.
+
+        Para reglas porcentuales da igual: son invariantes de escala y las dos
+        conversiones son inversas exactas, así que el resultado no cambia (caso
+        verificado: cadena Bs → EUR → USD con solo VEF y USD cargadas da el
+        mismo número que el servidor).
+
+        Pero ``price_surcharge`` y compañía son montos absolutos en la moneda
+        de la lista: sin conversión se suman en la escala equivocada. Preferimos
+        avisar antes que devolver un precio plausible y falso.
+        """
+        if not base_pricelist_ids:
+            return
+        risky = self.env["product.pricelist.item"].search(
+            [
+                ("pricelist_id", "in", list(base_pricelist_ids)),
+                "|",
+                "|",
+                ("price_surcharge", "!=", 0),
+                ("price_round", "!=", 0),
+                "|",
+                ("price_min_margin", "!=", 0),
+                ("price_max_margin", "!=", 0),
+            ]
+        )
+        if not risky:
+            return
+        _logger.warning(
+            "PdV: las listas de precios base %s usan montos absolutos (%s) en su "
+            "propia moneda, pero l10n_ve_pos no carga esa moneda en la caja. "
+            "El PdV puede mostrar un precio distinto al del servidor. "
+            "Usa reglas porcentuales en las listas intermedias de la cadena.",
+            risky.pricelist_id.mapped("display_name"),
+            ", ".join(_ABSOLUTE_AMOUNT_FIELDS),
+        )

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-chained-pricelist-loading/proposal.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-chained-pricelist-loading/proposal.md
@@ -1,0 +1,186 @@
+# Fix: el PdV no cargaba las listas de precios encadenadas más allá del primer nivel (l10n_ve_pos)
+
+## Why
+
+Reportado en producción (2doce / INVERSIONES MERCEBAR): la caja mostraba
+**1,16 Bs en todos los productos del catálogo** en vez del precio real.
+
+La configuración del cliente es el patrón venezolano habitual, y es correcta:
+
+| Lista | Moneda | Contenido |
+|---|---|---|
+| `DETAL VEF` (operativa, la única disponible en la caja) | VEF | 1 item global `formula`, `base=pricelist` → `Detal Euro` |
+| `Detal Euro` (intermedia) | EUR | 1 item global `formula`, `base=pricelist` → `BASE USD` |
+| `BASE USD` (referencia) | USD | 9.857 items `fixed`, uno por producto |
+
+Los precios fijos viven solo en la lista en divisa: es la forma de no reescribir
+el catálogo cada vez que se mueve la tasa BCV. Los `list_price` de los productos
+son un placeholder (1,0 en los 9.857).
+
+**El servidor resuelve la cadena bien.** Verificado con
+`product.pricelist._get_product_price`: 2,00 USD → 1,7340 EUR → 1.493,26 Bs.
+Ventas y facturación nunca estuvieron afectadas; el problema era solo del PdV.
+
+La causa está en QUÉ se carga en la caja, no en cómo se calcula. El core
+(`point_of_sale/models/product_pricelist.py` :: `_load_pos_data_domain`) resuelve
+las listas base **un solo nivel**:
+
+```python
+all_ids = config._get_available_pricelists().ids + pricelist_ids   # → [DETAL VEF]
+referenced_base_pricelist_ids = self.env['product.pricelist.item'].search([
+    ('pricelist_id', 'in', all_ids),        # solo busca en las disponibles
+    ('base', '=', 'pricelist'),
+    ('base_pricelist_id', '!=', False),
+]).base_pricelist_id.ids                     # → [Detal Euro] y se detiene
+return [('id', 'in', list(set(all_ids + referenced_base_pricelist_ids)))]
+```
+
+Encuentra `DETAL VEF → Detal Euro` y para. Nunca descubre
+`Detal Euro → BASE USD`. Medido con `pos.session.load_data([])` en la base del
+cliente: llegaban 2 listas y 2 items (los dos globales), **cero items de
+`BASE USD`**.
+
+Con el eslabón ausente, `rule.base_pricelist_id` llega vacío al navegador y en
+`getPrice()`
+(`point_of_sale/static/src/app/models/accounting/product_template_accounting.js`)
+el `if (rule.base_pricelist_id)` interno no entra, así que el precio se queda en
+`list_price`. Las dos conversiones EUR del nivel intermedio son inversas exactas
+y se cancelan (×0,00116 × 861,19 = 1,0), y el resultado sale
+`1,00 + 16% IVA = 1,16` — idéntico en todo el catálogo, que es exactamente el
+síntoma reportado.
+
+Falla **en silencio**: el alert del core ("Make sure all pricelists are available
+in the POS") solo salta si la lista recursada llega vacía a `getPrice()`, y aquí
+el `if` corta antes de llamar a la recursión.
+
+Se descartó explícitamente que el cálculo en JS estuviera mal. `getPrice()`
+convierte hacia la moneda de la lista antes de aplicar la regla y **de vuelta**
+a la moneda del PdV después (dos bloques `needsCurrencyConversion` simétricos),
+así que las cadenas entre monedas dan el mismo número que el servidor. **No hay
+que parchear `getPrice`.**
+
+Se encontró además un segundo hueco en la misma familia, que habría quedado
+latente al arreglar solo el primero: la carga **on-demand** de productos
+(`pos.session.get_pos_ui_product_pricelist_item_by_product`, usada por
+`product.template.load_product_from_pos` cuando el cajero busca un producto que
+no vino en la carga inicial) restringe los items a
+`config._get_available_pricelists()`. Las listas base **nunca** pueden estar ahí:
+`pos.config` exige que toda lista disponible tenga la moneda del PdV
+(constraint en `pos_config.py`) y las listas base están justamente en otra
+moneda. Así que cualquier producto que entre por búsqueda llegaba sin su precio
+fijo, sin importar el límite de carga.
+
+## What Changes
+
+- **Nuevo `models/product_pricelist.py`**:
+  - `_pos_expand_base_pricelists(pricelist_ids)`: calcula el **cierre
+    transitivo** de las listas base siguiendo `base='pricelist'`, a cualquier
+    profundidad. Nunca reexpande una lista ya vista, así que termina aunque los
+    datos traigan un ciclo — defensa en profundidad, porque
+    `_check_pricelist_recursion` ya impide crearlos por el ORM.
+  - `_load_pos_data_domain()`: extiende el dominio del core al cierre. Ejecuta
+    el dominio del core con `search` en vez de inspeccionar su forma, para
+    seguir siendo correctos si el core cambia cómo arma la semilla (listas
+    disponibles, presets, etc.).
+  - `_pos_warn_absolute_amounts_in_chain()`: ver "Limitación conocida".
+- **`models/pos_session.py`**: nuevo override de
+  `get_pos_ui_product_pricelist_item_by_product()`. Llama al core y le **suma**
+  los items de las listas base que el core excluye (más los registros de esas
+  listas, sin los cuales el many2one `base_pricelist_id` no resuelve en el
+  navegador). Se suma en vez de reimplementar el método para no heredar su
+  mantenimiento; el dominio de los items extra es espejo del del core cambiando
+  solo el conjunto de listas.
+- **`models/__init__.py`**: registra `product_pricelist`.
+- **Nuevo `tests/test_pos_pricelist_chain_loading.py`** (slice_b): reproduce la
+  cadena Bs → EUR → USD de 3 niveles y fija el contrato — cierre transitivo,
+  terminación con ciclos, listas e items en la carga inicial, items en la carga
+  on-demand, y paridad con el cálculo del servidor.
+
+## Verificación
+
+Medido contra la base del cliente (`dosdoce`, 9.857 productos), antes y después:
+
+| | antes | después |
+|---|---|---|
+| `product.pricelist` cargadas | 2 | **3** |
+| `product.pricelist.item` cargados | 2 | **13** (11 de `BASE USD` + 2 globales) |
+
+Se simuló `getPrice()` en Python usando **solo los datos que el loader entrega**
+y se comparó contra `_get_product_price` del servidor para los 16 productos de
+la sesión: **16/16 coinciden** (p. ej. ALIÑO PICADO PARADIS 150GR → 2.239,8891
+Bs en ambos). Los 5 productos sin regla son los de servicio del PdV (Discount,
+Tips, Deposit, Settle Due, Settle Invoice), que legítimamente no tienen item y
+cuyo fallback a `list_price` es el comportamiento correcto.
+
+## Impact
+
+- **Capability**: `pos-chained-pricelist-loading` (nueva).
+- **Módulo**: `l10n_ve_pos`, solo Python (loaders). No toca JS, ni vistas, ni
+  añade campos. Requiere reinicio del servicio; no requiere `-u`.
+- **Cambio de comportamiento visible**: en instalaciones con listas encadenadas
+  de 2+ niveles, la caja pasa a mostrar el precio de la lista en vez del
+  `list_price` del producto. En instalaciones con cadenas de un solo nivel (o
+  sin cadena) no cambia nada: el cierre transitivo devuelve el mismo conjunto
+  que el core.
+- **`point_of_sale.limited_product_count` deja de ser un asunto de
+  corrección.** Antes, un producto fuera del límite de carga nunca obtenía su
+  precio fijo. Con el override on-demand, los productos que entran por búsqueda
+  traen sus items. El parámetro vuelve a ser solo una palanca de rendimiento.
+  (En la base del cliente estaba en 10, lo que agravaba el síntoma pero no era
+  la causa.)
+- **Costo**: una consulta extra por nivel de la cadena en la carga de sesión
+  (cadenas típicas: 2-3 niveles), y una consulta extra en la carga on-demand
+  solo si la cadena tiene listas base. Despreciable frente al resto del payload.
+- **Riesgo de despliegue**: bajo. Ambos overrides solo **agregan** registros al
+  payload; ninguno quita ni reescribe lo que el core ya entregaba.
+
+### Paso de despliegue obligatorio: refrescar las cajas ya abiertas
+
+Reiniciar el servicio **no basta** para las cajas que ya tienen la sesión
+abierta en el navegador. El PdV guarda los datos en IndexedDB y en cargas
+posteriores sincroniza de forma **incremental**: `pos.load.mixin
+::_last_server_date_to_load` (`pos_load_mixin.py:42`) y
+`product.pricelist.item::_server_date_to_domain` filtran por
+`write_date > pos_last_server_date`.
+
+Este fix amplía **qué listas** entran en el alcance del loader, pero los items de
+la lista base ya existían y su `write_date` es viejo, así que el sync incremental
+los descarta. Efecto observado tras desplegar: una ventana nueva (o incógnito)
+muestra los precios correctos, mientras una caja ya abierta sigue mostrando el
+`list_price` aunque el servidor esté corregido.
+
+Hay que empujar el `write_date` de los items de las listas base para que el
+siguiente sync los baje:
+
+```sql
+UPDATE product_pricelist_item SET write_date = now()
+WHERE pricelist_id IN (<ids de las listas base de la cadena>);
+```
+
+`write_date` es metadata de auditoría: no altera precios ni contabilidad.
+
+La alternativa por navegador (borrar IndexedDB: *Clear site data*, o el botón
+"Delete all indexed DB" del widget de debug del PdV) sirve para una prueba
+puntual pero no escala a varias cajas, y el widget de debug puede no estar
+disponible si otro módulo rompe el bundle de assets del PdV.
+
+### Limitación conocida
+
+`models/res_currency.py` restringe a propósito las monedas que viajan al PdV
+(compañía + moneda del PdV + divisa, "Avoids loading extra currencies present in
+pricelists"), así que la moneda de una lista **intermedia** normalmente no se
+carga. En `getPrice()` eso hace que `needsCurrencyConversion` sea falso y se
+salten ambas conversiones de ese nivel.
+
+Para reglas porcentuales es inocuo: son invariantes de escala y las dos
+conversiones son inversas exactas — verificado en la cadena del cliente, donde
+solo viajan VEF y USD (no EUR) y el resultado igual coincide con el servidor.
+
+Pero `price_surcharge`, `price_round`, `price_min_margin` y `price_max_margin`
+son montos **absolutos** en la moneda de la lista: sin conversión se aplicarían
+en la escala equivocada. No se cambió el contrato de `res_currency.py` (tiene su
+propia razón de ser y un test que lo fija); en su lugar
+`_pos_warn_absolute_amounts_in_chain()` emite un warning al cargar la sesión si
+alguna lista base usa esos campos, para que el caso no devuelva un precio
+plausible y falso en silencio. Si algún cliente necesita recargos absolutos en
+una lista intermedia, hay que resolver primero la carga de monedas de la cadena.

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-chained-pricelist-loading/specs/pos-chained-pricelist-loading/spec.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-chained-pricelist-loading/specs/pos-chained-pricelist-loading/spec.md
@@ -1,0 +1,107 @@
+# Capability: pos-chained-pricelist-loading
+
+Carga en el Punto de Venta de listas de precios encadenadas a cualquier
+profundidad, incluso cuando los eslabones están en monedas distintas a la de la
+caja.
+
+## Contexto
+
+El PdV de Odoo 19 calcula los precios **en el navegador**, con los registros que
+el servidor le precarga. Por eso la corrección del precio depende de que la
+cadena completa de listas viaje al cliente, no solo la lista operativa.
+
+En Venezuela la forma habitual de manejar precios es:
+
+- La lista **operativa** está en Bs (la moneda de la caja y de la compañía) y es
+  la única que puede estar en `pos.config.available_pricelist_ids` — el
+  constraint de `pos.config` exige que toda lista disponible tenga la moneda del
+  PdV.
+- Los **precios fijos** viven en una lista de **referencia en divisa** (USD),
+  para no reescribir el catálogo cada vez que se mueve la tasa BCV.
+- Puede haber listas **intermedias** (p. ej. en EUR) entre ambas.
+
+El `list_price` de los productos suele ser un placeholder sin valor comercial.
+
+## Requisitos
+
+### R1 — La carga inicial de la sesión incluye la cadena completa
+
+`pos.session.load_data()` DEBE entregar todas las listas de precios alcanzables
+desde las listas disponibles de la caja siguiendo items con
+`base='pricelist'`, **a cualquier profundidad**, no solo el primer nivel.
+
+Rationale: el core resuelve un solo nivel. Con un eslabón ausente,
+`rule.base_pricelist_id` llega vacío al navegador, `getPrice()` cae a
+`list_price` y no emite ningún error — el cajero ve un precio equivocado sin
+señal alguna.
+
+### R2 — El cierre transitivo termina siempre
+
+El cálculo de la cadena DEBE terminar aunque los datos contengan un ciclo
+(A→B→A): una lista ya visitada NO se vuelve a expandir.
+
+Nota: `product.pricelist.item._check_pricelist_recursion` ya impide crear ciclos
+por el ORM, así que este requisito es defensa en profundidad para datos cargados
+por SQL. No es una configuración soportada.
+
+### R3 — Los items de las listas base viajan con sus listas
+
+La carga DEBE incluir tanto los `product.pricelist.item` de las listas base como
+los registros `product.pricelist` correspondientes.
+
+Rationale: sin el registro de la lista, el many2one `base_pricelist_id` del item
+no resuelve en el `related_models` del navegador y se cae al mismo fallback
+silencioso que R1 evita.
+
+### R4 — La carga on-demand cubre las mismas listas que la inicial
+
+Cuando el cajero busca un producto que no vino en la carga inicial,
+`pos.session.get_pos_ui_product_pricelist_item_by_product()` DEBE entregar
+también los items de las listas base de la cadena.
+
+Rationale: el core restringe esa ruta a `config._get_available_pricelists()`, y
+las listas base **nunca** pueden estar ahí (están en otra moneda, y el
+constraint de `pos.config` lo prohíbe). Sin esto, el límite
+`point_of_sale.limited_product_count` se convierte en un asunto de corrección y
+no de rendimiento: todo producto fuera del límite quedaría sin precio.
+
+### R5 — El precio en la caja coincide con el del servidor
+
+Para un producto cuyo precio se resuelve por la cadena, el precio calculado en
+el PdV DEBE coincidir con
+`product.pricelist._get_product_price()` del servidor.
+
+Rationale: es la única referencia que garantiza que el ticket, la factura y la
+pantalla digan lo mismo.
+
+### R6 — No se altera el cálculo del precio en el cliente
+
+Esta capability NO modifica `getPrice()`
+(`product_template_accounting.js`). El cálculo del core es correcto: convierte
+hacia la moneda de la lista antes de aplicar la regla y de vuelta a la moneda del
+PdV después, con dos bloques `needsCurrencyConversion` simétricos.
+
+Rationale: queda escrito para evitar que un diagnóstico futuro vuelva a
+sospechar del cálculo. El defecto estaba en **qué** se carga, no en **cómo** se
+calcula.
+
+### R7 — Los montos absolutos en listas intermedias no fallan en silencio
+
+Si una lista base de la cadena usa montos absolutos en su propia moneda
+(`price_surcharge`, `price_round`, `price_min_margin`, `price_max_margin`), el
+sistema DEBE dejar constancia en el log.
+
+Rationale: `res_currency.py` restringe a propósito las monedas que viajan al PdV,
+así que la moneda de una lista intermedia normalmente no se carga y sus dos
+conversiones se saltan. Para reglas porcentuales es inocuo (son invariantes de
+escala y las conversiones son inversas exactas), pero un monto absoluto se
+aplicaría en la escala equivocada. Preferimos un warning a un precio plausible
+y falso.
+
+## Fuera de alcance
+
+- Cargar las monedas de toda la cadena en el PdV. Hoy `res_currency.py` las
+  restringe deliberadamente; levantar esa restricción exige entender qué asume
+  el JS del módulo sobre el conjunto de monedas y es un cambio aparte.
+- Calcular el precio en el servidor para el PdV en vez de precargar el catálogo.
+  Sería un cambio de diseño mayor y no hace falta para corregir este defecto.

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-chained-pricelist-loading/tasks.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-chained-pricelist-loading/tasks.md
@@ -1,0 +1,62 @@
+# Tasks — l10n-ve-pos-chained-pricelist-loading
+
+## Diagnóstico
+
+- [x] Reproducir el síntoma en la base del cliente (`dosdoce`): 1,16 Bs en todo
+      el catálogo.
+- [x] Descartar el servidor: `_get_product_price` sobre la cadena da
+      2,00 USD → 1,7340 EUR → 1.493,26 Bs. Ventas/facturación no afectadas.
+- [x] Descartar que `getPrice()` en JS convierta mal: tiene dos bloques
+      `needsCurrencyConversion` simétricos (hacia la moneda de la lista antes de
+      aplicar la regla, de vuelta a la del PdV después). **No parchear.**
+- [x] Medir el payload real con `pos.session.load_data([])`: 2 listas, 2 items,
+      cero items de `BASE USD`.
+- [x] Ubicar la causa: `product.pricelist._load_pos_data_domain` del core
+      resuelve las listas base un solo nivel.
+- [x] Ubicar el segundo hueco: `get_pos_ui_product_pricelist_item_by_product`
+      restringe a `_get_available_pricelists()`, donde las listas base no pueden
+      estar por el constraint de moneda de `pos.config`.
+
+## Implementación
+
+- [x] `models/product_pricelist.py`: `_pos_expand_base_pricelists()` (cierre
+      transitivo, tolerante a ciclos).
+- [x] `models/product_pricelist.py`: `_load_pos_data_domain()` extendido, sin
+      depender de la forma del dominio del core.
+- [x] `models/product_pricelist.py`: `_pos_warn_absolute_amounts_in_chain()`
+      para que la limitación de monedas no falle en silencio.
+- [x] `models/pos_session.py`: override de
+      `get_pos_ui_product_pricelist_item_by_product()` que suma los items y las
+      listas base que el core excluye.
+- [x] `models/__init__.py`: registrar `product_pricelist`.
+
+## Pruebas
+
+- [x] `tests/test_pos_pricelist_chain_loading.py` (slice_b), cadena de 3 niveles
+      Bs → EUR → USD:
+  - [x] el cierre transitivo alcanza los 3 eslabones
+  - [x] una lista sin cadena devuelve solo a sí misma (el override no cambia
+        nada en instalaciones sin listas encadenadas)
+  - [x] el ORM rechaza los ciclos, así que nunca llegan al loader (el guard
+        `seen` es defensa en profundidad, no manejo de un caso soportado)
+  - [x] la carga inicial incluye la lista base de 2do nivel
+  - [x] la carga inicial incluye los items `fixed` de la lista base
+  - [x] la carga on-demand incluye items y registros de las listas base
+  - [x] el precio de la cadena difiere de `list_price` y coincide con el
+        servidor (test de discriminación: si el escenario diera lo mismo por
+        casualidad, no probaría nada)
+- [x] Verificación contra la base del cliente: simular `getPrice()` usando solo
+      el payload del loader y comparar con el servidor → 16/16 coinciden.
+- [ ] Correr la suite completa de `l10n_ve_pos` para descartar regresiones en
+      los otros slices.
+- [ ] Verificar en el navegador con la caja del cliente (abrir sesión y
+      confirmar que los productos muestran el precio de la lista).
+
+## Pendiente / seguimiento
+
+- [ ] Decidir si la carga de monedas debe cubrir la cadena completa. Hoy
+      `res_currency.py` restringe a compañía + PdV + divisa a propósito; es
+      inocuo para reglas porcentuales pero bloquea recargos absolutos en listas
+      intermedias. Ver "Limitación conocida" en `proposal.md`.
+- [ ] Revisar si `point_of_sale.limited_product_count` en la instancia del
+      cliente debe volver a un valor de rendimiento razonable (estaba en 10).

--- a/l10n_ve_pos/tests/__init__.py
+++ b/l10n_ve_pos/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_pos_data_loading
+from . import test_pos_pricelist_chain_loading
 from . import test_pos_serialization
 from . import test_pos_session_accounting_common
 from . import test_pos_session_accounting_accumulators

--- a/l10n_ve_pos/tests/test_pos_pricelist_chain_loading.py
+++ b/l10n_ve_pos/tests/test_pos_pricelist_chain_loading.py
@@ -1,0 +1,303 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "l10n_ve_pos", "slice_b")
+class TestPosPricelistChainLoading(TransactionCase):
+    """Carga de listas de precios encadenadas en el PdV.
+
+    Contrato en
+    ``openspec/changes/l10n-ve-pos-chained-pricelist-loading/specs/pos-chained-pricelist-loading/spec.md``.
+
+    Escenario venezolano: la lista operativa en Bs se ancla a una lista
+    intermedia en EUR, que se ancla a la lista de referencia en USD donde viven
+    los precios fijos. El core resuelve un solo nivel, así que la lista en USD
+    nunca llegaba a la caja y ``getPrice()`` caía a ``list_price``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.vef = cls.env["res.currency"].with_context(active_test=False).search(
+            [("name", "=", "VEF")], limit=1
+        )
+        if cls.vef and not cls.vef.active:
+            cls.vef.active = True
+        cls.usd = cls.env.ref("base.USD")
+        cls.eur = cls.env.ref("base.EUR")
+        if not cls.eur.active:
+            cls.eur.active = True
+
+        # Compañía en Bs con divisa USD: la forma real de una instalación VE.
+        cls.company = cls.env["res.company"].create(
+            {
+                "name": "Test VE Chain Co",
+                "currency_id": cls.vef.id,
+                "country_id": cls.env.ref("base.ve").id,
+            }
+        )
+        cls.company.write({"foreign_currency_id": cls.usd.id})
+
+        # Tasas relativas a la moneda de la compañía (VEF): 1 VEF = rate divisa.
+        cls.env["res.currency.rate"].search(
+            [("company_id", "=", cls.company.id)]
+        ).unlink()
+        for currency, rate in ((cls.usd, 0.00134), (cls.eur, 0.00116)):
+            cls.env["res.currency.rate"].create(
+                {
+                    "currency_id": currency.id,
+                    "rate": rate,
+                    "name": "2026-01-01",
+                    "company_id": cls.company.id,
+                }
+            )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Producto Cadena",
+                # list_price es un placeholder: el precio real vive en la lista
+                # en USD. Si el PdV cae al fallback, se ve este 1.0.
+                "lst_price": 1.0,
+                "available_in_pos": True,
+            }
+        )
+        cls.fixed_usd_price = 2.0
+
+        # Eslabón 3: precios fijos en USD.
+        cls.pl_usd = cls.env["product.pricelist"].create(
+            {
+                "name": "BASE USD",
+                "currency_id": cls.usd.id,
+                "company_id": cls.company.id,
+                "item_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "applied_on": "1_product",
+                            "product_tmpl_id": cls.product.product_tmpl_id.id,
+                            "compute_price": "fixed",
+                            "fixed_price": cls.fixed_usd_price,
+                        },
+                    )
+                ],
+            }
+        )
+        # Eslabón 2: intermedia en EUR, anclada a la de USD.
+        cls.pl_eur = cls.env["product.pricelist"].create(
+            {
+                "name": "Detal Euro",
+                "currency_id": cls.eur.id,
+                "company_id": cls.company.id,
+                "item_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "applied_on": "3_global",
+                            "compute_price": "formula",
+                            "base": "pricelist",
+                            "base_pricelist_id": cls.pl_usd.id,
+                        },
+                    )
+                ],
+            }
+        )
+        # Eslabón 1: la operativa en Bs, la única disponible en la caja.
+        cls.pl_vef = cls.env["product.pricelist"].create(
+            {
+                "name": "DETAL VEF",
+                "currency_id": cls.vef.id,
+                "company_id": cls.company.id,
+                "item_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "applied_on": "3_global",
+                            "compute_price": "formula",
+                            "base": "pricelist",
+                            "base_pricelist_id": cls.pl_eur.id,
+                        },
+                    )
+                ],
+            }
+        )
+
+        journal = cls.env["account.journal"].create(
+            {
+                "name": "POS Chain Sale",
+                "type": "sale",
+                "code": "POSCH",
+                "company_id": cls.company.id,
+            }
+        )
+        # ``pos.config`` exige que los métodos de pago sean de su compañía; los
+        # que se asignan por defecto pertenecen a otra.
+        cls.payment_method = cls.env["pos.payment.method"].create(
+            {
+                "name": "Efectivo Bs",
+                "is_cash_count": True,
+                "company_id": cls.company.id,
+                "journal_id": cls.env["account.journal"]
+                .create(
+                    {
+                        "name": "POS Chain Cash",
+                        "type": "cash",
+                        "code": "POSCC",
+                        "company_id": cls.company.id,
+                    }
+                )
+                .id,
+            }
+        )
+        cls.config = cls.env["pos.config"].create(
+            {
+                "name": "Test POS Chain",
+                "company_id": cls.company.id,
+                "journal_id": journal.id,
+                "invoice_journal_id": cls.env["account.journal"]
+                .create(
+                    {
+                        "name": "POS Chain Invoice",
+                        "type": "sale",
+                        "code": "POSCI",
+                        "company_id": cls.company.id,
+                    }
+                )
+                .id,
+                "use_pricelist": True,
+                "pricelist_id": cls.pl_vef.id,
+                "available_pricelist_ids": [(6, 0, [cls.pl_vef.id])],
+                "payment_method_ids": [(6, 0, cls.payment_method.ids)],
+            }
+        )
+        cls.session = cls.env["pos.session"].create(
+            {
+                "config_id": cls.config.id,
+                "user_id": cls.env.ref("base.user_admin").id,
+            }
+        )
+
+    # -- cierre transitivo ------------------------------------------------
+
+    def test_expand_base_pricelists_walks_the_whole_chain(self):
+        """El cierre incluye los tres eslabones, no solo el primero."""
+        chain = self.env["product.pricelist"]._pos_expand_base_pricelists(
+            [self.pl_vef.id]
+        )
+        self.assertEqual(
+            chain, {self.pl_vef.id, self.pl_eur.id, self.pl_usd.id}
+        )
+
+    def test_cycles_are_rejected_by_the_orm(self):
+        """Un ciclo nunca llega al loader: el ORM lo rechaza al escribirlo.
+
+        Documenta por qué el guard ``seen`` de ``_pos_expand_base_pricelists``
+        es defensa en profundidad (datos cargados por SQL saltándose el ORM) y
+        no el manejo de una configuración soportada.
+        """
+        self.pl_usd.item_ids.unlink()
+        with self.assertRaises(ValidationError):
+            self.pl_usd.write(
+                {
+                    "item_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "applied_on": "3_global",
+                                "compute_price": "formula",
+                                "base": "pricelist",
+                                "base_pricelist_id": self.pl_vef.id,
+                            },
+                        )
+                    ]
+                }
+            )
+
+    def test_expand_base_pricelists_is_idempotent_on_a_flat_pricelist(self):
+        """Una lista sin cadena devuelve solo a sí misma.
+
+        Fija que el override no cambia nada en instalaciones sin listas
+        encadenadas, que son la mayoría fuera de Venezuela.
+        """
+        flat = self.env["product.pricelist"].create(
+            {
+                "name": "Plana",
+                "currency_id": self.vef.id,
+                "company_id": self.company.id,
+            }
+        )
+        self.assertEqual(
+            self.env["product.pricelist"]._pos_expand_base_pricelists([flat.id]),
+            {flat.id},
+        )
+
+    # -- carga inicial ----------------------------------------------------
+
+    def test_load_data_includes_the_whole_pricelist_chain(self):
+        """La lista base de segundo nivel debe llegar a la caja."""
+        data = self.session.load_data([])
+        loaded_ids = {p["id"] for p in data["product.pricelist"]}
+        self.assertIn(self.pl_vef.id, loaded_ids)
+        self.assertIn(self.pl_eur.id, loaded_ids)
+        self.assertIn(
+            self.pl_usd.id,
+            loaded_ids,
+            "sin la lista base de 2do nivel, getPrice() cae a list_price",
+        )
+
+    def test_load_data_includes_fixed_items_of_the_base_pricelist(self):
+        """Los items donde viven los precios fijos deben viajar también."""
+        data = self.session.load_data([])
+        usd_items = [
+            item
+            for item in data["product.pricelist.item"]
+            if item["pricelist_id"] == self.pl_usd.id
+        ]
+        self.assertTrue(usd_items, "no llegó ningún item de la lista en USD")
+        self.assertEqual(usd_items[0]["fixed_price"], self.fixed_usd_price)
+
+    # -- carga on-demand --------------------------------------------------
+
+    def test_on_demand_product_load_includes_base_pricelist_items(self):
+        """Un producto que entra por búsqueda debe traer su precio fijo.
+
+        El core restringe esta ruta a ``_get_available_pricelists()``, que nunca
+        puede contener las listas base (están en otra moneda y ``pos.config`` lo
+        prohíbe), así que sin el override el producto llega sin precio.
+        """
+        res = self.session.get_pos_ui_product_pricelist_item_by_product(
+            self.product.product_tmpl_id.ids, self.product.ids, self.config.id
+        )
+        item_pricelist_ids = {
+            item["pricelist_id"] for item in res["product.pricelist.item"]
+        }
+        self.assertIn(self.pl_usd.id, item_pricelist_ids)
+        loaded_pricelist_ids = {p["id"] for p in res["product.pricelist"]}
+        self.assertIn(
+            self.pl_usd.id,
+            loaded_pricelist_ids,
+            "sin el registro de la lista, base_pricelist_id no resuelve en el navegador",
+        )
+
+    # -- paridad con el servidor -----------------------------------------
+
+    def test_chain_price_matches_server_side_computation(self):
+        """El precio de la cadena no es el placeholder de ``list_price``.
+
+        Fija la referencia contra la que el PdV debe coincidir: el cálculo del
+        servidor, no 1.0. Con tasas 1 VEF = 0.00134 USD, 2 USD ≈ 1492.54 Bs.
+        """
+        server_price = self.pl_vef.with_company(self.company)._get_product_price(
+            self.product, 1.0
+        )
+        self.assertNotAlmostEqual(
+            server_price,
+            self.product.lst_price,
+            places=2,
+            msg="el escenario no discrimina: la cadena da lo mismo que list_price",
+        )
+        expected = self.fixed_usd_price / 0.00134
+        self.assertAlmostEqual(server_price, expected, delta=1.0)


### PR DESCRIPTION
Reportado en producción (2doce / INVERSIONES MERCEBAR): la caja mostraba **1,16 Bs en todos los productos** del catálogo. La configuración del cliente es el patrón venezolano habitual y es correcta — `DETAL VEF` (Bs, la única disponible en la caja) anclada a `Detal Euro` (EUR), anclada a `BASE USD` (USD) donde viven los 9.857 precios fijos, uno por producto. Los `list_price` son un placeholder (1,0 en todos). El servidor resuelve la cadena bien: `_get_product_price` da 2,00 USD → 1,7340 EUR → 1.493,26 Bs, así que ventas y facturación nunca estuvieron afectadas.

El PdV de Odoo 19 calcula los precios en el navegador, y los loaders del core solo resuelven **un nivel** de listas base. `product.pricelist._load_pos_data_domain` busca los items `base='pricelist'` de las listas disponibles y agrega sus `base_pricelist_id` sin recursar: encontraba `Detal Euro` y se detenía, así que `BASE USD` nunca llegaba al navegador. Sin ese eslabón, `rule.base_pricelist_id` llega vacío, el `if` interno de `getPrice()` no entra y el precio se queda en `list_price` — 1,00 + 16% IVA = 1,16, idéntico en todo el catálogo. Falla en silencio: el alert del core ("Make sure all pricelists are available in the POS") solo salta si la lista recursada llega vacía a `getPrice()`, y el `if` corta antes de llamar a la recursión. Medido con `pos.session.load_data([])` en la base del cliente: llegaban 2 listas y 2 items, cero items de `BASE USD`.

Se encontró un segundo hueco de la misma familia, que habría quedado latente al arreglar solo el primero: `pos.session.get_pos_ui_product_pricelist_item_by_product` (la ruta on-demand que usa `load_product_from_pos` cuando el cajero busca un producto que no vino en la carga inicial) restringe los items a `config._get_available_pricelists()`. Las listas base nunca pueden estar ahí, porque `pos.config` exige que toda lista disponible tenga la moneda del PdV y las listas base están justamente en otra moneda. Cualquier producto que entrara por búsqueda quedaba sin precio fijo, sin importar `limited_product_count`.

El nuevo `models/product_pricelist.py` agrega `_pos_expand_base_pricelists()`, que calcula el **cierre transitivo** de la cadena a cualquier profundidad, y `_load_pos_data_domain()`, que lo aplica ejecutando el dominio del core con `search` en vez de inspeccionar su forma — así no se rompe si el core cambia cómo arma la semilla (presets, listas disponibles). El override en `pos_session.py` llama al core y le **suma** los items y registros de las listas base que excluye, con dedup por id, en vez de reimplementar el método. Ambos overrides solo agregan registros al payload; ninguno quita ni reescribe lo que el core ya entregaba, por eso en instalaciones sin listas encadenadas el resultado es idéntico al actual (hay una prueba que lo fija).

**El cálculo en JS del core es correcto y no se parchea.** `getPrice()` convierte hacia la moneda de la lista antes de aplicar la regla y de vuelta a la del PdV después, con dos bloques `needsCurrencyConversion` simétricos, así que las cadenas entre monedas dan el mismo número que el servidor. Queda fijado como requisito R6 del spec para que un diagnóstico futuro no vuelva a sospechar del cálculo.

Verificación contra la base del cliente (9.857 productos): el payload pasó de 2 listas y 2 items a 3 listas y 13 items. Se simuló `getPrice()` en Python usando **solo los datos que entrega el loader** y se comparó contra `_get_product_price` para los 16 productos de la sesión: **16/16 coinciden** (p. ej. ALIÑO PICADO PARADIS 150GR → 2.239,8891 Bs en ambos). Los 5 productos sin regla son los de servicio del PdV (Discount, Tips, Deposit, Settle Due, Settle Invoice), que legítimamente no tienen item y cuyo fallback a `list_price` es el comportamiento correcto.

**Nota de despliegue:** reiniciar el servicio no basta para cajas ya abiertas. El PdV sincroniza incrementalmente por `write_date` (`pos.load.mixin::_last_server_date_to_load`, `product.pricelist.item::_server_date_to_domain`), y los items de la lista base ya existían con `write_date` viejo, así que el sync los descarta. Efecto observado: una ventana nueva muestra los precios correctos mientras una caja ya abierta sigue mostrando el `list_price`. Hay que empujar el `write_date` de esos items; documentado en `proposal.md`.

7 pruebas nuevas en `tests/test_pos_pricelist_chain_loading.py` (slice_b) sobre una cadena de 3 niveles Bs → EUR → USD. Los 3 errores de `TestPosSessionAccountingMoveCreation` y `TestPosSessionCrossAccountMove` **ya venían de `origin/19.0`** — verificado corriendo la suite con los cambios guardados en stash sobre árbol limpio: baseline 50 tests / 3 errores, con el fix 57 tests / los mismos 3 errores.

Sube versión 1.8 -> 1.9. Documentado en `openspec/changes/l10n-ve-pos-chained-pricelist-loading/`.

Sin tarea de Odoo asociada — el diagnóstico salió de una revisión del ambiente local de 2doce, no de un ticket. De paso se detectó un problema **no relacionado** con este cambio, en `integra-addons` (imports JS inexistentes en Odoo 19 en `binaural_pos_discount` y `binaural_subsidiary_pos_hr` que rompen el bundle de assets del PdV): ticket #14424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)