### PR TITLE
[ADD] l10n_ve_pos_mf: grupo de permisos para cierre nativo de sesion PDV 

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "1.9",
+    "version": "1.10",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/models/pos_session.py
+++ b/l10n_ve_pos/models/pos_session.py
@@ -181,7 +181,7 @@ class PosSession(models.Model):
                     ref=session._cross_move_ref(),
                 )
 
-    def _is_cross_move_eligible(self, payment_method):
+    def _is_cross_move_eligible(self, payment_method, use_suspense=False):
         """Whether ``payment_method`` takes part in the automatic cross move.
 
         ``is_foreign_currency`` is the business marker that drives the whole
@@ -192,47 +192,65 @@ class PosSession(models.Model):
         that plainly needed it.)
 
         A method missing either cross journal is skipped in silence — that
-        configuration is incomplete, not wrong.
+        configuration is incomplete, not wrong. ``use_suspense`` must match
+        whatever will be passed to ``_create_cross_move_for`` — see
+        ``_get_cross_transitory_account``.
         """
         return bool(
             payment_method.is_foreign_currency
             and payment_method.type != "pay_later"
             and payment_method.cross_account_journal
             and payment_method.cross_journal
-            and self._get_cross_transitory_account(payment_method)
+            and self._get_cross_transitory_account(payment_method, use_suspense=use_suspense)
         )
 
-    def _get_cross_transitory_account(self, payment_method):
-        """Return the account the cross move drains — the one where native
-        Odoo parked the money once the session closed.
+    def _get_cross_transitory_account(self, payment_method, use_suspense=False):
+        """Return the account the cross move drains.
 
-        Which account that is depends on the payment method type, because the
-        native pipelines differ:
+        Which account that is depends on *what created the balance being
+        cleared*, not just the payment method type:
 
-        - ``bank``: ``_create_combine_account_payment`` posts an
-          ``account.payment`` with ``force_outstanding_account_id =
-          payment_method.outstanding_account_id`` (native
-          ``pos_session.py:1104``), so the balance sits in the outstanding
-          account.
-        - ``cash``: there is no outstanding account at all —
-          ``outstanding_account_id`` is ``invisible="type != 'bank'"`` in the
-          native view (``point_of_sale/views/pos_payment_method_views.xml:24``),
-          because Odoo routes cash straight to the journal. The statement line
-          debits the journal's own default account and credits the POS
-          receivable (``_get_combine_statement_line_vals``, native line 1452),
-          which leaves the POS receivable squared at zero and the balance in
-          ``journal_id.default_account_id``.
+        - ``use_suspense=False`` (sales, opening/closing differences): the
+          account where native Odoo parked the money once the session
+          closed / the difference was posted.
 
-        Draining the POS receivable for a cash method would therefore unbalance
-        an account already at zero while never touching the cash it was meant
-        to move.
+          - ``bank``: ``_create_combine_account_payment`` posts an
+            ``account.payment`` with ``force_outstanding_account_id =
+            payment_method.outstanding_account_id`` (native
+            ``pos_session.py:1104``), so the balance sits in the outstanding
+            account.
+          - ``cash``: there is no outstanding account at all —
+            ``outstanding_account_id`` is ``invisible="type != 'bank'"`` in
+            the native view
+            (``point_of_sale/views/pos_payment_method_views.xml:24``),
+            because Odoo routes cash straight to the journal. The statement
+            line debits the journal's own default account and credits the
+            POS receivable (``_get_combine_statement_line_vals``, native
+            line 1452) or, for differences, the configured loss/profit
+            account (``_post_foreign_statement_difference``) — either way
+            the leftover balance sits in ``journal_id.default_account_id``.
 
-        The company's default POS receivable account stays on as a last-resort
-        fallback so that an incomplete journal setup degrades into a skipped
-        cross move (see ``_is_cross_move_eligible``) rather than an
-        ``account_move_line_check_accountable_required_fields`` violation from
-        a NULL ``account_id``.
+          The company's default POS receivable account stays on as a
+          last-resort fallback so that an incomplete journal setup degrades
+          into a skipped cross move (see ``_is_cross_move_eligible``) rather
+          than an ``account_move_line_check_accountable_required_fields``
+          violation from a NULL ``account_id``.
+
+        - ``use_suspense=True`` (plain cash in/out, ``binaural_pos_close``'s
+          ``try_cash_in_out``): that flow never sets an explicit
+          ``counterpart_account_id``, so native
+          ``_prepare_move_line_default_vals`` falls back to
+          ``journal_id.suspense_account_id`` — Odoo's own "Cuenta
+          transitoria" field
+          (``account/i18n/es.po``: ``Suspense Account`` → ``Cuenta
+          transitoria``). That is the account actually left unexplained by
+          that flow, not ``default_account_id`` (which already got
+          reconciled by the other cross move, see
+          ``_line_vals_move_cross_incoming``/``_outgoing``'s ``use_suspense``
+          branch for why draining it requires inverting debit/credit too).
         """
+        if use_suspense:
+            return payment_method.journal_id.suspense_account_id
         if payment_method.type == "cash":
             account = payment_method.journal_id.default_account_id
         else:
@@ -242,8 +260,33 @@ class PosSession(models.Model):
             )
         return account or self.company_id.account_default_pos_receivable_account_id
 
+    def _get_cross_real_account(self, payment_method, outbound, use_suspense=False):
+        """Return the ``cross_journal`` account that receives/gives the value.
+
+        ``use_suspense=False`` (sales, opening/closing differences): the
+        journal's own inbound/outbound payment method line account — the
+        confirmed liquidity account, same as the native ``account.payment``/
+        bank pipeline would use.
+
+        ``use_suspense=True`` (cash in/out, ``binaural_pos_close``): lands in
+        ``cross_journal.suspense_account_id`` instead — pending an actual
+        bank statement to reconcile it, the same "not yet confirmed"
+        treatment already applied to the origin leg (see
+        ``_get_cross_transitory_account``). A journal has a single suspense
+        account regardless of direction, so ``outbound`` is unused here.
+        """
+        account_method = payment_method.cross_journal
+        if use_suspense:
+            return account_method.suspense_account_id
+        line_ids = (
+            account_method.outbound_payment_method_line_ids
+            if outbound
+            else account_method.inbound_payment_method_line_ids
+        )
+        return line_ids.payment_account_id
+
     def _line_vals_move_cross_incoming(
-        self, payment_method, amount, foreign_amount, foreign_rate, partner
+        self, payment_method, amount, foreign_amount, foreign_rate, partner, use_suspense=False
     ):
         """Build the cross-move lines for an incoming (amount >= 0) movement.
 
