### PR TITLE
[FIX] l10n_ve_mf_base: TfhkaDriver truncaba la descripción del produto a 40 caracteres compartidos con precio/cantidad/código

### DIFF
--- a/l10n_ve_mf_base/__manifest__.py
+++ b/l10n_ve_mf_base/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": "Driver base Web Serial API para impresoras fiscales The Factory HKA (TFHKA).",
     "license": "LGPL-3",
     "category": "Accounting",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Binaural",
     "website": "https://binauraldev.com",
     "depends": ["web"],

--- a/l10n_ve_mf_base/static/src/drivers/TfhkaDriver.js
+++ b/l10n_ve_mf_base/static/src/drivers/TfhkaDriver.js
@@ -39,6 +39,15 @@ export class TfhkaDriver {
     // Máximo de caracteres por línea que imprime la TFHKA
     static MAX_LINE_LEN = 40;
 
+    // Longitud máxima del campo "Descripción Producto" en el comando de
+    // registro de ítem (Tabla 27, Manual de Protocolos y Comandos V8.5.0 -
+    // Venezuela). Es un límite propio del campo, independiente de
+    // precio/cantidad/código: la impresora hace word-wrap automático en
+    // varias líneas físicas de MAX_LINE_LEN al imprimir. Valor para SRP-812
+    // (único modelo mapeado en getMachineModel/MODEL_MAP); otros modelos
+    // TFHKA van de 116 a 140 según la misma tabla.
+    static MAX_PRODUCT_DESC_LEN = 127;
+
     constructor() {
         this.connection = new SerialConnection();
         this.isConnected = false;
@@ -1206,10 +1215,8 @@ export class TfhkaDriver {
                     .replace(/ñ/g, 'n')
                     .trim();
 
-                const overhead = 1 + price.length + qty.length + code.length;
-                const available = TfhkaDriver.MAX_LINE_LEN - overhead;
-                if (available > 0 && desc.length > available) {
-                    desc = desc.substring(0, available);
+                if (desc.length > TfhkaDriver.MAX_PRODUCT_DESC_LEN) {
+                    desc = desc.substring(0, TfhkaDriver.MAX_PRODUCT_DESC_LEN);
                 }
 
                 phase1Commands.push(`${taxChar}${price}${qty}${code}${desc}`);
@@ -1432,10 +1439,8 @@ export class TfhkaDriver {
                     .replace(/Ñ/g, 'N').replace(/ñ/g, 'n')
                     .trim();
 
-                const overhead = 2 + price.length + qty.length + code.length;
-                const available = TfhkaDriver.MAX_LINE_LEN - overhead;
-                if (available > 0 && desc.length > available) {
-                    desc = desc.substring(0, available);
+                if (desc.length > TfhkaDriver.MAX_PRODUCT_DESC_LEN) {
+                    desc = desc.substring(0, TfhkaDriver.MAX_PRODUCT_DESC_LEN);
                 }
 
                 phase1Commands.push(`d${fiscalCode}${price}${qty}${code}${desc}`);
@@ -1627,10 +1632,8 @@ export class TfhkaDriver {
                     .replace(/Ñ/g, 'N').replace(/ñ/g, 'n')
                     .trim();
 
-                const overhead = 2 + price.length + qty.length + code.length;
-                const available = TfhkaDriver.MAX_LINE_LEN - overhead;
-                if (available > 0 && desc.length > available) {
-                    desc = desc.substring(0, available);
+                if (desc.length > TfhkaDriver.MAX_PRODUCT_DESC_LEN) {
+                    desc = desc.substring(0, TfhkaDriver.MAX_PRODUCT_DESC_LEN);
                 }
 
                 phase1Commands.push(`\`${fiscalCode}${price}${qty}${code}${desc}`);


### PR DESCRIPTION
El límite de 40 caracteres (MAX_LINE_LEN) usado para recortar la
descripción de cada ítem es el ancho físico de línea que documenta el
Manual de Protocolos y Comandos V8.5.0 - Venezuela para encabezado y
pie de página, no el límite real del campo "Descripción Producto" del
comando de registro de ítem. Según la Tabla 27 (Tabla de Caracteres) de
ese manual, ese campo es independiente de precio/cantidad/código y
admite hasta 127 caracteres para el SRP-812 (único modelo mapeado en
getMachineModel/MODEL_MAP) — la impresora reparte ese texto sola en
varias líneas físicas de 40 caracteres al imprimir, el driver no tiene
que hacer word-wrap manual.

El código anterior calculaba "available" restando a 40 la longitud de
precio + cantidad + código, así que con un producto con código el
margen real para el nombre bajaba a ~13-21 caracteres y cortaba nombres
de producto normales. Se reemplaza por un límite fijo
MAX_PRODUCT_DESC_LEN=127 aplicado solo a la descripción, en los tres
tipos de documento que registran ítems: factura/venta, nota de crédito