### PR TITLE
[FIX] l10n_ve_tax: Ajustes en vistas de configuracion

### DIFF
--- a/l10n_ve_tax/i18n/es_VE.po
+++ b/l10n_ve_tax/i18n/es_VE.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e-20260716\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-17 21:35+0000\n"
-"PO-Revision-Date: 2026-07-17 21:35+0000\n"
+"POT-Creation-Date: 2026-07-20 15:37+0000\n"
+"PO-Revision-Date: 2026-07-20 15:37+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -34,8 +34,8 @@ msgstr "Ajustes de configuración"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Configuration Taxes:"
-msgstr "Configuración Impuestos:"
+msgid "Configuration Taxes: IGTF"
+msgstr "Configuración Impuestos: IGTF"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
@@ -45,7 +45,8 @@ msgstr "Configuración Impuestos: No Deducibles"
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Configuration Taxes: Purchase Tax International Rates"
-msgstr "Configuración Impuestos: Tasas de Impuestos de Compras Internacionales"
+msgstr ""
+"Configuración Impuestos: Tasas de Impuestos de Compras Internacionales"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
@@ -74,18 +75,8 @@ msgstr "Opciones de visualización"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Enable Non-Deductible Taxes"
-msgstr "Habilitar impuestos no deducibles"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Enable discount column visibility on invoice lines"
 msgstr "Habilitar visibilidad de la columna de descuento en líneas de factura"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Exempt Aliquot"
-msgstr "Alícuota exenta"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__exent_aliquot_purchase
@@ -124,16 +115,6 @@ msgid "Extend Aliquot Sale"
 msgstr "Alicuota extendida Ventas"
 
 #. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Extended Aliquot"
-msgstr "Alícuota extendida"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "General Aliquot"
-msgstr "Alícuota general"
-
-#. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__general_aliquot_purchase
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__general_aliquot_purchase
 msgid "General Aliquot Purchase"
@@ -150,31 +131,6 @@ msgstr "Alícuota general compras internacionales"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__general_aliquot_sale
 msgid "General Aliquot Sale"
 msgstr "Alicuota general Ventas"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Hide Extended Aliquot"
-msgstr ""
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Hide National Exempt Total"
-msgstr ""
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Hide Reduced Aliquot"
-msgstr ""
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Hide Total Purchases National"
-msgstr ""
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Hide Total Purchases with IVA"
-msgstr ""
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_account_move_line__international_purchase_exempt_product
@@ -330,11 +286,6 @@ msgid "Purchase Tax Rates"
 msgstr "Tasas de Impuestos de Compras"
 
 #. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Reduced Aliquot"
-msgstr "Alícuota Reducida"
-
-#. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__reduced_aliquot_purchase
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__reduced_aliquot_purchase
 msgid "Reduced Aliquot Purchase"
@@ -390,11 +341,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__unique_tax
 msgid "Unique Tax"
 msgstr "Impuesto único"
-
-#. module: l10n_ve_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Zero Aliquot"
-msgstr ""
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__zero_aliquot_sale_international

--- a/l10n_ve_tax/i18n/es_VE.po
+++ b/l10n_ve_tax/i18n/es_VE.po
@@ -4,33 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250522\n"
+"Project-Id-Version: Odoo Server 17.0+e-20260716\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 13:51+0000\n"
-"PO-Revision-Date: 2026-04-17 13:51+0000\n"
+"POT-Creation-Date: 2026-07-17 21:35+0000\n"
+"PO-Revision-Date: 2026-07-17 21:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: l10n_ve_tax
-#. odoo-python
-#: code:addons/l10n_ve_tax/models/account_journal.py:0
-#, python-format
-msgid ""
-"An International Purchase Journal is already enabled. Only one is allowed."
-msgstr ""
-"Ya se ha habilitado un Diario de Compras Internacional. Solo se permite uno."
-
-#. module: l10n_ve_tax
-#. odoo-python
-#: code:addons/l10n_ve_tax/models/account_journal.py:0
-#, python-format
-msgid "An International Sale Journal is already enabled. Only one is allowed."
-msgstr ""
-"Ya se ha habilitado un Diario de Ventas Internacional. Solo se permite uno."
 
 #. module: l10n_ve_tax
 #: model:ir.model,name:l10n_ve_tax.model_res_company