@@ -259,10 +302,20 @@ class PosSession(models.Model):
         (``== 3``, VEF in the original dev database). Fixed to compare
         against ``self.foreign_currency_id`` (the session's configured
         foreign currency), which does not assume a fixed id.
+
+        ``use_suspense`` only changes *which* account
+        ``_get_cross_transitory_account`` resolves — ``_create_cross_move_for``
+        is what inverts debit/credit for that case, by swapping which of
+        ``_line_vals_move_cross_incoming``/``_outgoing`` gets called (see
+        there for why).
         """
-        transitory_account = self._get_cross_transitory_account(payment_method).id
+        transitory_account = self._get_cross_transitory_account(
+            payment_method, use_suspense=use_suspense
+        ).id
         account_method = payment_method.cross_journal
-        real_account = account_method.inbound_payment_method_line_ids.payment_account_id.id
+        real_account = self._get_cross_real_account(
+            payment_method, outbound=False, use_suspense=use_suspense
+        ).id
         line_currency = account_method.currency_id or self.env.company.currency_id
         is_foreign_line_currency = line_currency == self.foreign_currency_id
 
@@ -304,7 +357,7 @@ class PosSession(models.Model):
         ]
 
     def _line_vals_move_cross_outgoing(
-        self, payment_method, amount, foreign_amount, foreign_rate, partner
+        self, payment_method, amount, foreign_amount, foreign_rate, partner, use_suspense=False
     ):
         """Build the cross-move lines for an outgoing (amount < 0) movement.
 
@@ -313,9 +366,13 @@ class PosSession(models.Model):
         and credits the ``cross_journal``'s real bank account, using
         absolute magnitudes.
         """
-        transitory_account = self._get_cross_transitory_account(payment_method).id
+        transitory_account = self._get_cross_transitory_account(
+            payment_method, use_suspense=use_suspense
+        ).id
         account_method = payment_method.cross_journal
-        real_account = account_method.outbound_payment_method_line_ids.payment_account_id.id
+        real_account = self._get_cross_real_account(
+            payment_method, outbound=True, use_suspense=use_suspense
+        ).id
         line_currency = account_method.currency_id or self.env.company.currency_id
         is_foreign_line_currency = line_currency == self.foreign_currency_id
 
@@ -408,7 +465,8 @@ class PosSession(models.Model):
         return partner
 
     def _create_cross_move_for(
-        self, payment_method, amount, foreign_amount, foreign_rate, partner, date, ref
+        self, payment_method, amount, foreign_amount, foreign_rate, partner, date, ref,
+        use_suspense=False,
     ):
         """Create one clearing move for ``payment_method``.
 
@@ -417,14 +475,40 @@ class PosSession(models.Model):
         already the net of the method's payments, so a session whose refunds
         outweigh its sales yields a single outgoing move — the branch the
         legacy combine path never had.
