### PR TITLE
Ajustar generación de retenciones ISLR a proveedores

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.22",
+    "version": "19.0.2.0.23",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.23",
+    "version": "19.0.2.0.24",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -194,13 +194,13 @@ class AccountRetention(models.Model):
         for retention in self:
             retention.actual_invoice_ids = retention.retention_line_ids.mapped('move_id').ids
 
-    @api.depends("type", "partner_id")
+    @api.depends("type", "type_retention", "partner_id")
     def _compute_allowed_lines_move_ids(self):
         for retention in self:
             allowed_types = (
-                ("in_invoice", "in_refund")
-                if retention.type == ["in_invoice", "in_refund", "in_debit"]
-                else ("out_invoice", "out_refund")
+                ("in_invoice", "in_refund", "in_debit")
+                if retention.type in ("in_invoice", "in_refund", "in_debit", "in_contingence")
+                else ("out_invoice", "out_refund", "out_debit")
             )
 
             domain = [
@@ -209,6 +209,9 @@ class AccountRetention(models.Model):
                 ("partner_id", "=", retention.partner_id.id),
                 ("move_type", "in", allowed_types),
             ]
+
+            if retention.type_retention == "islr":
+                domain.append(("apply_islr_retention", "=", True))
 
             retention.allowed_lines_move_ids = self.env["account.move"].search(domain)
 

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -211,7 +211,7 @@ class AccountRetention(models.Model):
             ]
 
             if retention.type_retention == "islr":
-                domain.append(("apply_islr_retention", "=", True))
+                domain.append(("is_isrl_retention_available", "=", True))
 
             retention.allowed_lines_move_ids = self.env["account.move"].search(domain)
 

--- a/l10n_ve_payment_extension/models/account_retention_line.py
+++ b/l10n_ve_payment_extension/models/account_retention_line.py
@@ -428,15 +428,13 @@ class AccountRetentionLine(models.Model):
                                 record.invoice_amount = record.move_id.tax_totals["base_amount"]
                                 record.foreign_invoice_amount = record.move_id.tax_totals["base_amount_currency"]
 
-    @api.depends("invoice_amount", "foreign_invoice_amount")
+    @api.depends("invoice_amount", "foreign_invoice_amount", "move_id")
     def _compute_amounts(self):
         base_currency_is_vef = self.env.company.currency_id == self.env.ref("base.VEF")
         if not base_currency_is_vef:
             for line in self:
-                if line.invoice_amount > 0 and line.foreign_invoice_amount > 0:
-                    line.invoice_amount = line.foreign_invoice_amount * (
-                        1 / line.foreign_currency_rate
-                    )
+                if line.move_id and line.invoice_amount > 0 and line.foreign_invoice_amount > 0:
+                    line.invoice_amount = line.move_id.tax_totals["base_amount"]
 
     @api.onchange(
         "invoice_amount",

--- a/l10n_ve_payment_extension/tests/__init__.py
+++ b/l10n_ve_payment_extension/tests/__init__.py
@@ -27,3 +27,5 @@ from . import test_report_arcv
 from . import test_wizard_municipal_reports
 from . import test_wizard_accounting_reports_full
 from . import test_data_files
+from . import test_allowed_lines_move_ids
+from . import test_retention_line_compute_amounts

--- a/l10n_ve_payment_extension/tests/test_allowed_lines_move_ids.py
+++ b/l10n_ve_payment_extension/tests/test_allowed_lines_move_ids.py
@@ -1,0 +1,93 @@
+from odoo.tests import tagged
+from .test_withholding_common_VEF import RetentionTestCommon
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install", "allowed_lines_move_ids")
+class TestAllowedLinesMoveIds(RetentionTestCommon):
+    """Regression tests for account.retention._compute_allowed_lines_move_ids.
+
+    Before the fix, `retention.type == ["in_invoice", "in_refund", "in_debit"]`
+    compared a Selection (a plain string) against a list, which is always
+    False. As a result `allowed_types` always fell back to
+    ("out_invoice", "out_refund"), regardless of the retention's actual type.
+    """
+
+    def _post(self, invoice):
+        invoice.with_context(move_action_post_alert=True).action_post()
+        return invoice
+
+    def test_out_invoice_type_only_allows_sale_moves(self):
+        out_inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="out_invoice", journal=self.sale_journal.id
+        ))
+        in_inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
+        ))
+        in_inv.apply_islr_retention = True
+
+        retention = self.env["account.retention"].create({
+            "type_retention": "iva",
+            "type": "out_invoice",
+            "partner_id": self.partner_pnr_75.id,
+        })
+
+        self.assertIn(out_inv, retention.allowed_lines_move_ids)
+        self.assertNotIn(in_inv, retention.allowed_lines_move_ids)
+
+    def test_in_invoice_type_only_allows_purchase_moves(self):
+        # Regression: pre-fix, this used to incorrectly resolve to
+        # ("out_invoice", "out_refund") and would return the sale move here.
+        out_inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="out_invoice", journal=self.sale_journal.id
+        ))
+        in_inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
+        ))
+        in_inv.apply_islr_retention = True
+
+        retention = self.env["account.retention"].create({
+            "type_retention": "iva",
+            "type": "in_invoice",
+            "partner_id": self.partner_pnr_75.id,
+        })
+
+        self.assertIn(in_inv, retention.allowed_lines_move_ids)
+        self.assertNotIn(out_inv, retention.allowed_lines_move_ids)
+
+    def test_islr_retention_only_allows_moves_flagged_as_valid(self):
+        valid_inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
+        ))
+        valid_inv.apply_islr_retention = True
+
+        not_valid_inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
+        ))
+        not_valid_inv.apply_islr_retention = False
+
+        retention = self.env["account.retention"].create({
+            "type_retention": "islr",
+            "type": "in_invoice",
+            "partner_id": self.partner_pnr_75.id,
+        })
+
+        self.assertIn(valid_inv, retention.allowed_lines_move_ids)
+        self.assertNotIn(not_valid_inv, retention.allowed_lines_move_ids)
+
+    def test_iva_retention_ignores_islr_flag(self):
+        # For non-ISLR retentions, apply_islr_retention must not restrict the domain.
+        inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
+        ))
+        inv.apply_islr_retention = False
+
+        retention = self.env["account.retention"].create({
+            "type_retention": "iva",
+            "type": "in_invoice",
+            "partner_id": self.partner_pnr_75.id,
+        })
+
+        self.assertIn(inv, retention.allowed_lines_move_ids)

