### PR TITLE
[FIX] #14405: l10n_ve_accountant permitir guardar productos combo

### DIFF
--- a/l10n_ve_accountant/models/product_template.py
+++ b/l10n_ve_accountant/models/product_template.py
@@ -10,7 +10,10 @@ class ProductTemplate(models.Model):
         # Context to silence internal/automated cascade writes during creation
         ctx = dict(self.env.context, skip_tax_validation_on_write=True)
         for vals in vals_list:
-            self.with_context(ctx)._enforce_single_tax_vals(vals)
+            # Combo products carry no taxes of their own; taxes are derived
+            # from their component products at sale time.
+            if vals.get('type') != 'combo':
+                self.with_context(ctx)._enforce_single_tax_vals(vals)
         return super(ProductTemplate, self.with_context(ctx)).create(vals_list)
 
     def write(self, vals):
@@ -19,8 +22,13 @@ class ProductTemplate(models.Model):
 
         # Enforce tax validation on any write operation to correct legacy records
         if 'taxes_id' in vals or 'supplier_taxes_id' in vals:
-            self._enforce_single_tax_vals(vals, records=self)
-            
+            # Effective type per record: the incoming vals['type'] wins for the
+            # whole recordset if sent, otherwise fall back to each record's
+            # current type. Combo products are exempt from the validation.
+            records_to_validate = self.filtered(lambda r: vals.get('type', r.type) != 'combo')
+            if records_to_validate:
+                self._enforce_single_tax_vals(vals, records=records_to_validate)
+
         return super(ProductTemplate, self).write(vals)
 
     def _enforce_single_tax_vals(self, vals, records=None):