+
+        ``use_suspense=True`` (only ``binaural_pos_close``'s plain cash
+        in/out) clears ``journal_id.suspense_account_id`` instead of
+        ``default_account_id`` — see ``_get_cross_transitory_account``. That
+        account carries the OPPOSITE native polarity from
+        ``default_account_id`` for the same movement (a balanced 2-line
+        entry always splits debit/credit between its two accounts), so
+        clearing it needs the mirror-image entry: same magnitude, opposite
+        role. Rather than duplicating ``_line_vals_move_cross_incoming``/
+        ``_outgoing`` with the roles hand-swapped (and every sign/currency
+        field re-derived), this reuses them as-is by swapping *which one*
+        gets called and negating the amounts fed to it — the already-correct
+        abs()/sign logic in the builder then produces exactly the mirrored
+        entry. Confirmed line-by-line against a manual T-account trace
+        (see ``proposal.md``): for an entrada, calling the *outgoing*
+        builder with ``-amount`` debits the suspense account and credits
+        ``cross_journal`` (draining the placeholder, moving Banco Real
+        opposite to the sales-like direction); for a salida, the mirrored
+        call to the *incoming* builder credits suspense and debits
+        ``cross_journal``.
         """
+        is_outgoing = amount < 0
+        call_amount, call_foreign_amount = amount, foreign_amount
+        if use_suspense:
+            is_outgoing = not is_outgoing
+            call_amount, call_foreign_amount = -amount, -foreign_amount
         line_builder = (
             self._line_vals_move_cross_outgoing
-            if amount < 0
+            if is_outgoing
             else self._line_vals_move_cross_incoming
         )
         line_vals = line_builder(
-            payment_method, amount, foreign_amount, foreign_rate, partner
+            payment_method, call_amount, call_foreign_amount, foreign_rate, partner,
+            use_suspense=use_suspense,
         )
         return self._create_cross_move(
             payment_method, line_vals, foreign_rate, date, ref, partner

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-cross-move-by-split-transactions/specs/pos-cross-account-move/spec.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-cross-move-by-split-transactions/specs/pos-cross-account-move/spec.md
@@ -196,6 +196,49 @@ error de base de datos por `account_id` nulo.
 - **WHEN** se cierra la sesión con un pago de ese método
 - **THEN** la pata transitoria del asiento cae sobre `outstanding_account_id`
 
+### Requirement: Modo `use_suspense` para llamadores fuera de ventas
+
+`_is_cross_move_eligible`, `_get_cross_transitory_account`,
+`_get_cross_real_account`, `_line_vals_move_cross_incoming`/`_outgoing` y
+`_create_cross_move_for` SHALL aceptar un parámetro `use_suspense` (default
+`False`) que no cambia ningún comportamiento de `_validate_cross_move`
+(ventas) ni de las diferencias de apertura/cierre de `binaural_pos_close`
+(`_post_foreign_statement_difference`) — ambos siguen llamando estas
+funciones sin pasarlo. Es un modo opt-in agregado para
+`binaural_pos_close.try_cash_in_out` (ver capability `pos-close-foreign-cash`,
+change `binaural-pos-close-foreign-cash-cross-move`, tareas T2.1/T2.2 para el
+razonamiento contable completo — no se repite aquí).
+
+Con `use_suspense=True`:
+
+- `_get_cross_transitory_account` SHALL devolver
+  `payment_method.journal_id.suspense_account_id` en vez de
+  `default_account_id`/`outstanding_account_id`.
+- `_get_cross_real_account` SHALL devolver `cross_journal.suspense_account_id`
+  en vez de `cross_journal.inbound/outbound_payment_method_line_ids
+  .payment_account_id`.
+- `_create_cross_move_for` SHALL invertir la dirección entrante/saliente
+  (llamando al builder contrario con los importes negados) antes de construir
+  las líneas, porque `suspense_account_id` recibe siempre la polaridad nativa
+  opuesta a `default_account_id` para el mismo movimiento.
+
+#### Scenario: Llamador sin `use_suspense` no cambia
+
+- **GIVEN** cualquier llamada existente a estas funciones sin el parámetro
+  (ventas, diferencias)
+- **WHEN** se ejecuta el cruce
+- **THEN** el comportamiento es idéntico al de antes de agregar el parámetro
+
+#### Scenario: Llamador con `use_suspense=True`
+
+- **GIVEN** un método `cash` con `cross_journal`/`cross_account_journal`
+  configurados
+- **WHEN** `binaural_pos_close.try_cash_in_out` dispara el cruce con
+  `use_suspense=True` para una entrada de efectivo
+- **THEN** el asiento debita `journal_id.suspense_account_id` y acredita
+  `cross_journal.suspense_account_id` — ambas patas quedan pendientes de
+  reconciliación bancaria real, no de las cuentas de liquidez confirmadas
+
 ## REMOVED Requirements
 
 ### Requirement: Cruce automático combine entrante

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-cross-move-by-split-transactions/tasks.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-cross-move-by-split-transactions/tasks.md
@@ -164,5 +164,20 @@ con traza T-account; no se repite acá).
       `default_account_id`/`payment_account_id` para el mismo movimiento
 - [x] 10.4 Spec delta en `pos-cross-account-move/spec.md`: Requirement
       "Modo `use_suspense` para llamadores fuera de ventas"
-- [ ] 10.5 Verificación manual en navegador (pendiente, ver
+- [x] 10.5 Tests directos en `tests/test_pos_session_cross_account_move.py`
+      (hasta este punto solo lo ejercitaban indirectamente los tests de
+      `binaural_pos_close`, vía `try_cash_in_out`): llama
+      `_create_cross_move_for(..., use_suspense=True)` directo con importes
+      planos, sin pasar por `try_cash_in_out` (vive en otro módulo).
+      `test_use_suspense_incoming_uses_both_suspense_accounts` /
+      `test_use_suspense_outgoing_mirrors_incoming`: ninguna pata usa
+      `default_account_id`/`payment_account_id` de `cross_journal`, ambas
+      caen en el `suspense_account_id` de su propio diario, con la
+      polaridad invertida en las dos direcciones.
+      `test_use_suspense_eligibility_requires_journal_suspense_account`:
+      `_is_cross_move_eligible(..., use_suspense=True)` exige
+      `suspense_account_id` en el diario — no le basta con que
+      `default_account_id` esté resuelto (lo único que exige
+      `use_suspense=False`).
+- [ ] 10.6 Verificación manual en navegador (pendiente, ver
       `binaural-pos-close-foreign-cash-cross-move`)

--- a/l10n_ve_pos/openspec/changes/l10n-ve-pos-cross-move-by-split-transactions/tasks.md
+++ b/l10n_ve_pos/openspec/changes/l10n-ve-pos-cross-move-by-split-transactions/tasks.md
@@ -140,3 +140,29 @@ porque el partner iba sólo en las líneas) — se leían como uno solo.
 - [x] 9.4 Ejemplo contable con números en `design.md`: los dos asientos que el
       nativo genera para un pago en efectivo, el descuadre que producía el
       código viejo, y la query para detectar asientos ya afectados
+
+## 10. Parámetro `use_suspense` (para `binaural_pos_close.try_cash_in_out`)
+
+Añadido después, a raíz de `binaural-pos-close-foreign-cash-cross-move`
+(tareas T2.1/T2.2 de ese change — ahí está el razonamiento contable completo
+con traza T-account; no se repite acá).
+
+- [x] 10.1 `use_suspense=False` agregado como parámetro opcional a
+      `_is_cross_move_eligible`, `_get_cross_transitory_account`,
+      `_line_vals_move_cross_incoming`/`_outgoing` y `_create_cross_move_for`
+      — default preserva el comportamiento existente para ventas
+      (`_validate_cross_move`, este change) y diferencias
+      (`binaural_pos_close._post_foreign_statement_difference`), ninguno de
+      los dos pasa el parámetro
+- [x] 10.2 Nuevo helper `_get_cross_real_account(payment_method, outbound,
+      use_suspense=False)`: con `True` resuelve
+      `cross_journal.suspense_account_id` en vez de
+      `inbound/outbound_payment_method_line_ids.payment_account_id`
+- [x] 10.3 `_create_cross_move_for` invierte la rama entrante/saliente y
+      niega los importes cuando `use_suspense=True`, porque
+      `suspense_account_id` recibe la polaridad nativa opuesta a
+      `default_account_id`/`payment_account_id` para el mismo movimiento
+- [x] 10.4 Spec delta en `pos-cross-account-move/spec.md`: Requirement
+      "Modo `use_suspense` para llamadores fuera de ventas"
+- [ ] 10.5 Verificación manual en navegador (pendiente, ver
+      `binaural-pos-close-foreign-cash-cross-move`)

--- a/l10n_ve_pos/tests/test_pos_session_cross_account_move.py
+++ b/l10n_ve_pos/tests/test_pos_session_cross_account_move.py
@@ -9,6 +9,7 @@ Verifies the cruce automatico in ``pos_session.py``: ``_validate_cross_move``
 Spec: ``openspec/changes/l10n-ve-pos-cross-move-by-split-transactions/specs/pos-cross-account-move/spec.md``
 """
 