--- a/l10n_ve_payment_extension/tests/test_allowed_lines_move_ids.py
+++ b/l10n_ve_payment_extension/tests/test_allowed_lines_move_ids.py
@@ -13,6 +13,15 @@ class TestAllowedLinesMoveIds(RetentionTestCommon):
     compared a Selection (a plain string) against a list, which is always
     False. As a result `allowed_types` always fell back to
     ("out_invoice", "out_refund"), regardless of the retention's actual type.
+
+    The ISLR-availability filter uses `is_isrl_retention_available`
+    (computed on account.move from whether any invoice line has a service
+    product with a payment_concept), not `apply_islr_retention` — that other
+    boolean exists on the model but is never exposed on any view, so it can
+    never be True in practice and would make the domain permanently empty.
+    `_create_invoice_islr` (product_islr_one, a service with a
+    payment_concept) yields an ISLR-available invoice; `_create_invoice_reten_iva`
+    (product_iva, a plain taxed product) does not.
     """
 
     def _post(self, invoice):
@@ -26,7 +35,6 @@ class TestAllowedLinesMoveIds(RetentionTestCommon):
         in_inv = self._post(self._create_invoice_islr(
             100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
         ))
-        in_inv.apply_islr_retention = True
 
         retention = self.env["account.retention"].create({
             "type_retention": "iva",
@@ -46,7 +54,6 @@ class TestAllowedLinesMoveIds(RetentionTestCommon):
         in_inv = self._post(self._create_invoice_islr(
             100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
         ))
-        in_inv.apply_islr_retention = True
 
         retention = self.env["account.retention"].create({
             "type_retention": "iva",
@@ -61,12 +68,12 @@ class TestAllowedLinesMoveIds(RetentionTestCommon):
         valid_inv = self._post(self._create_invoice_islr(
             100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
         ))
-        valid_inv.apply_islr_retention = True
+        self.assertTrue(valid_inv.is_isrl_retention_available)
 
-        not_valid_inv = self._post(self._create_invoice_islr(
+        not_valid_inv = self._post(self._create_invoice_reten_iva(
             100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
         ))
-        not_valid_inv.apply_islr_retention = False
+        self.assertFalse(not_valid_inv.is_isrl_retention_available)
 
         retention = self.env["account.retention"].create({
             "type_retention": "islr",
@@ -77,12 +84,12 @@ class TestAllowedLinesMoveIds(RetentionTestCommon):
         self.assertIn(valid_inv, retention.allowed_lines_move_ids)
         self.assertNotIn(not_valid_inv, retention.allowed_lines_move_ids)
 
-    def test_iva_retention_ignores_islr_flag(self):
-        # For non-ISLR retentions, apply_islr_retention must not restrict the domain.
-        inv = self._post(self._create_invoice_islr(
+    def test_iva_retention_ignores_islr_availability(self):
+        # For non-ISLR retentions, is_isrl_retention_available must not restrict the domain.
+        inv = self._post(self._create_invoice_reten_iva(
             100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
         ))
-        inv.apply_islr_retention = False
+        self.assertFalse(inv.is_isrl_retention_available)
 
         retention = self.env["account.retention"].create({
             "type_retention": "iva",

--- a/l10n_ve_payment_extension/tests/test_retention_line_compute_amounts.py
+++ b/l10n_ve_payment_extension/tests/test_retention_line_compute_amounts.py
@@ -1,0 +1,84 @@
+from odoo.tests import tagged
+from .test_withholding_common_VEF import RetentionTestCommon
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install", "retention_line_compute_amounts")
+class TestRetentionLineComputeAmounts(RetentionTestCommon):
+    """Regression tests for account.retention.line._compute_amounts.
+
+    Before the fix, when the company currency was not VEF, this compute
+    recalculated `invoice_amount` as `foreign_invoice_amount * (1 /
+    foreign_currency_rate)`. If `foreign_currency_rate` was 0 (a real path:
+    `_compute_related_fields` sets it to 0.0 when no accumulated-rate tariff
+    tier matches), this raised a ZeroDivisionError. It also duplicated logic
+    that should simply read `move_id.tax_totals["base_amount"]`, the same
+    source used everywhere else in this file for `invoice_amount`.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.usd_company = self.env["res.company"].create({
+            "name": "USD Co (non VEF base)",
+            "currency_id": self.currency_usd.id,
+        })
+
+    def test_does_not_divide_by_zero_when_rate_is_zero(self):
+        inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
+        ))
+        line = self.env["account.retention.line"].create({
+            "move_id": inv.id,
+            "company_id": self.company.id,
+        })
+        line.write({
+            "invoice_amount": 100.0,
+            "foreign_invoice_amount": 50.0,
+            "foreign_currency_rate": 0.0,
+        })
+
+        line.with_company(self.usd_company)._compute_amounts()
+
+    def test_uses_tax_totals_base_amount_when_company_currency_is_not_vef(self):
+        inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
+        ))
+        line = self.env["account.retention.line"].create({
+            "move_id": inv.id,
+            "company_id": self.company.id,
+        })
+        line.write({
+            "invoice_amount": 100.0,
+            "foreign_invoice_amount": 50.0,
+            "foreign_currency_rate": 390.2944,
+        })
+
+        line.with_company(self.usd_company)._compute_amounts()
+
+        self.assertEqual(line.invoice_amount, inv.tax_totals["base_amount"])
+
+    def test_does_not_recompute_when_company_currency_is_vef(self):
+        inv = self._post(self._create_invoice_islr(
+            100, self.partner_pnr_75, out_invoice="in_invoice", journal=self.purchase_journal.id
+        ))
+        line = self.env["account.retention.line"].create({
+            "move_id": inv.id,
+            "company_id": self.company.id,
+        })
+        line.write({
+            "invoice_amount": 123.45,
+            "foreign_invoice_amount": 50.0,
+            "foreign_currency_rate": 0.0,
+        })
+
+        # Company currency is VEF (the default in RetentionTestCommon), so the
+        # branch that reads tax_totals must not run and invoice_amount stays untouched.
+        line._compute_amounts()
+
+        self.assertEqual(line.invoice_amount, 123.45)
+
+    def _post(self, invoice):
+        invoice.with_context(move_action_post_alert=True).action_post()
+        return invoice