@@ -51,8 +34,8 @@ msgstr "Ajustes de configuración"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Configuration Taxes: IGTF"
-msgstr "Configuración Impuestos: IGTF"
+msgid "Configuration Taxes:"
+msgstr "Configuración Impuestos:"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
@@ -61,8 +44,18 @@ msgstr "Configuración Impuestos: No Deducibles"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Configuration Taxes: Purchase Tax International Rates"
+msgstr "Configuración Impuestos: Tasas de Impuestos de Compras Internacionales"
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Configuration Taxes: Taxes Sales/Purchase"
 msgstr "Configuración Impuestos: Ventas/Compras"
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Configuration: Accountant Books"
+msgstr "Configuración: Libros Contables"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
@@ -73,14 +66,6 @@ msgstr "Configuración Principal"
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Deductibility"
 msgstr "Deducibilidad"
-
-#. module: l10n_ve_tax
-#. odoo-javascript
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#, python-format
-msgid "Discount"
-msgstr "Descuento"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
@@ -98,10 +83,15 @@ msgid "Enable discount column visibility on invoice lines"
 msgstr "Habilitar visibilidad de la columna de descuento en líneas de factura"
 
 #. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Exempt Aliquot"
+msgstr "Alícuota exenta"
+
+#. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__exent_aliquot_purchase
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__exent_aliquot_purchase
 msgid "Exent Aliquot Purchase"
-msgstr "Exento compras"
+msgstr "Exento Compras"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__exent_aliquot_purchase_international
@@ -119,7 +109,7 @@ msgstr "Exento ventas"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__extend_aliquot_purchase
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__extend_aliquot_purchase
 msgid "Extend Aliquot Purchase"
-msgstr "Alícuota extendida compras"
+msgstr "Alicuota extendida Compras"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__extend_aliquot_purchase_international
@@ -131,7 +121,7 @@ msgstr "Alícuota extendida compras internacionales"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__extend_aliquot_sale
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__extend_aliquot_sale
 msgid "Extend Aliquot Sale"
-msgstr "Alícuota extendida ventas"
+msgstr "Alicuota extendida Ventas"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
@@ -147,7 +137,7 @@ msgstr "Alícuota general"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__general_aliquot_purchase
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__general_aliquot_purchase
 msgid "General Aliquot Purchase"
-msgstr "Alícuota general compras"
+msgstr "Alicuota general Compras"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__general_aliquot_purchase_international
@@ -159,7 +149,32 @@ msgstr "Alícuota general compras internacionales"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__general_aliquot_sale
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__general_aliquot_sale
 msgid "General Aliquot Sale"
-msgstr "Alícuota general ventas"
+msgstr "Alicuota general Ventas"
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Hide Extended Aliquot"
+msgstr ""
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Hide National Exempt Total"
+msgstr ""
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Hide Reduced Aliquot"
+msgstr ""
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Hide Total Purchases National"
+msgstr ""
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Hide Total Purchases with IVA"
+msgstr ""
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_account_move_line__international_purchase_exempt_product
@@ -217,13 +232,6 @@ msgid "No Deductible Reduced Aliquot Purchase"
 msgstr "No Deducible Aliquota Reducida (Compra)"
 
 #. module: l10n_ve_tax
-#. odoo-python
-#: code:addons/l10n_ve_tax/models/account_tax.py:0
-#, python-format
-msgid "No foreign currency configured in the company"
-msgstr "No hay moneda extranjera configurada en la empresa"
-
-#. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Non-Deductible Rates"
 msgstr "Tasas no deducibles"
@@ -243,7 +251,7 @@ msgstr "No mostrar total compras exento"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_extend_aliquot_purchase
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_extend_aliquot_purchase
 msgid "Not Show Extend Aliquot Purchase"
-msgstr "No mostrar alícuota extendida (Compras Nacionales)"
+msgstr "No mostrar alicuota extendida (Compras)"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_extend_aliquot_purchase_international
@@ -255,7 +263,7 @@ msgstr "No mostrar alícuota extendida compras internacionales"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_extend_aliquot_sale
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_extend_aliquot_sale
 msgid "Not Show Extend Aliquot Sale"