+from odoo import fields
 from odoo.tests import tagged
 
 from .test_pos_session_accounting_common import TestPosSessionAccountingBase
@@ -93,13 +94,50 @@ class TestPosSessionCrossAccountMove(TestPosSessionAccountingBase):
             }
         )
 
-    def _legs(self, move, transitory_account):
-        """Split a cross move into (real-account leg, transitory leg)."""
-        real_leg = move.line_ids.filtered(lambda l: l.account_id == self.account_real_bank)
+    def _legs(self, move, transitory_account, real_account=None):
+        """Split a cross move into (real-account leg, transitory leg).
+
+        ``real_account`` defaults to ``account_real_bank`` (every
+        ``use_suspense=False`` caller: ventas). The ``use_suspense=True``
+        tests pass the journal's own suspense account instead -- see
+        ``_configure_use_suspense_accounts``.
+        """
+        real_account = real_account or self.account_real_bank
+        real_leg = move.line_ids.filtered(lambda l: l.account_id == real_account)
         transitory_leg = move.line_ids.filtered(lambda l: l.account_id == transitory_account)
         self.assertTrue(real_leg, "debe haber una linea sobre la cuenta real")
         self.assertTrue(transitory_leg, "debe haber una linea sobre la cuenta transitoria")
         return real_leg, transitory_leg
+
+    def _configure_use_suspense_accounts(self, method):
+        """Wire up dedicated suspense accounts for a ``use_suspense=True`` move.
+
+        Both legs need one: the origin journal's (``method.journal_id``,
+        cleared) and ``real_bank_journal``'s (credited/debited in place of
+        its confirmed liquidity account). Without the second, ``_get_cross_real_account``
+        resolves an empty recordset and ``account.move.create`` fails on a
+        null ``account_id`` -- this is what ``binaural_pos_close`` configures
+        implicitly via `cross_journal` in production.
+        """
+        suspense_origin = self.env["account.account"].create(
+            {
+                "name": f"C Suspense {method.name}",
+                "code": f"19{method.id:04d}C",
+                "account_type": "asset_current",
+                "company_ids": [(6, 0, [self.company.id])],
+            }
+        )
+        suspense_real = self.env["account.account"].create(
+            {
+                "name": f"C Real Bank Suspense {method.name}",
+                "code": f"18{method.id:04d}C",
+                "account_type": "asset_current",
+                "company_ids": [(6, 0, [self.company.id])],
+            }
+        )
+        method.journal_id.suspense_account_id = suspense_origin.id
+        self.real_bank_journal.suspense_account_id = suspense_real.id
+        return suspense_origin, suspense_real
 
     # ------------------------------------------------------------------
     # Granularidad: split_transactions decide cuantos asientos se crean
@@ -373,6 +411,123 @@ class TestPosSessionCrossAccountMove(TestPosSessionAccountingBase):
             moves.line_ids.filtered(lambda l: l.account_id == self.account_pos_receivable),
             "la POS receivable ya quedo saldada por el statement line nativo: "
             "el cruce no debe tocarla",
