### PR TITLE
Corrige migraciones de contabilidad y problemas de redondeo en IGTF/facturas

### DIFF
--- a/l10n_ve_accountant/migrations/17.0.0.0.56/post-migration.py
+++ b/l10n_ve_accountant/migrations/17.0.0.0.56/post-migration.py
@@ -42,7 +42,7 @@ def _reconciled_move_ids(cr, company, state_filter=('posted',)):
     return [row[0] for row in cr.fetchall()]
 
 
-def _do_sql_rounding(cr, company, fc_id, precision, state_filter, excluded_move_ids=()):
+def _do_sql_rounding(cr, company, precision, state_filter, excluded_move_ids=()):
     """Round foreign monetary fields via SQL, scoped to one company.
 
     - ``company_id`` filter keeps every company's lines from being rounded with
@@ -55,7 +55,6 @@ def _do_sql_rounding(cr, company, fc_id, precision, state_filter, excluded_move_
     params = {
         'prec': precision,
         'prec_fc': precision,
-        'fc_id': fc_id,
         'company_id': company.id,
         'states': state_filter,
         'excluded': list(excluded_move_ids),
@@ -141,35 +140,50 @@ def _do_sql_rounding(cr, company, fc_id, precision, state_filter, excluded_move_
     _logger.info("    SQL partial_reconcile: %s rows updated", cr.rowcount)
 
 
-def _check_and_fix_balance(cr, company, state_filter, excluded_move_ids=(), tolerance=0.01):
+def _check_and_fix_balance(cr, company, precision, state_filter, excluded_move_ids=(), tolerance=None):
     """Detect foreign debit/credit drift introduced by independent rounding and
-    repair it by adjusting the line with the largest debit (or credit)."""
+    repair it by adjusting the line with the largest debit (or credit).
+
+    Locked/closed periods are never touched, matching every other pass in
+    this file. ``precision`` drives both the rounding and the drift
+    tolerance instead of hardcoding 2 decimals (correct for USD/VEF, wrong
+    for any future 4-decimal foreign currency).
+    """
+    if tolerance is None:
+        tolerance = 10 ** -precision
+    params = {
+        'company_id': company.id,
+        'states': state_filter,
+        'excluded': list(excluded_move_ids),
+        'tolerance': tolerance,
+        'prec': precision,
+        'tax_lock': company.tax_lock_date or '1900-01-01',
+        'fy_lock': company.fiscalyear_lock_date or '1900-01-01',
+    }
+    lock_filter = _lock_expr('m')
     cr.execute("""
         SELECT m.id, m.name,
-               ROUND(SUM(l.foreign_debit) - SUM(l.foreign_credit), 2) AS delta
+               ROUND(SUM(l.foreign_debit) - SUM(l.foreign_credit), %(prec)s) AS delta
         FROM account_move_line l
         JOIN account_move m ON l.move_id = m.id
         WHERE m.state IN %(states)s
           AND m.company_id = %(company_id)s
           AND NOT (m.id = ANY(%(excluded)s::bigint[]))
+          AND """ + lock_filter + """
         GROUP BY m.id, m.name
         HAVING ABS(SUM(l.foreign_debit) - SUM(l.foreign_credit)) > %(tolerance)s
-    """, {
-        'company_id': company.id,
-        'states': state_filter,
-        'excluded': list(excluded_move_ids),
-        'tolerance': tolerance,
-    })
+    """, params)
     rows = cr.fetchall()
     for move_id, name, delta in rows:
         _logger.warning(
             "    Move %s (id=%s) drifted %.2f after rounding; repairing",
             name, move_id, delta,
         )
+        row_params = {'move_id': move_id, 'delta': delta, 'prec': precision}
         if delta > 0:
             cr.execute("""
                 UPDATE account_move_line l
-                SET foreign_debit = ROUND(l.foreign_debit - %(delta)s, 2)
+                SET foreign_debit = ROUND(l.foreign_debit - %(delta)s, %(prec)s)
                 WHERE l.id = (
                     SELECT ll.id FROM account_move_line ll
                     WHERE ll.move_id = %(move_id)s
@@ -177,11 +191,11 @@ def _check_and_fix_balance(cr, company, state_filter, excluded_move_ids=(), tole
                     ORDER BY ll.foreign_debit DESC NULLS LAST, ll.id
                     LIMIT 1
                 )
-            """, {'move_id': move_id, 'delta': delta})
+            """, row_params)
         else:
             cr.execute("""
                 UPDATE account_move_line l
-                SET foreign_credit = ROUND(l.foreign_credit + %(delta)s, 2)
+                SET foreign_credit = ROUND(l.foreign_credit + %(delta)s, %(prec)s)
                 WHERE l.id = (
                     SELECT ll.id FROM account_move_line ll
                     WHERE ll.move_id = %(move_id)s
@@ -189,13 +203,13 @@ def _check_and_fix_balance(cr, company, state_filter, excluded_move_ids=(), tole
                     ORDER BY ll.foreign_credit DESC NULLS LAST, ll.id
                     LIMIT 1
                 )
-            """, {'move_id': move_id, 'delta': delta})
+            """, row_params)
         # keep foreign_balance consistent with the adjusted debit/credit
         cr.execute("""
             UPDATE account_move_line l
