### PR TITLE
FIX(l10n_ve_invoice_digital):

### DIFF
--- a/l10n_ve_invoice_digital/__manifest__.py
+++ b/l10n_ve_invoice_digital/__manifest__.py
@@ -4,7 +4,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.0.0.19",
+    "version": "17.0.0.0.20",
     "depends": [
         "account",
         "l10n_ve_igtf",

--- a/l10n_ve_invoice_digital/i18n/es_VE.po
+++ b/l10n_ve_invoice_digital/i18n/es_VE.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e-20251016\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-04 22:56+0000\n"
-"PO-Revision-Date: 2025-11-04 22:56+0000\n"
+"POT-Creation-Date: 2026-08-01 21:46+0000\n"
+"PO-Revision-Date: 2026-08-01 21:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr "Creado el"
 #. module: l10n_ve_invoice_digital
 #: model:ir.model,name:l10n_ve_invoice_digital.model_res_currency
 msgid "Currency"
-msgstr "Divisa"
+msgstr "Moneda"
 
 #. module: l10n_ve_invoice_digital
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_payment_method_tfhka__description
@@ -110,9 +110,6 @@ msgid "Digitalization With Payment Tfhka"
 msgstr "Digitalización con Pago Tfhka"
 
 #. module: l10n_ve_invoice_digital
-#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_bank_statement_line__is_digitalized
-#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_move__is_digitalized
-#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_payment__is_digitalized
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_retention__is_digitalized
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_move_form_inherit
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_retention_islr_form_l10n_ve_payment_extension_inherit
@@ -163,9 +160,9 @@ msgstr "Error 401: Token no válido o caducado."
 #. module: l10n_ve_invoice_digital
 #. odoo-python
 #: code:addons/l10n_ve_invoice_digital/models/account_move.py:0
-#: code:addons/l10n_ve_invoice_digital/models/account_move.py:0
 #: code:addons/l10n_ve_invoice_digital/models/account_retention.py:0
-#: code:addons/l10n_ve_invoice_digital/models/account_retention.py:0
+#: code:addons/odoo-venezuela/l10n_ve_invoice_digital/models/account_move.py:0
+#: code:addons/odoo-venezuela/l10n_ve_invoice_digital/models/account_retention.py:0
 #, python-format
 msgid "Error connecting to the API: %(error)s"
 msgstr "Error al conectar con la API: %(error)s"
@@ -180,9 +177,9 @@ msgstr "Error al conectar con la API de TFHKA: %s"
 #. module: l10n_ve_invoice_digital
 #. odoo-python
 #: code:addons/l10n_ve_invoice_digital/models/account_move.py:0
-#: code:addons/l10n_ve_invoice_digital/models/account_move.py:0
 #: code:addons/l10n_ve_invoice_digital/models/account_retention.py:0
-#: code:addons/l10n_ve_invoice_digital/models/account_retention.py:0
+#: code:addons/odoo-venezuela/l10n_ve_invoice_digital/models/account_move.py:0
+#: code:addons/odoo-venezuela/l10n_ve_invoice_digital/models/account_retention.py:0
 #, python-format
 msgid ""
 "Error in the API response: %(message)s \n"
@@ -239,9 +236,9 @@ msgstr "Generar Token para TFHKA."
 #. module: l10n_ve_invoice_digital
 #. odoo-python
 #: code:addons/l10n_ve_invoice_digital/models/account_move.py:0
-#: code:addons/l10n_ve_invoice_digital/models/account_move.py:0
 #: code:addons/l10n_ve_invoice_digital/models/account_retention.py:0
-#: code:addons/l10n_ve_invoice_digital/models/account_retention.py:0
+#: code:addons/odoo-venezuela/l10n_ve_invoice_digital/models/account_move.py:0
+#: code:addons/odoo-venezuela/l10n_ve_invoice_digital/models/account_retention.py:0
 #, python-format
 msgid "HTTP error %(status_code)s: %(text)s"
 msgstr "Error HTTP %(status_code)s: %(text)s"
@@ -261,6 +258,13 @@ msgstr "Factura Digital"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_company__invoice_digital_tfhka
 msgid "Invoice Digital Tfhka"
 msgstr "Factura Digital Tfhka"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_bank_statement_line__is_digitalized
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_move__is_digitalized
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_payment__is_digitalized
+msgid "Is Digitalized"
+msgstr "Digitalizado"
 
 #. module: l10n_ve_invoice_digital
 #: model:ir.model,name:l10n_ve_invoice_digital.model_account_journal
@@ -405,7 +409,7 @@ msgstr ""
 #, python-format
 msgid "The 'NIF' field of the Customer cannot be empty for digitalization."
 msgstr ""
-"El campo ‘NIF’ del Cliente no puede estar vacío para la digitalización."
+"El campo 'RIF' del Cliente no puede estar vacío para la digitalización."
 
 #. module: l10n_ve_invoice_digital
 #. odoo-python
@@ -441,22 +445,39 @@ msgstr "El documento ya ha sido digitalizado."
 #: code:addons/l10n_ve_invoice_digital/models/account_retention.py:0
 #, python-format
 msgid ""
-"The document sequence in Odoo (%(odoo_seq)s) does not match the sequence in The "
-"Factory (%(factory_seq)s). Do you want to continue anyway?"
+"The document sequence in Odoo (%(odoo_seq)s) does not match the sequence in "
+"The Factory (%(factory_seq)s). Do you want to continue anyway?"
 msgstr ""
-"La secuencia de documentos en Odoo (%(odoo_seq)s) no coincide con la secuencia en The "
-"Factory (%(factory_seq)s). ¿Desea continuar de todas formas?"
+"La secuencia de documentos en Odoo (%(odoo_seq)s) no coincide con la "
+"secuencia en The Factory (%(factory_seq)s). ¿Desea continuar de todas "
+"formas?"
 
 #. module: l10n_ve_invoice_digital
 #. odoo-python
 #: code:addons/l10n_ve_invoice_digital/models/account_move.py:0
+#: code:addons/odoo-venezuela/l10n_ve_invoice_digital/models/account_move.py:0
 #, python-format
 msgid ""
-"The document sequence in Odoo (%(odoo_seq)s) does not match the sequence in The "
-"Factory (%(factory_seq)s).Please check your numbering settings."
+"The document sequence in Odoo (%(odoo_seq)s) does not match the sequence in "
+"The Factory (%(factory_seq)s).Please check your numbering settings."
 msgstr ""
-"La secuencia de documentos en Odoo (%(odoo_seq)s) no coincide con la secuencia en The "
-"Factory (%(factory_seq)s). Verifique su configuración de numeración."
+"La secuencia de documentos en Odoo (%(odoo_seq)s) no coincide con la "
+"secuencia en The Factory (%(factory_seq)s). Verifique su configuración de "
+"numeración."
+
+#. module: l10n_ve_invoice_digital
+#. odoo-python
+#: code:addons/l10n_ve_invoice_digital/models/account_move.py:0
+#: code:addons/odoo-venezuela/l10n_ve_invoice_digital/models/account_move.py:0
+#, python-format
+msgid ""
+"The emission date of the current invoice is earlier than the date of the "
+"last digitalized invoice (%(invoice_date)s). This could cause sequence "
+"inconsistencies."
+msgstr ""
+"La fecha de emisión de la factura actual es anterior a la fecha de la "
+"última factura digitalizada (%(invoice_date)s). Esto podría provocar "
+"inconsistencias en la secuencia."
 
 #. module: l10n_ve_invoice_digital
 #. odoo-python
@@ -566,6 +587,11 @@ msgid "URL"
 msgstr ""
 
 #. module: l10n_ve_invoice_digital
+#: model:ir.model.fields.selection,name:l10n_ve_invoice_digital.selection__account_move__line_currency__usd
+msgid "USD"
+msgstr ""
+
+#. module: l10n_ve_invoice_digital
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_company__url_tfhka
 msgid "Url Tfhka"
 msgstr "URL Tfhka"
@@ -580,6 +606,20 @@ msgstr "Nombre de Usuario"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_company__username_tfhka
 msgid "Username Tfhka"
 msgstr "Nombre de Usuario Tfhka"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields.selection,name:l10n_ve_invoice_digital.selection__account_move__line_currency__ves
+msgid "VES"
+msgstr ""
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,help:l10n_ve_invoice_digital.field_account_bank_statement_line__line_currency
+#: model:ir.model.fields,help:l10n_ve_invoice_digital.field_account_move__line_currency
+#: model:ir.model.fields,help:l10n_ve_invoice_digital.field_account_payment__line_currency
+msgid ""
+"VES: precios de líneas en Bolívares, totales solo en VES.\n"
+"USD: precios de líneas en dólares, totales en ambas monedas."
+msgstr ""
 
 #. module: l10n_ve_invoice_digital
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.account_retention_alert_wizard
@@ -601,6 +641,33 @@ msgid ""
 msgstr ""
 "Advertencia aceptada: Se reconoce y acepta la diferencia de secuencia entre "
 "Odoo y The Factory."
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,help:l10n_ve_invoice_digital.field_res_company__multi_currency_invoice_tfhka
+#: model:ir.model.fields,help:l10n_ve_invoice_digital.field_res_config_settings__multi_currency_invoice_tfhka
+msgid ""
+"When enabled, invoices can be digitalized with multi-currency support (VES "
+"or USD line prices + dual totals if USD selected). An additional checkbox + "
+"currency selector will appear on each invoice."
+msgstr ""
+"Al activarse, las facturas se pueden digitalizar con soporte multi-moneda "
+"(precios de línea en VES o USD + totales duales si se selecciona USD). "
+"Aparecerá una casilla adicional y un selector de moneda en cada factura."
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,help:l10n_ve_invoice_digital.field_account_bank_statement_line__multi_currency_invoice
+#: model:ir.model.fields,help:l10n_ve_invoice_digital.field_account_move__multi_currency_invoice
+#: model:ir.model.fields,help:l10n_ve_invoice_digital.field_account_payment__multi_currency_invoice
+msgid ""
+"When enabled, the 'Line Currency' selector appears, allowing you to choose "
+"VES (prices in Bolivars, totals in VES) or USD (prices in USD, totals in "
+"both currencies). Requires 'Multi-currency digital invoicing' in company "
+"settings."
+msgstr ""
+"Al activarse, aparece el selector 'Moneda de Línea', que permite elegir VES "
+"(precios en Bolívares, totales en VES) o USD (precios en USD, totales en "
+"ambas monedas). Requiere 'Facturación digital multi-moneda' en los ajustes "
+"de la compañía."
 
 #. module: l10n_ve_invoice_digital
 #. odoo-python

--- a/l10n_ve_invoice_digital/models/account_move.py
+++ b/l10n_ve_invoice_digital/models/account_move.py
@@ -23,6 +23,128 @@ class AccountMove(models.Model):
     show_digital_debit_note = fields.Boolean(string="Show Digital Note Debit", compute="_compute_invisible_check", copy=False)
     show_digital_credit_note = fields.Boolean(string="Show Digital Note Credit", compute="_compute_invisible_check", copy=False)
 
+    def action_post(self):
+        for invoice in self:
+            invoice._tfhka_validate_mixed_invoicing()
+            invoice._tfhka_validate_invoice_date()
+
+        res = super(AccountMove, self).action_post()
+        return res
+
+    def _tfhka_validate_invoice_date(self):
+        """Validates that the emission date of the current invoice is not earlier than the date of the last digitalized invoice."""
+        self.ensure_one()
+        if not self._is_eligible_for_tfhka():
+            return
+
+        domain = [
+            ("state", "=", "posted"),
+            ("journal_id.digital_invoice", "=", True),
+            ("journal_id", "=", self.journal_id.id),
+            ("move_type", "=", self.move_type),
+            ("is_digitalized", "=", True),
+        ]
+
+        last_invoice = self.env["account.move"].search(
+            domain, order="invoice_date desc, name desc", limit=1
+        )
+
+        current_invoice_date = self.invoice_date or fields.Date.today()
+
+        if last_invoice and last_invoice.invoice_date:
+            if current_invoice_date < last_invoice.invoice_date:
+                raise ValidationError(
+                    _(
+                        "The emission date of the current invoice is earlier than the date of the last digitalized invoice (%(invoice_date)s). "
+                        "This could cause sequence inconsistencies.",
+                        invoice_date=last_invoice.invoice_date,
+                    )
+                )
+
+    def _is_eligible_for_tfhka(self):
+        """Check if the invoice should process TFHKA logic."""
+        self.ensure_one()
+        config_invoice_can_be_digitalized = self.company_id.invoice_digital_tfhka
+        if not self.journal_id.digital_invoice or not config_invoice_can_be_digitalized:
+            return False
+        if self.move_type not in ("out_invoice", "out_refund"):
+            return False
+        return True
+
+    def _tfhka_validate_mixed_invoicing(self):
+        """Validates if mixed invoicing is allowed."""
+        self.ensure_one()
+        config_invoice_can_be_digitalized = self.company_id.invoice_digital_tfhka
+        config_mix_invoicing = self.company_id.mix_invoicing_tfhka
+
+        if not self.journal_id.digital_invoice and config_invoice_can_be_digitalized and not config_mix_invoicing:
+            if self.move_type in ['out_invoice', 'out_refund']:
+                raise ValidationError(_(
+                    "The company is configured for strict digital invoicing (mixed invoicing is disabled). "
+                    "Only journals with digital invoicing enabled are allowed for this operation. "
+                    "Please check the company configuration or select a valid digital journal."
+                ))
+
+    def _tfhka_get_document_type_and_series(self):
+        """Returns the TFHKA document type and series."""
+        self.ensure_one()
+        document_type = ""
+        if self.move_type == "out_invoice":
+            document_type = "03" if self.debit_origin_id else "01"
+        elif self.move_type == "out_refund" and self.reversed_entry_id:
+            document_type = "02"
+        
+        series = ""
+        if self.company_id.group_sales_invoicing_series and self.journal_id.series_correlative_sequence_id:
+            if self.journal_id.sequence_id and self.journal_id.sequence_id.prefix:
+                series = re.sub(r'[^a-zA-Z0-9]', '', self.journal_id.sequence_id.prefix)
+            else:
+                raise UserError(_("The selected series is not configured"))
+                
+        return document_type, series
+
+    # --- MULTI-MONEDA ---
+    # Flag por factura: habilita el selector de moneda de línea (VES/USD).
+    # Requiere que multi_currency_invoice_tfhka esté activo en la compañía.
+    multi_currency_invoice = fields.Boolean(
+        string='Multi-Currency Invoice',
+        default=False,
+        tracking=True,
+        help="When enabled, the 'Line Currency' selector appears, allowing you to "
+             "choose VES (prices in Bolivars, totals in VES) or USD (prices in USD, "
+             "totals in both currencies). "
+             "Requires 'Multi-currency digital invoicing' in company settings."
+    )
+    # Indica si la funcionalidad multi-moneda está disponible (según compañía).
+    # Controla la visibilidad del campo multi_currency_invoice en vista.
+    multi_currency_enabled = fields.Boolean(
+        string='Multi-currency enabled',
+        compute='_compute_multi_currency_enabled',
+        store=False
+    )
+
+    @api.depends('company_id.multi_currency_invoice_tfhka')
+    def _compute_multi_currency_enabled(self):
+        for move in self:
+            move.multi_currency_enabled = move.company_id.multi_currency_invoice_tfhka
+
+    # Moneda de las líneas de producto: VES (precios en Bs.) o USD (precios en USD).
+    # Solo visible cuando multi_currency_invoice está activo en la factura.
+    line_currency = fields.Selection([
+        ('VES', 'VES'),
+        ('USD', 'USD'),
+    ], default='VES',
+       help="VES: precios de líneas en Bolívares, totales solo en VES.\n"
+            "USD: precios de líneas en dólares, totales en ambas monedas.")
+
+    # Resuelve si esta factura debe tratarse como multi-moneda.
+    # El modo multi-moneda (USD + totales bimoneda) se activa solo cuando
+    # multi_currency_invoice=True y line_currency='USD'.
+    # Sigue el patrón de binaural_unidigital con la adición de line_currency.
+    def is_invoice_multi_currency_enabled(self):
+        self.ensure_one()
+        return bool(self.multi_currency_invoice and self.line_currency == 'USD')
+
     def generate_document_digital(self):
         if not self.company_id.invoice_digital_tfhka:
             return

--- a/l10n_ve_invoice_digital/models/account_move.py
+++ b/l10n_ve_invoice_digital/models/account_move.py
@@ -307,9 +307,54 @@ class AccountMove(models.Model):
                 amounts["totalIVA"] = round(sum(group.get('tax_group_amount', 0) for group in tax_totals.get('groups_by_subtotal', {}).get('Subtotal', [])), 2)
                 amounts["montoTotalConIVA"] = str(round(tax_totals.get("amount_total", 0), 2))
                 amounts["totalDescuento"] = str(abs(round(tax_totals.get("discount_amount", 0), 2)))
-                
-                taxes_subtotal = self.get_tax_subtotals(currency)
-                currency = record.company_id.currency_id.code_tfhka
+
+                taxes_subtotal, _dummy = self.get_tax_subtotals(currency)
+                currency_tfhka_code = record.company_id.currency_id.code_tfhka
+
+                # TotalesOtraMoneda activo: factura VEF/VES con tipo de cambio.
+                # Se genera cuando multi_currency_invoice=True + line_currency='USD'
+                # (multi_currency), o cuando hay un foreign_rate (ej. desde POS).
+                # Enviamos Totales en VES (amounts) y TotalesOtraMoneda en USD
+                # (amounts_foreign = amounts / tasa de cambio).
+                has_foreign_rate = bool(record.foreign_rate)
+                if multi_currency or has_foreign_rate:
+                    rate = record.foreign_rate or 1.0
+                    amounts_foreign["montoGravadoTotal"] = str(
+                        round(float(amounts["montoGravadoTotal"]) / rate, 2)
+                    )
+                    amounts_foreign["montoExentoTotal"] = str(
+                        round(float(amounts["montoExentoTotal"]) / rate, 2)
+                    )
+                    amounts_foreign["subtotal"] = str(
+                        round(float(amounts["subtotal"]) / rate, 2)
+                    )
+                    amounts_foreign["subtotalAntesDescuento"] = str(
+                        round(float(amounts["subtotalAntesDescuento"]) / rate, 2)
+                    )
+                    amounts_foreign["totalAPagar"] = str(
+                        round(float(amounts["totalAPagar"]) / rate, 2)
+                    )
+                    amounts_foreign["totalIVA"] = round(
+                        float(amounts["totalIVA"]) / rate, 2
+                    )
+                    amounts_foreign["montoTotalConIVA"] = str(
+                        round(float(amounts["montoTotalConIVA"]) / rate, 2)
+                    )
+                    amounts_foreign["totalDescuento"] = str(
+                        abs(round(float(amounts["totalDescuento"]) / rate, 2))
+                    )
+                    # Impuestos desglosados en ambas monedas para ImpuestosSubtotal.
+                    taxes_subtotal, taxes_subtotal_foreign = self.get_tax_subtotals(
+                        currency, multi_currency=True
+                    )
+                    # Código de moneda extranjera (ej. "USD") para TotalesOtraMoneda.
+                    foreign_currency_code = (
+                        record.company_id.currency_foreign_id.code_tfhka
+                    )
+                else:
+                    foreign_currency_code = None
+
+                currency = currency_tfhka_code
 
             else:
                 amounts_foreign["montoGravadoTotal"] = str(
@@ -425,7 +470,7 @@ class AccountMove(models.Model):
             "3.0 %": "3.0"
         }
         for record in self:
-            if currency == "VEF":
+            if currency in ("VEF", "VES") and not multi_currency:
                 for tax_totals in record.tax_totals.get('groups_by_subtotal', {}).get('Subtotal', []):
                     tax_subtotals.append({
                         "codigoTotalImp": tax_code[tax_totals.get('tax_group_name')],
@@ -433,7 +478,52 @@ class AccountMove(models.Model):
                         "baseImponibleImp": str(round(tax_totals.get('tax_group_base_amount'), 2)),
                         "valorTotalImp": str(round(tax_totals.get('tax_group_amount'), 2)),
                     })
-                return tax_subtotals
+                if record.tax_totals.get('igtf', {}).get('apply_igtf'):
+                    igtf = record.tax_totals.get('igtf', {})
+                    tax_subtotals.append({
+                        "codigoTotalImp": "IGTF",
+                        "alicuotaImp": tax_rate.get(igtf.get('name'), "3.0"),
+                        "baseImponibleImp": str(round(igtf.get('igtf_base_amount'), 2)),
+                        "valorTotalImp": str(round(igtf.get('igtf_amount'), 2)),
+                    })
+                return tax_subtotals, tax_subtotals_foreign
+            # Rama multi-moneda: factura en VES con flag multi_currency activo.
+            # Se construyen dos listas de impuestos:
+            #   - tax_subtotals: montos en VES (base imponible original).
+            #   - tax_subtotals_foreign: montos convertidos a USD ÷ tasa de cambio.
+            elif multi_currency:
+                rate = record.foreign_rate or 1.0
+                for tax_line in record.tax_totals.get('groups_by_subtotal', {}).get('Subtotal', []):
+                    tax_subtotals.append({
+                        "codigoTotalImp": tax_code[tax_line.get('tax_group_name')],
+                        "alicuotaImp": tax_rate[tax_line.get('tax_group_name')],
+                        "baseImponibleImp": str(round(tax_line.get('tax_group_base_amount'), 2)),
+                        "valorTotalImp": str(round(tax_line.get('tax_group_amount'), 2)),
+                    })
+                if record.tax_totals.get('igtf', {}).get('apply_igtf'):
+                    igtf = record.tax_totals.get('igtf', {})
+                    tax_subtotals.append({
+                        "codigoTotalImp": "IGTF",
+                        "alicuotaImp": tax_rate.get(igtf.get('name'), "3.0"),
+                        "baseImponibleImp": str(round(igtf.get('igtf_base_amount'), 2)),
+                        "valorTotalImp": str(round(igtf.get('igtf_amount'), 2)),
+                    })
+                for tax_line in record.tax_totals.get('groups_by_subtotal', {}).get('Subtotal', []):
+                    tax_subtotals_foreign.append({
+                        "codigoTotalImp": tax_code[tax_line.get('tax_group_name')],
+                        "alicuotaImp": tax_rate[tax_line.get('tax_group_name')],
+                        "baseImponibleImp": str(round(tax_line.get('tax_group_base_amount') / rate, 2)),
+                        "valorTotalImp": str(round(tax_line.get('tax_group_amount') / rate, 2)),
+                    })
+                if record.tax_totals.get('igtf', {}).get('apply_igtf'):
+                    igtf = record.tax_totals.get('igtf', {})
+                    tax_subtotals_foreign.append({
+                        "codigoTotalImp": "IGTF",
+                        "alicuotaImp": tax_rate.get(igtf.get('name'), "3.0"),
+                        "baseImponibleImp": str(round(igtf.get('igtf_base_amount') / rate, 2)),
+                        "valorTotalImp": str(round(igtf.get('igtf_amount') / rate, 2)),
+                    })
+                return tax_subtotals, tax_subtotals_foreign
             else:
                 for tax_totals in record.tax_totals.get('groups_by_foreign_subtotal', {}).get('Subtotal', []):
                     tax_subtotals.append({
@@ -453,13 +543,13 @@ class AccountMove(models.Model):
                     igtf = record.tax_totals.get('igtf', {})
                     tax_subtotals_foreign.append({
                         "codigoTotalImp": "IGTF",
-                        "alicuotaImp": tax_rate[igtf.get('name')],
+                        "alicuotaImp": tax_rate.get(igtf.get('name'), "3.0"),
                         "baseImponibleImp": str(round(igtf.get('igtf_base_amount'), 2)),
                         "valorTotalImp": str(round(igtf.get('igtf_amount'), 2)),
                     })
                     tax_subtotals.append({
                         "codigoTotalImp": "IGTF",
-                        "alicuotaImp": tax_rate[igtf.get('name')],
+                        "alicuotaImp": tax_rate.get(igtf.get('name'), "3.0"),
                         "baseImponibleImp": str(round(igtf.get('foreign_igtf_base_amount'), 2)),
                         "valorTotalImp": str(round(igtf.get('foreign_igtf_amount'), 2)),
                     })

--- a/l10n_ve_invoice_digital/models/account_move.py
+++ b/l10n_ve_invoice_digital/models/account_move.py
@@ -482,21 +482,24 @@ class AccountMove(models.Model):
                 taxes = line.tax_ids.filtered(lambda t: t.amount)
                 tax_rate = taxes[0].amount if taxes else 0.0
 
-                if record.company_id.currency_id.name == "VEF":
-                    unit_price = round(line.price_unit, 2)
-                    unit_price_discount = round(line.price_unit * (line.discount / 10), 2)
-                    discount_amount = round((line.price_unit * (line.discount / 100)) * line.quantity, 2)
-                    item_price = round(line.price_subtotal, 2)
-                    price_before_discount = round(line.price_unit * line.quantity, 2)
-
+                # Determinar valores base según moneda/configuración
+                if not record.is_invoice_multi_currency_enabled() and record.company_id.currency_id.name in ("VEF", "VES"):
+                    base_price = line.price_unit
+                    base_subtotal = line.price_subtotal
                 else:
-                        unit_price = round(line.foreign_price, 2)
-                        unit_price_discount = round(line.foreign_price * (line.discount / 10), 2)
-                        discount_amount = round((line.foreign_price * (line.discount / 100)) * line.quantity, 2)
-                        item_price = round(line.foreign_subtotal, 2)
-                        price_before_discount = round(line.foreign_price * line.quantity, 2)
+                    base_price = line.foreign_price
+                    base_subtotal = line.foreign_subtotal
 
-                vat = round(item_price * line.tax_ids.amount / 100, 2)
+                discount_factor = (line.discount or 0.0) / 100.0
+
+                unit_price = round(base_price, 2)
+                discount_unit = round(base_price * discount_factor, 2)
+                unit_price_discount = round(base_price - discount_unit, 2)
+                discount_amount = round(base_price * discount_factor * line.quantity, 2)
+                item_price = round(base_subtotal, 2)
+                price_before_discount = round(base_price * line.quantity, 2)
+
+                vat = round(item_price * tax_rate / 100.0, 2)
                 total_item_value = round(item_price + vat, 2)
 
                 item_details.append({


### PR DESCRIPTION
refactorizar y simplificar el cálculo de montos de líneas en facturas multimoneda

- Se unifica la determinación de precios base y subtotales según el modo multimoneda y la moneda de la compañía.
- Se simplifica el cálculo de precios unitarios, descuentos e IVA en get_item_details para evitar código duplicado.

References:
- Ticket: https://www.binauraldev.com/odoo/all-tickets/14341