+        )
+
+    # ------------------------------------------------------------------
+    # Modo use_suspense (llamadores fuera de ventas -- ver binaural_pos_close)
+    # ------------------------------------------------------------------
+    def test_use_suspense_incoming_uses_both_suspense_accounts(self):
+        """``use_suspense=True``, entrada: ninguna pata usa las cuentas de
+        ``use_suspense=False`` (``default_account_id`` / ``payment_account_id``
+        de ``cross_journal``) -- ambas caen en el ``suspense_account_id`` de
+        su propio diario.
+
+        Usado por ``binaural_pos_close.try_cash_in_out``: ese flujo nunca fija
+        ``counterpart_account_id`` en su linea de extracto, asi que la nativa
+        cae en ``journal_id.suspense_account_id``, no en ``default_account_id``
+        -- ese es el saldo que este modo debe drenar. Se llama directo a
+        ``_create_cross_move_for`` con importes planos, sin pasar por
+        ``try_cash_in_out`` (vive en otro modulo).
+        """
+        suspense_origin, suspense_real = self._configure_use_suspense_accounts(
+            self.split_cash_method
+        )
+        self._configure_cross(self.split_cash_method)
+        session = self._new_session().with_company(self.company)
+
+        move = session._create_cross_move_for(
+            self.split_cash_method,
+            amount=58.0,
+            foreign_amount=58.0 * 36.5,
+            foreign_rate=36.5,
+            partner=self.env["res.partner"],
+            date=fields.Datetime.now(),
+            ref="use_suspense incoming",
+            use_suspense=True,
+        )
+
+        self.assertEqual(move.state, "draft")
+        real_leg, transitory_leg = self._legs(
+            move, suspense_origin, real_account=suspense_real
+        )
+        self.assertFalse(
+            move.line_ids.filtered(lambda l: l.account_id == self.account_cash),
+            "default_account_id no debe aparecer: ese saldo ya lo drena el "
+            "cruce use_suspense=False (ventas), este es un saldo distinto",
+        )
+        self.assertFalse(
+            move.line_ids.filtered(lambda l: l.account_id == self.account_real_bank),
+            "tampoco la cuenta de liquidez confirmada de cross_journal",
+        )
+        # Polaridad invertida respecto a use_suspense=False: suspense_account_id
+        # recibe siempre el lado nativo opuesto a default_account_id para el
+        # mismo movimiento, asi que limpiarla debita la transitoria (no la
+        # acredita) y acredita la real (no la debita).
+        self.assertAlmostEqual(transitory_leg.debit, 58.0, places=2)
+        self.assertAlmostEqual(transitory_leg.foreign_debit, 58.0 * 36.5, places=2)
+        self.assertAlmostEqual(real_leg.credit, 58.0, places=2)
+        self.assertAlmostEqual(real_leg.foreign_credit, 58.0 * 36.5, places=2)
+
+    def test_use_suspense_outgoing_mirrors_incoming(self):
+        """``use_suspense=True``, salida (``amount<0``): espejo exacto de la
+        entrada -- se debita la real y se acredita la transitoria."""
+        suspense_origin, suspense_real = self._configure_use_suspense_accounts(
+            self.split_cash_method
+        )
+        self._configure_cross(self.split_cash_method)
+        session = self._new_session().with_company(self.company)
+
+        move = session._create_cross_move_for(
+            self.split_cash_method,
+            amount=-25.0,
+            foreign_amount=-25.0 * 36.5,
+            foreign_rate=36.5,
+            partner=self.env["res.partner"],
+            date=fields.Datetime.now(),
+            ref="use_suspense outgoing",
+            use_suspense=True,
+        )
+
+        real_leg, transitory_leg = self._legs(
+            move, suspense_origin, real_account=suspense_real
+        )
+        self.assertAlmostEqual(transitory_leg.credit, 25.0, places=2)
+        self.assertAlmostEqual(real_leg.debit, 25.0, places=2)
+
+    def test_use_suspense_eligibility_requires_journal_suspense_account(self):
+        """``_is_cross_move_eligible(..., use_suspense=True)`` exige que el
+        diario tenga ``suspense_account_id`` propio -- no le basta con que
+        ``default_account_id`` este resuelto, que es lo unico que exige
+        ``use_suspense=False`` (ventas)."""
+        self._configure_cross(self.split_cash_method)
+        session = self._new_session().with_company(self.company)
+
+        self.assertFalse(
+            self.split_cash_method.journal_id.suspense_account_id,
+            "fixture: sin configurar todavia",
+        )
+        self.assertTrue(
+            session._is_cross_move_eligible(self.split_cash_method),
+            "use_suspense=False (default, ventas) ya es elegible con "
+            "default_account_id resuelto",
+        )
+        self.assertFalse(
+            session._is_cross_move_eligible(self.split_cash_method, use_suspense=True),
+            "use_suspense=True no es elegible sin suspense_account_id en el diario",
+        )
+
+        suspense_origin = self.env["account.account"].create(
+            {
+                "name": "C Eligibility Suspense",
+                "code": "199999C",
+                "account_type": "asset_current",
+                "company_ids": [(6, 0, [self.company.id])],
+            }
+        )
+        self.split_cash_method.journal_id.suspense_account_id = suspense_origin.id
+        self.assertTrue(
+            session._is_cross_move_eligible(self.split_cash_method, use_suspense=True),
+            "una vez configurado el suspense del diario, si es elegible",
         )
 
     # ------------------------------------------------------------------

--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -14,6 +14,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/res_group.xml",
         "views/pos_config.xml",
         "views/pos_order.xml",
         "views/pos_session.xml",

--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
-    "version": "19.0.3.0.1",
+    "version": "19.0.3.0.2",
     "category": "Accounting",
     "summary": "Venezuela - Integración de Punto de Venta con Maquina Fiscal (Web Serial API)",
     "sequence": "1",

--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
-    "version": "19.0.3.0.0",
+    "version": "19.0.3.0.1",
     "category": "Accounting",
     "summary": "Venezuela - Integración de Punto de Venta con Maquina Fiscal (Web Serial API)",
     "sequence": "1",

