### PR TITLE
FIX #14412: l10n_ve_accountant register-payment

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.54",
+    "version": "17.0.0.0.55",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -953,7 +953,8 @@ class AccountMove(models.Model):
         
         for move in self:
             move._compute_inverse_rate_vef()
-            total_foreign_paid += move.tax_totals['foreign_total_amount_paid'] - move.tax_totals['foreign_amount_total']
+            tax_totals = move.tax_totals or {}
+            total_foreign_paid += tax_totals.get('foreign_total_amount_paid', 0) - tax_totals.get('foreign_amount_total', 0)
 
         if len(set(self.mapped("foreign_rate"))) > 1:
             raise UserError(


### PR DESCRIPTION
problema: al marcar como pagado un recibo de nómina individual (no por lotes), `action_register_payment` indexa `move.tax_totals` asumiendo un dict, pero ese campo computa `False` para asientos tipo `entry` (los que genera `hr.payslip`), lo que revienta con `TypeError: 'bool' object is not subscriptable`.

solucion: usar `tax_totals.get(...)` con default `0` en vez de indexar directo, sin cambiar el comportamiento para invoices con moneda extranjera.

link: https://binaural.odoo.com/odoo/action-390/14412
ticket de triaje-atc [x]