### PR TITLE
tasa del wizard de pagos y monto conciliado en moneda alterna

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.56",
+    "version": "17.0.0.0.57",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.57",
+    "version": "17.0.0.0.58",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -842,8 +842,6 @@ class AccountMove(models.Model):
                 _("You can only register payments for one foreign rate at a time.")
             )
         res = super().action_register_payment()
-        res["context"]["default_foreign_rate"] = self[0].foreign_rate
-        res["context"]["default_foreign_inverse_rate"] = self[0].foreign_inverse_rate
         return res
 
     def action_update_account_id(self):

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -447,6 +447,7 @@ class AccountMoveLine(models.Model):
             
             # Si el balance en Bs es 0 (evitar división por cero)
             if not aml.balance:
+                
                 return 0.0
 
             # CALCULAMOS LA PROPORCIÓN

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -468,10 +468,23 @@ class AccountMoveLine(models.Model):
         foreign_debit_amount = get_foreign_partial_amount(debit_aml, amount_company)
         foreign_credit_amount = get_foreign_partial_amount(credit_aml, amount_company)
 
-        # El monto de la conciliación parcial foránea es el mínimo de ambos lados proporcionalmente
-        # pero usualmente en una conciliación parcial, el 'amount' de la partial es único.
+        # El monto foráneo mostrado como "lo conciliado" debe reflejar la tasa del lado que no es
+        # la factura (el pago o extracto bancario), no la tasa histórica de la factura. Usar
+        # siempre el mínimo hacía que, con tasas subiendo con el tiempo, casi siempre se eligiera
+        # el lado de la factura (su valor en Bs es menor por ser de una fecha con tasa más baja).
+        debit_is_invoice = debit_aml.move_id.is_invoice(include_receipts=True)
+        credit_is_invoice = credit_aml.move_id.is_invoice(include_receipts=True)
+        if debit_is_invoice and not credit_is_invoice:
+            foreign_amount = foreign_credit_amount
+        elif credit_is_invoice and not debit_is_invoice:
+            foreign_amount = foreign_debit_amount
+        else:
+            # Ninguno de los dos lados es claramente "el pago" (p.ej. factura contra nota de
+            # crédito): se conserva el comportamiento anterior.
+            foreign_amount = min(foreign_debit_amount, foreign_credit_amount)
+
         res['partial_values'].update({
-            'foreign_amount': min(foreign_debit_amount, foreign_credit_amount),
+            'foreign_amount': foreign_amount,
             'debit_foreign_amount_currency': foreign_debit_amount,
             'credit_foreign_amount_currency': foreign_credit_amount,
         })

--- a/l10n_ve_accountant/tests/test_coverage_gaps.py
+++ b/l10n_ve_accountant/tests/test_coverage_gaps.py
@@ -679,18 +679,28 @@ class TestCoverageGaps(TransactionCase):
         action = invoice.action_register_payment()
         context = action.get('context', {})
         self.assertIn('active_ids', context)
-        if 'default_foreign_rate' in context:
-            self.assertAlmostEqual(context['default_foreign_rate'], 50.0, places=2)
+        self.assertNotIn(
+            'default_foreign_rate', context,
+            "action_register_payment must not force the invoice's rate into the wizard",
+        )
 
     def test_payment_register_wizard_uses_current_date_rate_not_invoice_rate(self):
         """
         The payment register wizard must compute foreign_rate from its own
         payment_date (defaulting to today), never from the rate stored on the
         old invoice being paid.
+
+        old_rate > today_rate on purpose: this makes the invoice's own foreign
+        amount (amount_bs / old_rate) the *smaller* of the two sides, so a
+        plain min(foreign_debit_amount, foreign_credit_amount) would wrongly
+        pick the invoice's side. Only the is_invoice()-based branching in
+        _prepare_reconciliation_single_partial picks the payment's side
+        correctly here, so this actually exercises that fix (see
+        test_coverage_gaps.py history / PR #14473 review).
         """
         old_date = fields.Date.today() - timedelta(days=10)