-msgstr "No mostrar alícuota extendida (Ventas)"
+msgstr "No mostrar alicuota extendida (Ventas)"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_general_aliquot_purchase_international
@@ -273,7 +281,7 @@ msgstr "No mostrar total compras exentas (Compras Nacionales)"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_reduced_aliquot_purchase
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_reduced_aliquot_purchase
 msgid "Not Show Reduced Aliquot Purchase"
-msgstr "No mostrar alícuota reducida (Compras Nacionales)"
+msgstr "No mostrar alicuota reducida (Compras)"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_reduced_aliquot_purchase_international
@@ -285,7 +293,7 @@ msgstr "No mostrar alícuota reducida compras internacionales"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_reduced_aliquot_sale
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__not_show_reduced_aliquot_sale
 msgid "Not Show Reduced Aliquot Sale"
-msgstr "No mostrar alícuota reducida (Ventas)"
+msgstr "No mostrar alicuota reducida (Ventas)"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__not_show_total_purchases_international
@@ -313,12 +321,12 @@ msgstr "No mostrar total compras con IVA (Compras Nacionales)"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Purchase Tax International Rates"
-msgstr "Tasas de Impuestos de Compras Internacionales"
+msgid "Purchase Book"
+msgstr "Libro de Compras"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
-msgid "Purchases Tax Rates"
+msgid "Purchase Tax Rates"
 msgstr "Tasas de Impuestos de Compras"
 
 #. module: l10n_ve_tax
@@ -330,7 +338,7 @@ msgstr "Alícuota Reducida"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__reduced_aliquot_purchase
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__reduced_aliquot_purchase
 msgid "Reduced Aliquot Purchase"
-msgstr "Alícuota reducida compras"
+msgstr "Alicuota reducida compras"
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__reduced_aliquot_purchase_international
@@ -342,12 +350,17 @@ msgstr "Alícuota reducida compras internacionales"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__reduced_aliquot_sale
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__reduced_aliquot_sale
 msgid "Reduced Aliquot Sale"
-msgstr "Alícuota reducida ventas"
+msgstr "Alicuota reducida Ventas"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
 msgid "Sale Tax International Rates"
 msgstr "Tasas de Impuestos de Ventas Internacionales"
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Sales Book"
+msgstr "Libro de Ventas"
 
 #. module: l10n_ve_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
@@ -358,15 +371,7 @@ msgstr "Tasas de Impuestos de Ventas"
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__show_discount_on_moves
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__show_discount_on_moves
 msgid "Show Discount On Moves"
-msgstr "Mostrar descuento en facturas"
-
-#. module: l10n_ve_tax
-#. odoo-javascript
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#, python-format
-msgid "Subtotal"
-msgstr ""
+msgstr "Mostrar Descuento en Facturas"
 
 #. module: l10n_ve_tax
 #: model:ir.model,name:l10n_ve_tax.model_account_tax
@@ -381,24 +386,15 @@ msgstr ""
 "permite un impuesto"
 
 #. module: l10n_ve_tax
-#. odoo-javascript
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#, python-format
-msgid "Total"
-msgstr ""
-
-#. module: l10n_ve_tax
-#. odoo-javascript
-#: code:addons/l10n_ve_tax/static/src/components/tax_totals/tax_totals.xml:0
-#, python-format
-msgid "Total to pay"
-msgstr "Total a pagar"
-
-#. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__unique_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_config_settings__unique_tax
 msgid "Unique Tax"
 msgstr "Impuesto único"
+
+#. module: l10n_ve_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ve_tax.view_res_config_settings_l10n_ve_taxes
+msgid "Zero Aliquot"
+msgstr ""
 
 #. module: l10n_ve_tax
 #: model:ir.model.fields,field_description:l10n_ve_tax.field_res_company__zero_aliquot_sale_international

--- a/l10n_ve_tax/views/res_config_settings.xml
+++ b/l10n_ve_tax/views/res_config_settings.xml
@@ -6,7 +6,7 @@
             <field name="inherit_id" ref="l10n_ve_base.l10n_ve_base_view_res_config_settings"/>
             <field name="arch" type="xml">
                 <xpath expr="//app[@name='l10n_ve_base']" position="inside">