--- a/l10n_ve_pos_mf/i18n/es_VE.po
+++ b/l10n_ve_pos_mf/i18n/es_VE.po
@@ -444,3 +444,8 @@ msgstr "La máquina fiscal no respondió a tiempo"
 #, python-format
 msgid "Error with the tax machine"
 msgstr "Error con la máquina fiscal"
+
+#. module: l10n_ve_pos_mf
+#: model:res.groups,name:l10n_ve_pos_mf.group_pos_close_native
+msgid "Close POS session natively (skip mandatory Z report)"
+msgstr "Cerrar sesión de PDV de forma nativa (sin Reporte Z obligatorio)"

--- a/l10n_ve_pos_mf/models/__init__.py
+++ b/l10n_ve_pos_mf/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_tax
 from . import pos_session
 from . import pos_payment_method
 from . import res_config_settings
+from . import res_users

--- a/l10n_ve_pos_mf/models/res_users.py
+++ b/l10n_ve_pos_mf/models/res_users.py
@@ -1,0 +1,23 @@
+from odoo import models, api
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    @api.model
+    def _load_pos_data_read(self, records, config):
+        """Expone si el usuario puede cerrar la sesion de PDV con el boton
+        nativo de Odoo (sin Reporte Z ni validacion de pedidos sin
+        facturar), ademas del flujo dual existente.
+
+        Clave con prefijo "_" obligatorio: es el unico formato que el
+        related_models del cliente conserva sin descartar (mismo mecanismo
+        que usa _role en el core, ver l10n_ve_pos/models/res_users.py).
+        """
+        read_records = super()._load_pos_data_read(records, config)
+        if read_records:
+            user = records[0]
+            read_records[0]['_can_close_session_native'] = user.has_group(
+                'l10n_ve_pos_mf.group_pos_close_native'
+            )
+        return read_records

--- a/l10n_ve_pos_mf/openspec/changes/l10n-ve-pos-mf-close-session-native-group/design.md
+++ b/l10n_ve_pos_mf/openspec/changes/l10n-ve-pos-mf-close-session-native-group/design.md
@@ -1,0 +1,66 @@
+## Context
+
+El popup de cierre de sesión del PDV (`ClosePosPopup`) ya fue modificado por
+`l10n_ve_pos_mf` para exigir un flujo fiscal dual (Reporte X + Reporte Z
+obligatorio) a todo usuario, reemplazando el botón nativo `Close Register`
+del core de Odoo 19 vía herencia XML (`t-inherit-mode="extension"`, xpath
+`position="replace"` sobre `//button[@t-on-click='confirm']`). El módulo
+hermano `l10n_ve_pos` (dependencia de `l10n_ve_pos_mf`) ya resuelve un
+problema análogo — exponer un permiso custom de VE al frontend del PDV — con
+`group_change_qty_on_pos_order` / `group_change_price_on_pos_order`
+(`res.groups` sin `privilege_id`, expuestos vía `_load_pos_data_read` con
+clave `_`). Este cambio reutiliza ese mismo patrón para un permiso nuevo.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Permitir que usuarios seleccionados cierren sesión de PDV con el botón
+  nativo de Odoo (sin Reporte Z), cuando la situación lo amerite.
+- No alterar el comportamiento de nadie que no tenga el grupo.
+
+**Non-Goals:**
+- No se rediseña el flujo fiscal dual existente (Reporte X / Reporte Z).
+- No se agrega UI de configuración nueva (el control de acceso es 100% vía
+  grupo de seguridad estándar de Odoo, en "Extra Rights").
+- No se restringe también el Reporte X para el nuevo grupo — ese botón de
+  consulta sigue disponible para todos, como hoy.
+
+## Decisions
+
+- **Aditivo, no toggle/reemplazo:** el botón nativo se agrega como tercera
+  opción junto a los dos existentes, en vez de mostrar unos u otros según el
+  grupo. Alternativa considerada y descartada: `t-if`/`t-else` que
+  reemplazara el flujo dual por el nativo para el grupo — el usuario indicó
+  explícitamente que quiere las tres opciones visibles a la vez para poder
+  elegir en el momento del cierre.
+- **Bypass total, no parcial:** el botón nativo llama a `confirm()` directo,
+  sin ejecutar `_getUnfiscalizedOrders()` ni exigir Reporte Z. Alternativa
+  considerada: mantener la validación de pedidos sin facturar y solo saltar
+  el Reporte Z. Se descartó porque el usuario confirmó que quiere el
+  comportamiento 100% nativo de Odoo para este botón, asumiendo el riesgo
+  fiscal como decisión deliberada (grupo de asignación restringida).
+- **`res.groups` sin `privilege_id`:** igual que los dos grupos VE ya
+  existentes en `l10n_ve_pos`, para que aparezca como checkbox independiente
+  en "Extra Rights" en vez de fusionarse (radio/select) con
+  `group_pos_user`/`group_pos_manager`.
+- **Exposición vía `_load_pos_data_read` con prefijo `_`:** único formato
+  que el `related_models` del cliente conserva sin descartar en Odoo 19 (ver
+  capability `pos-close-session-permission` / spec.md, y memoria
+  `pos-o19-related-models-underscore-fields`).
+- **Botón nuevo colocado después del de Reporte Z** (`position="after"` en
+  el xpath), no antes del de Reporte X, para que el orden visual sea:
+  Reporte X → Cerrar sesion e imprimir Z → Cerrar sesión (nativo), dejando
+  la opción de bypass fiscal al final.
+
+## Risks / Trade-offs
+
+- [Riesgo] Un usuario con el grupo puede cerrar una sesión con ventas sin
+  fiscalizar en la máquina fiscal, sin ninguna advertencia adicional más
+  allá del tooltip del botón → Mitigación: el grupo es opt-in explícito (no
+  se asigna a nadie por defecto) y debe reservarse a roles de
+  gerencia/soporte; el tooltip dice explícitamente que se salta Reporte Z y
+  la validación de pedidos.
+- [Riesgo] Confusión del cajero entre los tres botones → Mitigación: el
+  tercer botón solo aparece para quien tenga el grupo (la mayoría de
+  cajeros no lo verá) y usa una etiqueta distinta ("Cerrar sesión" vs
+  "Cerrar sesion e imprimir Z").