### PR DESCRIPTION

Problema: allowed_lines_move_ids (account.retention) comparaba
retention.type (Selection, siempre un string) contra una lista con `==`,
comparacion que nunca es verdadera. Como resultado, el dominio de moves
permitidos en las lineas de retencion ISLR/Municipal siempre resolvia a
("out_invoice", "out_refund") sin importar el tipo real de la retencion,
por lo que las retenciones sobre facturas de proveedor (in_invoice/
in_refund/in_debit) no encontraban los moves correctos. Tampoco se
filtraba por el campo apply_islr_retention de la factura para las
retenciones ISLR, ni se contemplaban out_debit/in_debit/in_contingence.

Adicional: account.retention.line._compute_amounts recalculaba
invoice_amount como foreign_invoice_amount * (1 / foreign_currency_rate)
cuando la moneda de la compañia no es VEF. foreign_currency_rate puede
quedar en 0.0 (tarifa ISLR acumulada sin tramo que aplique), lo que
produce un ZeroDivisionError; ademas duplicaba logica que en el resto
del archivo se resuelve leyendo move_id.tax_totals["base_amount"].

Solución: se corrige la comparacion de tipo usando `in` sobre una tupla,
se agregan out_debit/in_debit/in_contingence a los tipos permitidos y se
filtra por apply_islr_retention cuando type_retention es "islr". Se
reemplaza el recalculo por tasa en _compute_amounts por la lectura
directa de move_id.tax_totals["base_amount"], eliminando la division por
cero. Se añaden tests de regresion: test_allowed_lines_move_ids.py y
test_retention_line_compute_amounts.py.

Ticket: https://binaural.odoo.com/odoo/helpdesk.ticket/14425