-                    <block title="Configuration Taxes: IGTF" name="l10n_ve_tax_block_igtf" >
+                    <block title="Configuration Taxes:" name="l10n_ve_tax_block_igtf">
                         <separator string="Core Settings"/>
                         <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_config_igtf_unique_tax">
                             <div class="col-lg-6 o_setting_left_pane">
@@ -33,117 +33,90 @@
                         </div>
                     </block>
 
-
                     <block title="Configuration Taxes: Taxes Sales/Purchase" name="l10n_ve_tax_block_tax_rates">
-                        <h2>Sales Tax Rates</h2>
                         <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_tax_rates_sales">
-
-                            <div class="o_setting_left_pane">
-                            </div>
                             <div class="o_setting_right_pane">
-                                <div class="content-group">
-                                    <div class="row">
-                                        <label for="exent_aliquot_sale" class="col-lg-6 o_light_label"/>   
-                                        <field name="exent_aliquot_sale"/>
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <label for="general_aliquot_sale" class="col-lg-6 o_light_label"/>
+                                <separator string="Sales Tax Rates"/>
+                                <group>
+                                    <field name="exent_aliquot_sale"/>
                                     <field name="general_aliquot_sale"/>
-                                </div>
-                                <div class="row">
-                                    <label for="reduced_aliquot_sale" class="col-lg-6 o_light_label"/>
                                     <field name="reduced_aliquot_sale"/>
-                                </div>
-                                <div class="row">
-                                    <label for="extend_aliquot_sale" class="col-lg-6 o_light_label"/>
                                     <field name="extend_aliquot_sale"/>
-                                </div>
+                                </group>
                             </div>
                         </div>
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <br/>
-                                <br/>
-                                <br/>
-                                <field name="not_show_reduced_aliquot_sale"/>
-                                <field name="not_show_extend_aliquot_sale"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <br/>
-                                <br/>
-                                <br/>
-                                <label for="not_show_reduced_aliquot_sale"/>
-                                <br/>
-                                <label for="not_show_extend_aliquot_sale"/>
-                            </div>
-                        </div>
-
-                        <h2>Sale Tax International Rates</h2>
-                        <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_tax_rates_sale_international">
-                            <div class="o_setting_left_pane">
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <div class="content-group">
-                                    <div class="row">
-                                        <label for="zero_aliquot_sale_international" class="col-lg-6 o_light_label"/>   
-                                        <field name="zero_aliquot_sale_international"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <h2>Purchases Tax Rates</h2>
                         <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_tax_rates_purchase">
-                            <div class="o_setting_left_pane">
-                            </div>
                             <div class="o_setting_right_pane">
-                                <div class="content-group">
-                                    <div class="row">
-                                        <label for="exent_aliquot_purchase" class="col-lg-6 o_light_label"/>
-                                        <field name="exent_aliquot_purchase"/>
-                                    </div>
-                                    <div class="row">
-                                        <label for="general_aliquot_purchase" class="col-lg-6 o_light_label"/>
-                                        <field name="general_aliquot_purchase"/>
-                                    </div>
-                                    <div class="row">
-                                        <label for="reduced_aliquot_purchase" class="col-lg-6 o_light_label"/>
-                                        <field name="reduced_aliquot_purchase"/>
-                                    </div>
-                                    <div class="row">
-                                        <label for="extend_aliquot_purchase" class="col-lg-6 o_light_label"/>
-                                        <field name="extend_aliquot_purchase"/>
-                                    </div>
-                                </div>
+                                <separator string="Purchase Tax Rates"/>
+                                <group>
+                                    <field name="exent_aliquot_purchase"/>
+                                    <field name="general_aliquot_purchase"/>
+                                    <field name="reduced_aliquot_purchase"/>
+                                    <field name="extend_aliquot_purchase"/>
+                                </group>
                             </div>
                         </div>