--- a/l10n_ve_pos_mf/openspec/changes/l10n-ve-pos-mf-close-session-native-group/proposal.md
+++ b/l10n_ve_pos_mf/openspec/changes/l10n-ve-pos-mf-close-session-native-group/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+En `l10n_ve_pos_mf`, cerrar sesión de PDV exige hoy, para todo usuario, pasar
+por el flujo dual fiscal (Reporte X + Reporte Z obligatorio, con bloqueo si
+hay pedidos sin facturar en la máquina fiscal). No existe forma de que un
+usuario autorizado (ej. gerente, soporte) cierre una sesión con el botón
+nativo de Odoo cuando la situación lo amerite (correcciones, sesiones sin
+máquina fiscal), sin quitarle a nadie el flujo fiscal existente.
+
+## What Changes
+
+- Nuevo grupo de seguridad `l10n_ve_pos_mf.group_pos_close_native` ("Close
+  POS session natively (skip mandatory Z report)"), checkbox independiente
+  en "Extra Rights" (sin `privilege_id`).
+- Nuevo `models/res_users.py` que expone `_can_close_session_native` al
+  frontend del PDV vía `_load_pos_data_read` (mismo patrón que
+  `l10n_ve_pos/models/res_users.py`).
+- `ClosePosPopup.js`/`ClosePosPopup.xml`: se añade un tercer botón "Cerrar
+  sesión", visible solo con el grupo, junto a los dos botones existentes
+  (Reporte X, Cerrar sesion e imprimir Z) — no los reemplaza.
+- El botón nuevo es un bypass total (llama a `confirm()` nativo): no imprime
+  Reporte Z, no incrementa `report_z`/`mf_reportz`, y no valida pedidos sin
+  facturar (`_getUnfiscalizedOrders`). Decisión deliberada, confirmada con el
+  usuario.
+- Sin el grupo, el comportamiento no cambia: solo se ven los dos botones del
+  flujo dual, igual que hoy. Nadie tiene el grupo asignado por defecto.
+- Traducción es_VE del nombre del grupo añadida en `i18n/es_VE.po`.
+
+## Capabilities
+
+### New Capabilities
+- `pos-close-session-permission`: control de acceso por grupo a un cierre de
+  sesión de PDV nativo (sin Reporte Z) como alternativa opcional al flujo
+  fiscal dual existente.
+
+### Modified Capabilities
+(ninguna — el flujo dual existente no tiene spec propio documentado hasta
+ahora y no cambia su comportamiento)
+
+## Impact
+
+- Módulo: `l10n_ve_pos_mf` (seguridad, modelos, frontend PDV, i18n). No se
+  toca `l10n_ve_pos` ni ningún otro módulo — solo se sigue su patrón de
+  permisos existente (`group_change_qty_on_pos_order` /
+  `group_change_price_on_pos_order`).
+- Riesgo fiscal: un usuario con el nuevo grupo puede cerrar una sesión con
+  ventas sin fiscalizar en la máquina fiscal. El grupo debe asignarse con
+  criterio, no de forma general.
+- Verificación: manual en navegador (ver `tasks.md`); no se ejecutaron tests
+  automatizados ni `odoo -u` como parte de este cambio.
+- Referencia: tarea https://binaural.odoo.com/odoo/action-341/78328

--- a/l10n_ve_pos_mf/openspec/changes/l10n-ve-pos-mf-close-session-native-group/specs/pos-close-session-permission/spec.md
+++ b/l10n_ve_pos_mf/openspec/changes/l10n-ve-pos-mf-close-session-native-group/specs/pos-close-session-permission/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Native close session button for authorized users
+The system SHALL show an additional "Cerrar sesión" button in the POS
+closing popup, alongside the existing dual fiscal flow (Reporte X / Cerrar
+sesion e imprimir Z), for users in the `l10n_ve_pos_mf.group_pos_close_native`
+group.
+
+#### Scenario: User with the group sees three buttons
+- **WHEN** a cashier with `group_pos_close_native` opens the closing popup
+- **THEN** the popup shows "Reporte X", "Cerrar sesion e imprimir Z", and
+  "Cerrar sesión"
+
+#### Scenario: User without the group sees only the dual flow
+- **WHEN** a cashier without `group_pos_close_native` opens the closing
+  popup
+- **THEN** the popup shows only "Reporte X" and "Cerrar sesion e imprimir Z",
+  unchanged from current behavior
+
+### Requirement: Native close bypasses fiscal validations
+The native "Cerrar sesión" button MUST close the POS session using Odoo's
+native `confirm()` flow, without printing the Z report and without
+validating that all session orders are invoiced in the fiscal machine.
+
+#### Scenario: Close with unfiscalized orders
+- **WHEN** a user with `group_pos_close_native` clicks "Cerrar sesión" while
+  the session has orders with an empty `mf_invoice_number`
+- **THEN** the session closes normally, without blocking on unfiscalized
+  orders and without printing a Z report
+
+### Requirement: Permission exposed to the POS frontend
+The system SHALL expose whether the current user belongs to
+`l10n_ve_pos_mf.group_pos_close_native` to the POS frontend as
+`_can_close_session_native`, computed server-side via `_load_pos_data_read`.
+
+#### Scenario: Frontend reads the permission
+- **WHEN** the POS session loads data for the current user
+- **THEN** `pos.user._can_close_session_native` reflects the user's
+  membership in `group_pos_close_native`

--- a/l10n_ve_pos_mf/openspec/changes/l10n-ve-pos-mf-close-session-native-group/tasks.md
+++ b/l10n_ve_pos_mf/openspec/changes/l10n-ve-pos-mf-close-session-native-group/tasks.md
@@ -1,0 +1,29 @@
+## 1. Grupo de permisos y exposición al frontend
+
+- [x] 1.1 `security/res_group.xml`: nuevo `res.groups`
+      `group_pos_close_native`, sin `privilege_id`
+- [x] 1.2 Registrar `security/res_group.xml` en `__manifest__.py` (`data`)
+- [x] 1.3 `models/res_users.py`: override `_load_pos_data_read` exponiendo
+      `_can_close_session_native`
+- [x] 1.4 Registrar `res_users` en `models/__init__.py`
+- [x] 1.5 Traducción es_VE del nombre del grupo en `i18n/es_VE.po`
+
+## 2. Frontend: tercer botón de cierre nativo
+
+- [x] 2.1 `ClosePosPopup.js`: `this.canCloseNative` en `setup()`
+- [x] 2.2 `ClosePosPopup.xml`: nuevo xpath `position="after"` sobre el botón
+      de Reporte Z, botón "Cerrar sesión" con `t-if="canCloseNative"`
+      llamando a `confirm()` nativo
+
+## 3. Verificación funcional (manual, en navegador)
+
+- [ ] 3.1 Actualizar el módulo `l10n_ve_pos_mf`
+- [ ] 3.2 Asignar el grupo "Close POS session natively (skip mandatory Z
+      report)" a un usuario de prueba en Ajustes > Usuarios (Extra Rights)
+- [ ] 3.3 Abrir el PDV con ese usuario, cerrar sesión: deben verse los tres
+      botones (Reporte X, Cerrar sesion e imprimir Z, Cerrar sesión). Probar
+      el tercero: debe cerrar sin exigir Reporte Z ni pedidos facturados
+- [ ] 3.4 Abrir el PDV con un usuario SIN el grupo: debe verse solo el flujo
+      dual de siempre, sin el tercer botón
+- [ ] 3.5 Confirmar que ningún usuario existente quedó con el grupo asignado
+      por accidente tras actualizar el módulo

