### PR TITLE
[FIX] l10n_ve_pos: Corrige linea equivocada en monto Bs

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.2.0",
+    "version": "17.0.0.2.1",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/models/pos_session.py
+++ b/l10n_ve_pos/models/pos_session.py
@@ -407,7 +407,14 @@ class PosSession(models.Model):
 
     def set_foreign_amount_in_line(self, line, foreign_amount, amount=0.0):
         other_lines = line.move_id.line_ids.filtered(
-            lambda x: x != line and x.account_id.account_type != "asset_receivable"
+            lambda x: x != line
+            and not x.not_foreign_recalculate
+            and float_compare(
+                x.debit or x.credit,
+                abs(amount),
+                precision_rounding=self.currency_id.rounding,
+            )
+            == 0
         )
         if other_lines:
             other_line = other_lines[0]


### PR DESCRIPTION
## Resumen
Se corrige el método `set_foreign_amount_in_line` (l10n_ve_pos), usado al cerrar la sesión del PdV para reflejar el monto en Bs (moneda alterna) en la línea contraparte de cada pago en efectivo/combinado. Validado en el ambiente de Higea (Ticket 14426).

## Problema
Los asientos de cierre de sesión (ej. APOS1/2026/8034) quedaban balanceados en USD pero desbalanceados en Bs, con diferencias de miles de bolívares entre el total débito y crédito alterno del asiento.

## Causa
Para ubicar la línea contraparte, el método tomaba "la primera línea del asiento cuyo tipo de cuenta no sea por cobrar (asset_receivable)", sin verificar que esa línea realmente correspondiera al pago que se estaba procesando. Cuando un pago en efectivo se contabiliza directamente contra la misma cuenta "Cuentas por Cobrar POS" (asset_receivable) usada por otros métodos de pago del mismo cierre, esa condición excluía a la verdadera contraparte y en su lugar tomaba la primera línea de otro método de pago distinto (ej. la línea transitoria de un banco), sobrescribiendo su monto en Bs con un valor que no le correspondía.

## Solución
Se reemplaza el criterio de búsqueda: en vez de filtrar por tipo de cuenta, ahora se exige que el monto de la línea candidata coincida con el del pago que se está procesando, y se excluyen líneas que ya fueron fijadas por una iteración anterior, evitando que un pago distinto las sobrescriba.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/14426