-
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="not_show_reduced_aliquot_purchase"/>
-                                <field name="not_show_extend_aliquot_purchase"/>
-                                <field name="not_show_total_purchases_with_iva" />
-                                <field name="not_show_national_exempt_total_purchases" />
-                                <field name="not_show_total_purchases_national" />
-                            </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_tax_rates_sale_international">
                             <div class="o_setting_right_pane">
-                                <label for="not_show_reduced_aliquot_purchase"/>
-                                <label for="not_show_extend_aliquot_purchase"/>
-                                <label for="not_show_total_purchases_with_iva" />
-                                <label for="not_show_national_exempt_total_purchases" />
-                                <label for="not_show_total_purchases_national" />
+                                <separator string="Sale Tax International Rates"/>
+                                <group>
+                                    <field name="zero_aliquot_sale_international"/>
+                                </group>
                             </div>
                         </div>
+                    </block>
 
-                        <h2>Purchase Tax International Rates</h2>
+                    <block title="Configuration Taxes: Non-Deductible" name="l10n_ve_tax_block_non_deductible">
+                        <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_deductibility">
+                            <div class="o_setting_right_pane">
+                                <separator string="Deductibility"/>
+                                <group>
+                                    <field name="config_deductible_tax"/>
+                                </group>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box" invisible="not config_deductible_tax" id="l10n_ve_tax_div_non_deductible_rates">
+                            <div class="o_setting_right_pane">
+                                <separator string="Non-Deductible Rates"/>
+                                <group>
+                                    <field name="no_deductible_general_aliquot_purchase"/>
+                                    <field name="no_deductible_reduced_aliquot_purchase"/>
+                                    <field name="no_deductible_extend_aliquot_purchase"/>
+                                </group>
+                            </div>
+                        </div>
+                    </block>
+
+                    <block title="Configuration: Accountant Books" name="l10n_ve_tax_block_books">
+                        <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_sales_book">
+                            <div class="o_setting_right_pane">
+                                <separator string="Sales Book"/>
+                                <group>
+                                    <field name="not_show_reduced_aliquot_sale"/>
+                                    <field name="not_show_extend_aliquot_sale"/>
+                                </group>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_purchase_book">
+                            <div class="o_setting_right_pane">
+                                <separator string="Purchase Book"/>
+                                <group>
+                                    <field name="not_show_reduced_aliquot_purchase"/>
+                                    <field name="not_show_extend_aliquot_purchase"/>
+                                    <field name="not_show_total_purchases_with_iva"/>
+                                    <field name="not_show_national_exempt_total_purchases"/>
+                                    <field name="not_show_total_purchases_national"/>
+                                </group>
+                            </div>
+                        </div>
+                    </block>
+
+                    <block title="Configuration Taxes: Purchase Tax International Rates" name="l10n_ve_tax_block_tax_rates_purchase_international">
                         <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_tax_rates_purchase_international">
-                            <div class="o_setting_left_pane">
-                            </div>
                             <div class="o_setting_right_pane">
                                 <div class="content-group">
                                     <div class="row">
-                                        <label for="exent_aliquot_purchase_international" class="col-lg-6 o_light_label"/>   
+                                        <label for="exent_aliquot_purchase_international" class="col-lg-6 o_light_label"/>
                                         <field name="exent_aliquot_purchase_international"/>
                                     </div>
                                 </div>
@@ -161,50 +134,59 @@
                                 </div>
                             </div>
                         </div>
-
                         <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="not_show_general_aliquot_purchase_international" />
-                                <field name="not_show_reduced_aliquot_purchase_international" />
-                                <field name="not_show_extend_aliquot_purchase_international" />
-                                <field name="not_show_total_purchases_with_international_iva" />
-                                <field name="not_show_exempt_total_purchases" />
-                                <field name="not_show_total_purchases_international" />
+                            <div class="row mt8">
+                                <div class="col-1">
+                                    <field name="not_show_general_aliquot_purchase_international"/>
+                                </div>
+                                <div class="col-11">
+                                    <label for="not_show_general_aliquot_purchase_international"/>
+                                </div>
                             </div>