--- a/l10n_ve_pos_mf/openspec/config.yaml
+++ b/l10n_ve_pos_mf/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/l10n_ve_pos_mf/security/res_group.xml
+++ b/l10n_ve_pos_mf/security/res_group.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data>
+
+    <record id="group_pos_close_native" model="res.groups">
+        <field name="name">Close POS session natively (skip mandatory Z report)</field>
+        <!-- Sin privilege_id a propósito: mismo patrón que
+             l10n_ve_pos.group_change_qty_on_pos_order, para que quede como
+             checkbox independiente en "Extra Rights" y no como opción
+             excluyente con group_pos_user/group_pos_manager. -->
+        <field name="privilege_id" eval="False"/>
+    </record>
+
+</data>
+</odoo>

--- a/l10n_ve_pos_mf/static/src/js/ClosePosPopup.js
+++ b/l10n_ve_pos_mf/static/src/js/ClosePosPopup.js
@@ -13,6 +13,10 @@ patch(ClosePosPopup.prototype, {
     super.setup(...arguments);
     this.orm = useService("orm");
     this.mfState = useState({ isPrintingReport: false });
+    // Permiso VE: usuarios con l10n_ve_pos_mf.group_pos_close_native ven
+    // ademas un boton de cierre nativo (sin Reporte Z ni validacion de
+    // pedidos sin facturar), junto al flujo dual existente.
+    this.canCloseNative = Boolean(this.pos.user._can_close_session_native);
   },
 
   getFiscalPrinter() {

--- a/l10n_ve_pos_mf/static/src/xml/ClosePosPopup.xml
+++ b/l10n_ve_pos_mf/static/src/xml/ClosePosPopup.xml
@@ -29,5 +29,18 @@
                 <t t-else="">Reporte X</t>
             </button>
         </xpath>
+        <!-- Boton adicional (solo con el grupo group_pos_close_native):
+             cierre 100% nativo de Odoo, sin Reporte Z ni validacion de
+             pedidos sin facturar. -->
+        <xpath expr="//button[@t-on-click='closeSessionAndPrintZ']" position="after">
+            <button
+                t-if="canCloseNative"
+                class="button btn btn-secondary btn-lg"
+                t-att-disabled="!canConfirm()"
+                t-on-click="confirm"
+                title="Cierra la sesion de POS sin imprimir Reporte Z ni validar pedidos sin facturar (cierre nativo)">
+                Cerrar sesión
+            </button>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Nuevo grupo group_pos_close_native que añade un tercer boton "Cerrar
sesion" en el popup de cierre del PDV, junto al flujo dual existente
(Reporte X / Cerrar sesion e imprimir Z). El boton nuevo es un bypass
total (cierre nativo de Odoo, sin Reporte Z ni validacion de pedidos
sin facturar), pensado para gerencia/soporte en casos ex