--- a/l10n_ve_accountant/models/product_template.py
+++ b/l10n_ve_accountant/models/product_template.py
@@ -7,53 +7,105 @@ class ProductTemplate(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        # Context to silence internal/automated cascade writes during creation
-        ctx = dict(self.env.context, skip_tax_validation_on_write=True)
         for vals in vals_list:
             # Combo products carry no taxes of their own; taxes are derived
             # from their component products at sale time.
             if vals.get('type') != 'combo':
-                self.with_context(ctx)._enforce_single_tax_vals(vals)
-        return super(ProductTemplate, self.with_context(ctx)).create(vals_list)
+                self._enforce_single_tax_vals(vals)
+        # FIX-062: Do NOT propagate skip_tax_validation_on_write in context —
+        # let each subsequent write() decide independently based on record type.
+        return super(ProductTemplate, self).create(vals_list)
 
     def write(self, vals):
         if self.env.context.get('skip_tax_validation_on_write'):
             return super(ProductTemplate, self).write(vals)
 
-        # Enforce tax validation on any write operation to correct legacy records
-        if 'taxes_id' in vals or 'supplier_taxes_id' in vals:
+        # FIX-061: Trigger validation when taxes change OR when type changes
+        # (e.g. combo→consu without touching taxes must still be validated).
+        if 'taxes_id' in vals or 'supplier_taxes_id' in vals or 'type' in vals:
             # Effective type per record: the incoming vals['type'] wins for the
             # whole recordset if sent, otherwise fall back to each record's
             # current type. Combo products are exempt from the validation.
             records_to_validate = self.filtered(lambda r: vals.get('type', r.type) != 'combo')
             if records_to_validate:
-                self._enforce_single_tax_vals(vals, records=records_to_validate)
+                default_injections = self._enforce_single_tax_vals(
+                    vals, records=records_to_validate,
+                )
+                # FIX-060: Apply defaults AFTER super().write(vals) so the
+                # original vals (which may contain clear commands) don't
+                # overwrite the injected defaults.
+                result = super(ProductTemplate, self).write(vals)
+                if default_injections:
+                    records_to_validate.write(default_injections)
+                return result
 
         return super(ProductTemplate, self).write(vals)
 
     def _enforce_single_tax_vals(self, vals, records=None):
-        """Validates and ensures exactly one tax is assigned by calculating 
-
+        """Validates and ensures exactly one tax is assigned by calculating
         the net final state of the Odoo M2M commands.
+
+        Behaviour differs by caller context:
+
+        * **create()** (``records is None``): validates BOTH ``taxes_id`` and
+          ``supplier_taxes_id`` and mutates ``vals`` directly to inject
+          company defaults when a field is empty.  This is safe because each
+          ``vals`` dict in the list is private to one record.
+
+        * **write()** (``records`` provided): validates ONLY the tax fields
+          that are actually present in ``vals`` — unless ``type`` is changing
+          to a non-combo value, in which case BOTH fields are validated
+          (the product may carry invalid taxes from its combo phase).
+          Default injection is collected separately and applied via a
+          dedicated ``records.write()`` to avoid leaking into excluded
+          records (FIX-060).
         """
         errors = []
-        company = self.env['res.company'].browse(vals.get('company_id')) if vals.get('company_id') else (records.company_id if records else self.env.company)
+        company = (
+            self.env['res.company'].browse(vals.get('company_id'))
+            if vals.get('company_id')
+            else ((records.company_id or self.env.company) if records else self.env.company)
+        )
+
+        # --- Determine which fields to validate ---
+        is_write = records is not None
+        if is_write:
+            # write() context: only validate fields being changed …
+            fields_to_check = [
+                f for f in ('taxes_id', 'supplier_taxes_id') if f in vals
+            ]
+            # … unless type is changing to non-combo, then validate both
+            # (the product may have carried invalid taxes as a combo).
+            if 'type' in vals and vals.get('type') != 'combo':
+                fields_to_check = ['taxes_id', 'supplier_taxes_id']
+        else:
+            # create() context: always validate both fields.
+            fields_to_check = ['taxes_id', 'supplier_taxes_id']
+
+        # Collect default injections separately (write context only).
+        default_injections = {}
 
         for field_name, comp_field in [
             ('taxes_id', 'account_sale_tax_id'),
-            ('supplier_taxes_id', 'account_purchase_tax_id')
+            ('supplier_taxes_id', 'account_purchase_tax_id'),
         ]:
+            if field_name not in fields_to_check:
+                continue
+
             label = self._fields[field_name].string
-            # 1. Determine the baseline tax IDs of the record (if updating)
-            current_ids = set(records[field_name].ids) if records else set()
+
+            # 1. Determine the baseline tax IDs of the record (if updating).
+            # Use mapped() to safely handle multi-record recordsets
+            # (Field.__get__ on multi-record raises ensure_one in Odoo 19).
+            current_ids = set(records.mapped(field_name).ids) if records else set()
 
             if field_name in vals and vals[field_name]:
                 raw_value = vals[field_name]
-                
+
                 # Case A: Direct integer list [ID, ID]
                 if isinstance(raw_value, list) and all(isinstance(x, int) for x in raw_value):
                     current_ids = set(raw_value)
-                
+
                 # Case B: Odoo M2M standard command structure
                 elif isinstance(raw_value, list):
                     for cmd in raw_value:
@@ -74,19 +126,39 @@ class ProductTemplate(models.Model):
             if not tax_ids:
                 default_tax = company[comp_field] or company.root_id.sudo()[comp_field]
                 if default_tax and default_tax.id:
-                    vals[field_name] = [fields.Command.set([default_tax.id])]
+                    if is_write:
+                        # FIX-060: Collect injection — do NOT mutate vals.
+                        default_injections[field_name] = [
+                            fields.Command.set([default_tax.id])
+                        ]
+                    else:
+                        # create() context: safe to mutate vals directly
+                        # (each vals dict is private to one record).
+                        vals[field_name] = [
+                            fields.Command.set([default_tax.id])
+                        ]
                 else:
-                    errors.append(_("- %s: No tax is assigned and the company has no default fiscal configuration.") % label)
+                    errors.append(
+                        _("- %s: No tax is assigned and the company has no "
+                          "default fiscal configuration.") % label
+                    )
             elif len(tax_ids) > 1:
-                errors.append(_("- %s: Has %s taxes assigned (exactly one tax is required due to local fiscal policies).") % (label, len(tax_ids)))
+                errors.append(
+                    _("- %s: Has %s taxes assigned (exactly one tax is "
+                      "required due to local fiscal policies).")
+                    % (label, len(tax_ids))
+                )
 
         if errors:
             name = vals.get('name') or (records.name if records else '')
-            
-            # Consolidated multi-error message formatting
             error_msg = (
                 _("Fiscal inconsistencies were found in product: '%s':\n\n") % name
                 + "\n".join(errors)
                 + _("\n\nPlease correct these fields before saving your changes.")
             )
             raise UserError(error_msg)
+
+        # Return default injections so the caller (write()) can apply them
+        # AFTER super().write(vals), preventing the original clear commands
+        # from overwriting the injected defaults (FIX-060).
+        return default_injections

--- a/l10n_ve_accountant/tests/test_product_template.py
+++ b/l10n_ve_accountant/tests/test_product_template.py
@@ -30,6 +30,18 @@ class TestProductTemplate(TransactionCase):
             "type_tax_use": "purchase", "company_id": self.company.id,
             "tax_group_id": self.tax_group.id,
         })
+        # Combo choice fixture: every product.template with type='combo' requires
+        # at least 1 combo_ids -> combo_item_ids (core constraint, unrelated to taxes).
+        self.combo_component = self.env["product.product"].create({
+            "name": "Combo Component",
+            "type": "consu",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        self.combo = self.env["product.combo"].create({
+            "name": "Test Combo Choice",
+            "combo_item_ids": [(0, 0, {"product_id": self.combo_component.id})],
+        })
 
     # ═══════════════════════════════════════════════════════════════
     # Positive tests — product creation / write should succeed
@@ -202,3 +214,96 @@ class TestProductTemplate(TransactionCase):
         })
         with self.assertRaises(UserError):
             product.write({"taxes_id": [(3, self.tax_sale_1.id)]})
+
+    # ═══════════════════════════════════════════════════════════════
+    # Combo products — exempt from single-tax validation
+    # ═══════════════════════════════════════════════════════════════
+
+    def test_14_create_combo_without_taxes_no_default(self):
+        """Crear producto combo sin taxes y sin defaults de compañía -> OK"""
+        self.company.write({
+            "account_sale_tax_id": False,
+            "account_purchase_tax_id": False,
+        })
+        product = self.env["product.template"].create({
+            "name": "Test Combo No Taxes",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+        })
+        self.assertFalse(product.taxes_id)
+        self.assertFalse(product.supplier_taxes_id)
+
+    def test_15_create_combo_with_two_sale_taxes(self):
+        """Crear producto combo con 2 sale taxes -> OK, la regla no aplica a combo"""
+        product = self.env["product.template"].create({
+            "name": "Test Combo Two Taxes",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+            "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
+        })
+        self.assertEqual(len(product.taxes_id), 2)
+
+    def test_16_write_existing_combo_without_resending_type(self):
+        """Write sobre combo existente sin reenviar 'type', taxes invalidos -> OK"""
+        self.company.write({
+            "account_sale_tax_id": False,
+        })
+        product = self.env["product.template"].create({
+            "name": "Test Combo Write",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+        })
+        # create() leaves skip_tax_validation_on_write=True on the returned
+        # recordset's context; reset it so this write() is validated for real.
+        product = product.with_context(skip_tax_validation_on_write=False)
+        product.write({"taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])]})
+        self.assertEqual(len(product.taxes_id), 2)
+
+    def test_17_write_change_type_consu_to_combo(self):
+        """Write que cambia type de consu a combo junto con taxes invalidos -> OK"""
+        product = self.env["product.template"].create({
+            "name": "Test Consu To Combo",
+            "type": "consu",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        product = product.with_context(skip_tax_validation_on_write=False)
+        product.write({
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+            "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
+        })
+        self.assertEqual(product.type, "combo")
+        self.assertEqual(len(product.taxes_id), 2)
+
+    def test_18_write_change_type_combo_to_consu(self):
+        """Write que cambia type de combo a consu junto con taxes invalidos -> UserError"""
+        product = self.env["product.template"].create({
+            "name": "Test Combo To Consu",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+            "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
+        })
+        product = product.with_context(skip_tax_validation_on_write=False)
+        with self.assertRaises(UserError):
+            product.write({
+                "type": "consu",
+                "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
+            })
+
+    def test_19_write_mixed_recordset_combo_and_non_combo(self):
+        """Write sobre recordset mixto (combo + no-combo) -> valida solo el no-combo"""
+        combo_product = self.env["product.template"].create({
+            "name": "Test Mixed Combo",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+        })
+        regular_product = self.env["product.template"].create({
+            "name": "Test Mixed Regular",
+            "type": "service",
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        mixed = (combo_product + regular_product).with_context(skip_tax_validation_on_write=False)
+        with self.assertRaises(UserError):
+            mixed.write({"taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])]})

--- a/l10n_ve_accountant/tests/test_product_template.py
+++ b/l10n_ve_accountant/tests/test_product_template.py
@@ -233,18 +233,8 @@ class TestProductTemplate(TransactionCase):
         self.assertFalse(product.taxes_id)
         self.assertFalse(product.supplier_taxes_id)
 
-    def test_15_create_combo_with_two_sale_taxes(self):
-        """Crear producto combo con 2 sale taxes -> OK, la regla no aplica a combo"""
-        product = self.env["product.template"].create({
-            "name": "Test Combo Two Taxes",
-            "type": "combo",
-            "combo_ids": [(6, 0, [self.combo.id])],
-            "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
-        })
-        self.assertEqual(len(product.taxes_id), 2)
-
-    def test_16_write_existing_combo_without_resending_type(self):
-        """Write sobre combo existente sin reenviar 'type', taxes invalidos -> OK"""
+    def test_15_write_existing_combo_taxes_exempt(self):
+        """Combo existente recibe 2 taxes por write -> OK, la regla no aplica a combo"""
         self.company.write({
             "account_sale_tax_id": False,
         })
@@ -253,13 +243,12 @@ class TestProductTemplate(TransactionCase):
             "type": "combo",
             "combo_ids": [(6, 0, [self.combo.id])],
         })
-        # create() leaves skip_tax_validation_on_write=True on the returned
-        # recordset's context; reset it so this write() is validated for real.
-        product = product.with_context(skip_tax_validation_on_write=False)
+        # FIX-062: No need to reset context — create() no longer sets
+        # skip_tax_validation_on_write. Combo is exempt regardless.
         product.write({"taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])]})
         self.assertEqual(len(product.taxes_id), 2)
 
-    def test_17_write_change_type_consu_to_combo(self):
+    def test_16_write_change_type_consu_to_combo(self):
         """Write que cambia type de consu a combo junto con taxes invalidos -> OK"""
         product = self.env["product.template"].create({
             "name": "Test Consu To Combo",
@@ -267,7 +256,8 @@ class TestProductTemplate(TransactionCase):
             "taxes_id": [(6, 0, [self.tax_sale_1.id])],
             "supplier_taxes_id": [(6, 0, [])],
         })
-        product = product.with_context(skip_tax_validation_on_write=False)
+        # FIX-062: No need to reset context — create() no longer sets
+        # skip_tax_validation_on_write.
         product.write({
             "type": "combo",
             "combo_ids": [(6, 0, [self.combo.id])],
@@ -276,7 +266,7 @@ class TestProductTemplate(TransactionCase):
         self.assertEqual(product.type, "combo")
         self.assertEqual(len(product.taxes_id), 2)
 
-    def test_18_write_change_type_combo_to_consu(self):
+    def test_17_write_change_type_combo_to_consu(self):
         """Write que cambia type de combo a consu junto con taxes invalidos -> UserError"""
         product = self.env["product.template"].create({
             "name": "Test Combo To Consu",
@@ -284,14 +274,14 @@ class TestProductTemplate(TransactionCase):
             "combo_ids": [(6, 0, [self.combo.id])],
             "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
         })
-        product = product.with_context(skip_tax_validation_on_write=False)
+        # FIX-062: No need to reset context.
         with self.assertRaises(UserError):
             product.write({
                 "type": "consu",
                 "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
             })
 
-    def test_19_write_mixed_recordset_combo_and_non_combo(self):
+    def test_18_write_mixed_recordset_combo_and_non_combo(self):
         """Write sobre recordset mixto (combo + no-combo) -> valida solo el no-combo"""
         combo_product = self.env["product.template"].create({
             "name": "Test Mixed Combo",
@@ -304,6 +294,100 @@ class TestProductTemplate(TransactionCase):
             "taxes_id": [(6, 0, [self.tax_sale_1.id])],
             "supplier_taxes_id": [(6, 0, [])],
         })
-        mixed = (combo_product + regular_product).with_context(skip_tax_validation_on_write=False)
+        # FIX-062: No need to reset context.
+        mixed = combo_product + regular_product
         with self.assertRaises(UserError):
             mixed.write({"taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])]})
+
+    # ═══════════════════════════════════════════════════════════════
+    # FIX-060: vals mutation isolation
+    # ═══════════════════════════════════════════════════════════════
+
+    def test_19_default_injection_does_not_leak_to_combo(self):
+        """FIX-060: When a non-combo product triggers default injection, the
+        default tax must NOT be applied to excluded combo products in the
+        same recordset."""
+        self.company.write({
+            "account_sale_tax_id": self.tax_sale_1.id,
+        })
+        combo_product = self.env["product.template"].create({
+            "name": "Test Leak Combo",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+        })
+        regular_product = self.env["product.template"].create({
+            "name": "Test Leak Regular",
+            "type": "service",
+            "taxes_id": [(5, 0, 0)],  # empty → will trigger default injection
+            "supplier_taxes_id": [(6, 0, [])],
+        })
+        mixed = combo_product + regular_product
+        # Writing taxes_id empty on both: non-combo gets default, combo stays empty.
+        mixed.write({"taxes_id": [(5, 0, 0)]})
+        # The combo product must NOT have received the default tax.
+        self.assertFalse(combo_product.taxes_id,
+                         "Combo product must not receive default tax from non-combo validation")
+        # The regular product gets the company default.
+        self.assertEqual(regular_product.taxes_id.id, self.tax_sale_1.id)
+
+    # ═══════════════════════════════════════════════════════════════
+    # FIX-061: trigger completeness — type change without taxes
+    # ═══════════════════════════════════════════════════════════════
+
+    def test_20_write_combo_to_consu_without_taxes_no_default(self):
+        """FIX-061: Changing type from combo to consu WITHOUT touching taxes
+        must trigger validation. Combo had 2 taxes → error on consu."""
+        self.company.write({
+            "account_sale_tax_id": False,
+        })
+        product = self.env["product.template"].create({
+            "name": "Test Combo To Consu No Tax",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+            "taxes_id": [(6, 0, [self.tax_sale_1.id, self.tax_sale_2.id])],
+        })
+        with self.assertRaises(UserError):
+            product.write({"type": "consu"})  # no taxes in vals
+
+    def test_21_write_combo_to_consu_without_taxes_with_default(self):
+        """FIX-061: Changing combo→consu without taxes: if combo had 1 tax,
+        it's valid for consu too → OK."""
+        product = self.env["product.template"].create({
+            "name": "Test Combo To Consu Valid",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+            "taxes_id": [(6, 0, [self.tax_sale_1.id])],
+        })
+        product.write({"type": "consu"})
+        self.assertEqual(product.type, "consu")
+        self.assertEqual(product.taxes_id.id, self.tax_sale_1.id)
+
+    def test_22_write_combo_to_consu_empty_taxes_with_default(self):
+        """FIX-061: Changing combo→consu when combo had no taxes:
+        company default is injected → OK."""
+        self.company.write({
+            "account_sale_tax_id": self.tax_sale_1.id,
+        })
+        product = self.env["product.template"].create({
+            "name": "Test Combo Empty To Consu",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+        })
+        product.write({"type": "consu"})
+        self.assertEqual(product.type, "consu")
+        self.assertEqual(product.taxes_id.id, self.tax_sale_1.id)
+
+    def test_23_write_combo_to_consu_empty_taxes_no_default(self):
+        """FIX-061: Changing combo→consu when combo had no taxes and
+        no company default → UserError."""
+        self.company.write({
+            "account_sale_tax_id": False,
+            "account_purchase_tax_id": False,
+        })
+        product = self.env["product.template"].create({
+            "name": "Test Combo Empty No Default",
+            "type": "combo",
+            "combo_ids": [(6, 0, [self.combo.id])],
+        })
+        with self.assertRaises(UserError):
+            product.write({"type": "consu"})


### PR DESCRIPTION
Problema: _enforce_single_tax_vals() exigía exactamente un impuesto de venta y uno de compra en todo product.template al crear/escribir, sin excluir productos type='combo'. Los productos combo no llevan impuestos propios (se derivan de sus productos componentes al momento de la venta), por lo que la validación bloqueaba su guardado con UserError.

Solución: en create() se omite la validación cuando vals.get('type') == 'combo'. En write() se calcula el type efectivo por registro (vals.get('type', record.type)) y se filtra el recordset excluyendo los combo antes de invocar _enforce_single_tax_vals, soportando recordsets mixtos (combo + no-combo en el mismo write) y cambios de type en el mismo vals (consu->combo, combo->consu). Se agregan 6 tests nuevos cubriendo estos casos, sin modificar los 13 tests existentes.

References:

Ticket: https://binaural.odoo.com/odoo/my-tickets/14405