-                            <div class="o_setting_right_pane" >
-                                <label for="not_show_general_aliquot_purchase_international" />
-                                <label for="not_show_reduced_aliquot_purchase_international" />
-                                <label for="not_show_extend_aliquot_purchase_international" />
-                                <label for="not_show_total_purchases_with_international_iva" />
-                                <label for="not_show_exempt_total_purchases" />
-                                <label for="not_show_total_purchases_international" />
+                            <div class="row mt8">
+                                <div class="col-1">
+                                    <field name="not_show_reduced_aliquot_purchase_international"/>
+                                </div>
+                                <div class="col-11">
+                                    <label for="not_show_reduced_aliquot_purchase_international"/>
+                                </div>
+                            </div>
+                            <div class="row mt8">
+                                <div class="col-1">
+                                    <field name="not_show_extend_aliquot_purchase_international"/>
+                                </div>
+                                <div class="col-11">
+                                    <label for="not_show_extend_aliquot_purchase_international"/>
+                                </div>
+                            </div>
+                            <div class="row mt8">
+                                <div class="col-1">
+                                    <field name="not_show_total_purchases_with_international_iva"/>
+                                </div>
+                                <div class="col-11">
+                                    <label for="not_show_total_purchases_with_international_iva"/>
+                                </div>
+                            </div>
+                            <div class="row mt8">
+                                <div class="col-1">
+                                    <field name="not_show_exempt_total_purchases"/>
+                                </div>
+                                <div class="col-11">
+                                    <label for="not_show_exempt_total_purchases"/>
+                                </div>
+                            </div>
+                            <div class="row mt8">
+                                <div class="col-1">
+                                    <field name="not_show_total_purchases_international"/>
+                                </div>
+                                <div class="col-11">
+                                    <label for="not_show_total_purchases_international"/>
+                                </div>
                             </div>
                         </div>
                     </block>
-
-                    <block title="Configuration Taxes: Non-Deductible " name="l10n_ve_tax_block_non_deductible" >
-                        <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_deductibility">
-                            <div class="o_setting_right_pane">
-                                <separator string="Deductibility"/>
-                                <group>
-                                    <field name="config_deductible_tax" string="Enable Non-Deductible Taxes"/>
-                                </group>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box" invisible="not config_deductible_tax" id="l10n_ve_tax_div_non_deductible_rates">
-                            <div class="o_setting_right_pane">
-                                <separator string="Non-Deductible Rates" />
-                                <group>
-                                    <field name="no_deductible_general_aliquot_purchase" string="General Aliquot"/>
-                                    <field name="no_deductible_reduced_aliquot_purchase" string="Reduced Aliquot"/>
-                                    <field name="no_deductible_extend_aliquot_purchase" string="Extended Aliquot"/>
-                                </group>
-                            </div>
-                        </div>
-                    </block>
-                   
                 </xpath>
             </field>
         </record>
     </data>
-    </odoo>
+</odoo>

--- a/l10n_ve_tax/views/res_config_settings.xml
+++ b/l10n_ve_tax/views/res_config_settings.xml
@@ -6,7 +6,7 @@
             <field name="inherit_id" ref="l10n_ve_base.l10n_ve_base_view_res_config_settings"/>
             <field name="arch" type="xml">
                 <xpath expr="//app[@name='l10n_ve_base']" position="inside">
-                    <block title="Configuration Taxes:" name="l10n_ve_tax_block_igtf">
+                    <block title="Configuration Taxes: IGTF" name="l10n_ve_tax_block_igtf">
                         <separator string="Core Settings"/>
                         <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_tax_div_config_igtf_unique_tax">
                             <div class="col-lg-6 o_setting_left_pane">


### PR DESCRIPTION
## Summary

Backport a `maintenance-17.0` de los ajustes de `l10n_ve_tax` hechos en el ticket 14172 (mismo cambio que en higea#319, `mg_stg_l10n_ve_17.0`). Reestructura `res_config_settings.xml` (checks que se solapaban entre si, espacios en blanco innecesarios) replicando en V17 la estructura ya usada en V19, y corrige las traducciones asociadas.

Cherry-pick limpio de los commits `2cd704327` y `0fc98da14`, sin conflictos con el refactor de impuestos de SaulOrte (`adfc269d0`) que también toca `l10n_ve_tax` pero solo `models/account_tax.py`.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/14172
- PR relacionado: https://github.com/binaural-dev/higea/pull/319