-        old_rate = 30.0
-        today_rate = 65.0
+        old_rate = 65.0
+        today_rate = 30.0
 
         self.env["res.currency.rate"].create({
             "name": old_date, "currency_id": self.currency_usd.id,
@@ -744,7 +754,8 @@ class TestCoverageGaps(TransactionCase):
         )
         self.assertNotAlmostEqual(
             partial.debit_foreign_amount_currency, partial.foreign_amount, places=2,
-            msg="foreign_amount must no longer collapse to the invoice's (lower, older-rate) side",
+            msg="foreign_amount must not collapse to the invoice's side, even though it is the "
+                "smaller value here (old_rate > today_rate) and would be picked by a plain min()",
         )
 
     # ═══════════════════════════════════════════════════════════════

--- a/l10n_ve_accountant/tests/test_coverage_gaps.py
+++ b/l10n_ve_accountant/tests/test_coverage_gaps.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from datetime import timedelta
 
 from odoo.tests import TransactionCase, tagged
 from odoo.tests.common import Form
@@ -680,6 +681,71 @@ class TestCoverageGaps(TransactionCase):
         self.assertIn('active_ids', context)
         if 'default_foreign_rate' in context:
             self.assertAlmostEqual(context['default_foreign_rate'], 50.0, places=2)
+
+    def test_payment_register_wizard_uses_current_date_rate_not_invoice_rate(self):
+        """
+        The payment register wizard must compute foreign_rate from its own
+        payment_date (defaulting to today), never from the rate stored on the
+        old invoice being paid.
+        """
+        old_date = fields.Date.today() - timedelta(days=10)
+        old_rate = 30.0
+        today_rate = 65.0
+
+        self.env["res.currency.rate"].create({
+            "name": old_date, "currency_id": self.currency_usd.id,
+            "inverse_company_rate": old_rate, "company_id": self.company.id,
+        })
+        # Overrides the today rate created in setUp (50.0) with a distinct value.
+        self.env["res.currency.rate"].search([
+            ("currency_id", "=", self.currency_usd.id),
+            ("company_id", "=", self.company.id),
+            ("name", "=", fields.Date.today()),
+        ]).write({"inverse_company_rate": today_rate})
+
+        invoice = self._create_invoice(self.currency_usd, 100.0)
+        invoice.write({"date": old_date, "invoice_date": old_date})
+        invoice.with_context(move_action_post_alert=True).action_post()
+        self.assertAlmostEqual(invoice.foreign_rate, old_rate, places=2)
+
+        action = invoice.action_register_payment()
+        self.assertNotIn(
+            "default_foreign_rate", action.get("context", {}),
+            "action_register_payment must not force the invoice's rate into the wizard",
+        )
+
+        wizard_form = Form(
+            self.env["account.payment.register"].with_context(**action["context"])
+        )
+        self.assertEqual(wizard_form.payment_date, fields.Date.today())
+        self.assertAlmostEqual(
+            wizard_form.foreign_rate, today_rate, places=2,
+            msg="Wizard should use today's rate, not the invoice's rate",
+        )
+        self.assertNotAlmostEqual(wizard_form.foreign_rate, old_rate, places=2)
+
+        wizard = wizard_form.save()
+        payments = wizard._create_payments()
+        self.assertAlmostEqual(
+            payments.foreign_rate, today_rate, places=2,
+            msg="_create_payment_vals_from_wizard must persist today's rate, not the invoice's",
+        )
+        self.assertNotAlmostEqual(payments.foreign_rate, old_rate, places=2)
+
+        partial = self.env["account.partial.reconcile"].search([
+            "|", ("debit_move_id", "in", payments.move_id.line_ids.ids),
+            ("credit_move_id", "in", payments.move_id.line_ids.ids),
+        ], limit=1)
+        self.assertTrue(partial, "Payment should be reconciled with the invoice")
+        self.assertAlmostEqual(
+            partial.credit_foreign_amount_currency, partial.foreign_amount, places=2,
+            msg="foreign_amount shown in the payments widget must match the payment's own "
+                "foreign valuation, not the invoice's",
+        )
+        self.assertNotAlmostEqual(
+            partial.debit_foreign_amount_currency, partial.foreign_amount, places=2,
+            msg="foreign_amount must no longer collapse to the invoice's (lower, older-rate) side",
+        )
 
     # ═══════════════════════════════════════════════════════════════
     # account_move.py - action_post validation

--- a/l10n_ve_accountant/wizard/account_payment_register.xml
+++ b/l10n_ve_accountant/wizard/account_payment_register.xml
@@ -10,7 +10,7 @@
                 <label for="foreign_rate" />
                 <div name="foreign_currency_div" class="o_row">
                     <field name="foreign_currency_id" options="{'no_create': True, 'no_open': True}" required="1" />
-                    <field name="foreign_rate" />
+                    <field name="foreign_rate" readonly="1" />
                 </div>
                 <field name="foreign_inverse_rate" invisible="1"/>
                 <label for="foreign_inverse_rate" invisible="base_currency_is_vef == True"/>


### PR DESCRIPTION
[FIX] l10n_ve_accountant: tasa del wizard de pagos y monto conciliado en moneda alterna

Al registrar un pago desde una factura, action_register_payment forzaba en el wizard la tasa alterna guardada en la factura (default_foreign_rate), en vez de dejar que el wizard calculara la tasa vigente según la fecha de pago seleccionada. Se elimina esa inyección de contexto para que el wizard use siempre _compute_foreign_rate en base a payment_date.

Además, el monto conciliado en moneda alterna que se muestra en el widget de pagos de la factura (invoice_payments_widget) tomaba el mínimo entre el valor foráneo de la factura y el del pago (_prepare_reconciliation_single_partial). Como la tasa alterna sube con el tiempo, esto hacía que casi siempre se mostrara la tasa histórica de la factura en vez de la tasa real del pago. Se ajusta para que el monto foráneo mostrado corresponda al lado del pago (o extracto bancario), conservando el mínimo solo cuando ninguno de los dos lados es claramente el pago (p.ej. factura contra nota de crédito).

Tarea: https://binaural.odoo.com/odoo/helpdesk/92/tickets/14473