-            SET foreign_balance = ROUND(l.foreign_debit - l.foreign_credit, 2)
+            SET foreign_balance = ROUND(l.foreign_debit - l.foreign_credit, %(prec)s)
             WHERE l.move_id = %(move_id)s
-        """, {'move_id': move_id})
+        """, row_params)
         _logger.info("    Repaired move %s (delta=%.2f)", name, delta)
 
 
@@ -637,8 +651,8 @@ def migrate(cr, version):
 
         # ---- SQL rounding for draft (reliable) ----
         _logger.info("    Draft SQL rounding...")
-        _do_sql_rounding(cr, company, fc.id, fc_precision, ('draft',))
-        _check_and_fix_balance(cr, company, ('draft',))
+        _do_sql_rounding(cr, company, fc_precision, ('draft',))
+        _check_and_fix_balance(cr, company, fc_precision, ('draft',))
 
         # ---- POSTED SQL rounding (only VEF base) ----
         reconciled_ids = _reconciled_move_ids(cr, company, ('posted',))
@@ -653,19 +667,22 @@ def migrate(cr, version):
                 len(reconciled_ids),
             )
             _do_sql_rounding(
-                cr, company, fc.id, fc_precision, ('posted',),
+                cr, company, fc_precision, ('posted',),
                 excluded_move_ids=reconciled_ids,
             )
             _check_and_fix_balance(
-                cr, company, ('posted',), excluded_move_ids=reconciled_ids,
+                cr, company, fc_precision, ('posted',), excluded_move_ids=reconciled_ids,
             )
 
-        # ---- Reconciled lines + settlements (respecting lock dates) ----
-        _logger.info("    Reconciled rounding pass (%s reconciled moves)...",
-                     len(reconciled_ids))
-        _round_reconciled_lines(cr, company, fc_precision, reconciled_ids)
-        _rebuild_reconciled_partials(cr, company, fc_precision)
-        _recompute_residuals(cr, company)
+            # ---- Reconciled lines + settlements (respecting lock dates) ----
+            # Gated behind process_posted: these touch posted reconciled
+            # lines/partials/residuals, so a base=USD company ("draft only")
+            # must not have its posted data rounded/rebuilt here either.
+            _logger.info("    Reconciled rounding pass (%s reconciled moves)...",
+                         len(reconciled_ids))
+            _round_reconciled_lines(cr, company, fc_precision, reconciled_ids)
+            _rebuild_reconciled_partials(cr, company, fc_precision)
+            _recompute_residuals(cr, company)
 
     if all_errors:
         raise RuntimeError(

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -800,10 +800,6 @@ class AccountMove(models.Model):
         main_move_payment_concept = ""
         payment_related_move_ids = []
 
-        main_move = {
-            "name": self.name,
-        }
-
         line_ids_ids = self._get_account_move_line_related()
         line_ids = self.env["account.move.line"].browse(line_ids_ids)
         account_analytic_by_line_id = self._account_analytic_by_line_id(line_ids)

--- a/l10n_ve_accountant/tests/test_migration_rounding.py
+++ b/l10n_ve_accountant/tests/test_migration_rounding.py
@@ -103,7 +103,7 @@ class TestMigrationRounding(TransactionCase):
 
         self.company.tax_lock_date = fields.Date.today()
         self.mod._do_sql_rounding(
-            self.env.cr, self.company, self.currency_usd.id, 2, ("posted",),
+            self.env.cr, self.company, 2, ("posted",),
         )
         self.assertEqual(
             self._line_value(inv.id, self.acc_inc), (1.23456, 0.0),
@@ -112,7 +112,7 @@ class TestMigrationRounding(TransactionCase):
 
         self.company.tax_lock_date = False
         self.mod._do_sql_rounding(
-            self.env.cr, self.company, self.currency_usd.id, 2, ("posted",),
+            self.env.cr, self.company, 2, ("posted",),
         )
         self.assertEqual(
             self._line_value(inv.id, self.acc_inc), (1.23, 0.0),
@@ -124,7 +124,7 @@ class TestMigrationRounding(TransactionCase):
         self._dirty(inv.id)
 
         self.mod._do_sql_rounding(
-            self.env.cr, self.company, self.currency_usd.id, 2, ("posted",),
+            self.env.cr, self.company, 2, ("posted",),
             excluded_move_ids=[inv.id],
         )
         self.assertEqual(
@@ -133,7 +133,7 @@ class TestMigrationRounding(TransactionCase):
         )
 
         self.mod._do_sql_rounding(
-            self.env.cr, self.company, self.currency_usd.id, 2, ("posted",),
+            self.env.cr, self.company, 2, ("posted",),
         )
         self.assertEqual(
             self._line_value(inv.id, self.acc_inc), (1.23, 0.0),
@@ -191,10 +191,10 @@ class TestMigrationRounding(TransactionCase):
         )
 
         self.mod._do_sql_rounding(
-            self.env.cr, self.company, self.currency_usd.id, 2, ("posted",),
+            self.env.cr, self.company, 2, ("posted",),
         )
         self.mod._check_and_fix_balance(
-            self.env.cr, self.company, ("posted",),
+            self.env.cr, self.company, 2, ("posted",),
         )
 
         self.env.cr.execute(

--- a/l10n_ve_igtf/migrations/17.0.1.0.2/post-migration.py
+++ b/l10n_ve_igtf/migrations/17.0.1.0.2/post-migration.py
@@ -47,6 +47,16 @@ def migrate(cr, version):
                         cr.execute(sql.SQL("ALTER TABLE {} DROP CONSTRAINT {}").format(tbl, fk_id))
                         _logger.info("    Dropped FK %s on %s.%s", fk_name, table, col)
 
+                cr.execute(
+                    sql.SQL("SELECT count(*) FROM {} WHERE {} IS NOT NULL").format(tbl, col_id)
+                )
+                non_null_count = cr.fetchone()[0]
+                if non_null_count:
+                    _logger.warning(
+                        "    %s.%s had %s non-null row(s) before being dropped",
+                        table, col, non_null_count,
+                    )
+
                 cr.execute(sql.SQL("ALTER TABLE {} DROP COLUMN {}").format(tbl, col_id))
                 _logger.info("    Dropped column %s.%s", table, col)
             else:

--- a/l10n_ve_igtf/wizard/accounting_reports.py
+++ b/l10n_ve_igtf/wizard/accounting_reports.py
@@ -97,7 +97,7 @@ class WizardAccountingReports(models.TransientModel):
         is_check_currency_system = self.currency_system
         fields = super()._fields_sale_book_line(move, taxes)
         multiplier = -1 if move.move_type == "out_refund" else 1
-        is_igtf = bool(move.alter_bi_igtf > 0 or move.foreign_alter_bi_igtf > 0)
+        is_igtf = bool(getattr(move, "alter_bi_igtf", 0) > 0 or getattr(move, "foreign_alter_bi_igtf", 0) > 0)
         igtf = (move.tax_totals["igtf"]["igtf_amount"] if is_check_currency_system else move.tax_totals["igtf"]["foreign_igtf_amount"]) if is_igtf else 0
         fields |= {"igtf": igtf * multiplier,}
         return fields
@@ -126,7 +126,7 @@ class WizardAccountingReports(models.TransientModel):
         is_check_currency_system = self.currency_system
         fields = super()._fields_purchase_book_line(move, taxes)
         multiplier = -1 if move.move_type == "in_refund" else 1
-        is_igtf = bool(move.alter_bi_igtf > 0 or move.foreign_alter_bi_igtf > 0)
+        is_igtf = bool(getattr(move, "alter_bi_igtf", 0) > 0 or getattr(move, "foreign_alter_bi_igtf", 0) > 0)
         igtf =  (move.tax_totals["igtf"]["igtf_amount"] if is_check_currency_system else move.tax_totals["igtf"]["foreign_igtf_amount"]) if is_igtf else 0
         fields |= {"igtf": igtf * multiplier,}
         return fields

--- a/l10n_ve_igtf/wizard/accounting_reports.py
+++ b/l10n_ve_igtf/wizard/accounting_reports.py
@@ -97,7 +97,7 @@ class WizardAccountingReports(models.TransientModel):
         is_check_currency_system = self.currency_system
         fields = super()._fields_sale_book_line(move, taxes)
         multiplier = -1 if move.move_type == "out_refund" else 1
-        is_igtf = bool(getattr(move, "alter_bi_igtf", 0) > 0 or getattr(move, "foreign_alter_bi_igtf", 0) > 0)
+        is_igtf = bool(move.alter_bi_igtf > 0 or move.foreign_alter_bi_igtf > 0)
         igtf = (move.tax_totals["igtf"]["igtf_amount"] if is_check_currency_system else move.tax_totals["igtf"]["foreign_igtf_amount"]) if is_igtf else 0
         fields |= {"igtf": igtf * multiplier,}
         return fields
@@ -126,7 +126,7 @@ class WizardAccountingReports(models.TransientModel):
         is_check_currency_system = self.currency_system
         fields = super()._fields_purchase_book_line(move, taxes)
         multiplier = -1 if move.move_type == "in_refund" else 1
-        is_igtf = bool(getattr(move, "alter_bi_igtf", 0) > 0 or getattr(move, "foreign_alter_bi_igtf", 0) > 0)
+        is_igtf = bool(move.alter_bi_igtf > 0 or move.foreign_alter_bi_igtf > 0)
         igtf =  (move.tax_totals["igtf"]["igtf_amount"] if is_check_currency_system else move.tax_totals["igtf"]["foreign_igtf_amount"]) if is_igtf else 0
         fields |= {"igtf": igtf * multiplier,}
         return fields

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -86,11 +86,19 @@ class AccountMove(models.Model):
             if float_compare(line.price_unit, 0, precision_digits=precision) == -1:
                 from_loyalty = self.env.context.get('from_loyalty', False)
                 
-                discount_product = getattr(self.env.company, "sale_discount_product_id", False)
-                is_official_discount = bool(discount_product) and line.product_id == discount_product
-                
-                sale_lines = getattr(line, "sale_line_ids", None)
-                is_reward = bool(sale_lines) and any(l.reward_id or l.coupon_id for l in sale_lines)
+                # sale_discount_product_id/sale_line_ids only exist when
+                # l10n_ve_invoice_loyalty/sale are installed alongside this
+                # module - checked explicitly instead of getattr() so a real
+                # AttributeError from any other cause is never swallowed.
+                is_official_discount = (
+                    "sale_discount_product_id" in self.env.company._fields
+                    and self.env.company.sale_discount_product_id
+                    and line.product_id == self.env.company.sale_discount_product_id
+                )
+
+                is_reward = "sale_line_ids" in line._fields and any(
+                    l.reward_id or l.coupon_id for l in line.sale_line_ids
+                )
                 
                 if not from_pos and not from_loyalty and not is_official_discount and not is_reward:
                     raise ValidationError(_("An invoice cannot have a line with a negative price unless it is a registered discount or reward"))

--- a/l10n_ve_rate/models/res_currency.py
+++ b/l10n_ve_rate/models/res_currency.py
@@ -11,20 +11,18 @@ class ResCurrency(models.Model):
         self, to_currency = self or to_currency, to_currency or self
         assert self, "convert amount from unknown currency"
         assert to_currency, "convert amount to unknown currency"
-        assert company, "convert amount from unknown company"
-        assert date, "convert amount from unknown date"
+        company = company or self.env.company
+        date = date or fields.Date.context_today(self)
 
-        if from_amount:
-            if custom_rate > 0:
-               
-                if company.currency_id != self and company.currency_id == self.env.ref("base.USD"):
-                    to_amount = from_amount / custom_rate
-                else:
-                    to_amount = from_amount * custom_rate
-               
-            else:
-                to_amount = from_amount * self._get_conversion_rate(self, to_currency, company, date)
-        else:
+        if not from_amount:
             return 0.0
 
-        return to_currency.round(to_amount) 
+        if custom_rate > 0:
+            if company.currency_id != self and company.currency_id == self.env.ref("base.USD"):
+                to_amount = from_amount / custom_rate
+            else:
+                to_amount = from_amount * custom_rate
+        else:
+            to_amount = from_amount * self._get_conversion_rate(self, to_currency, company, date)
+
+        return to_currency.round(to_amount) if round else to_amount


### PR DESCRIPTION
…acturas

- Usa precisión decimal configurable en vez de 2 fijo en la migración de redondeo SQL 17.0.0.0.56, agrega filtro por fechas de bloqueo, y condiciona la reconstrucción de líneas reconciliadas a process_posted para no tocar compañías con base USD
- Registra en log la cantidad de filas no nulas antes de eliminar columnas en la migración de IGTF 17.0.1.0.2
- Elimina el diccionario main_move sin uso en account_move.py
- Simplifica las validaciones de bi/foreign_bi del IGTF en el wizard (los campos siempre existen)
- Reemplaza los getattr() silenciosos por verificación explícita de existencia de campos para la integración opcional de loyalty/sale en l10n_ve_invoice
- Corrige la conversión de montos en res_currency para usar compañía y fecha por defecto en vez de assert, y respeta el flag round