### PR TITLE
[FIX] l10n_ve_accountant: evitar "Expected singleton: res.currency()"…

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.10",
+    "version": "19.0.1.0.11",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_tax.py
+++ b/l10n_ve_accountant/models/account_tax.py
@@ -144,30 +144,44 @@ class AccountTax(models.Model):
                 currency_obj=ves_currency
             )
         foreign_lines = []
-        if record._name == 'account.move':
-            foreign_lines, _foreign_tax_lines = record._get_rounded_foreign_base_and_tax_lines()
-        elif record._name in ('sale.order','purchase.order'):
-            company_id = (record.company_id or self.env.company)
-            foreign_lines = [
-                line._prepare_foreign_base_line_for_taxes_computation()
-                for line in record.order_line
-                if hasattr(line, '_prepare_foreign_base_line_for_taxes_computation')
-            ]
-            
-            self._add_tax_details_in_base_lines(foreign_lines, company_id)
-            self._round_base_lines_tax_details(foreign_lines, company_id)
-        foreign_res = super()._get_tax_totals_summary(
-            foreign_lines,
-            foreign_currency_id,
-            company,
-            cash_rounding
-        )
-        #amounts in foreign currency
-        res['foreign_currency_id'] = foreign_res['currency_id']
-        res['ves_currency_id'] = self.env.company.currency_id.id
-        res['base_amount_foreign_currency'] = foreign_res['base_amount_currency']
-        res['tax_amount_foreign_currency'] = foreign_res['tax_amount_currency']
-        res['total_amount_foreign_currency'] = foreign_res['total_amount_currency']
+        foreign_res = {}
+        if not foreign_currency_id:
+            # No foreign currency is configured (neither on the move nor on the company), so
+            # there are no alternate-currency totals to compute. Fill the foreign keys with
+            # neutral values instead of handing an empty res.currency() to the core helpers:
+            # _round_base_lines_tax_details / _get_tax_totals_summary both call currency.round(),
+            # which raises "Expected singleton: res.currency()" on an empty recordset and aborts
+            # any module installation that recomputes sale.order.tax_totals on a fresh database.
+            res['foreign_currency_id'] = False
+            res['ves_currency_id'] = self.env.company.currency_id.id
+            res['base_amount_foreign_currency'] = 0.0
+            res['tax_amount_foreign_currency'] = 0.0
+            res['total_amount_foreign_currency'] = 0.0
+        else:
+            if record._name == 'account.move':
+                foreign_lines, _foreign_tax_lines = record._get_rounded_foreign_base_and_tax_lines()
+            elif record._name in ('sale.order','purchase.order'):
+                company_id = (record.company_id or self.env.company)
+                foreign_lines = [
+                    line._prepare_foreign_base_line_for_taxes_computation()
+                    for line in record.order_line
+                    if hasattr(line, '_prepare_foreign_base_line_for_taxes_computation')
+                ]
+
+                self._add_tax_details_in_base_lines(foreign_lines, company_id)
+                self._round_base_lines_tax_details(foreign_lines, company_id)
+            foreign_res = super()._get_tax_totals_summary(
+                foreign_lines,
+                foreign_currency_id,
+                company,
+                cash_rounding
+            )
+            #amounts in foreign currency
+            res['foreign_currency_id'] = foreign_res['currency_id']
+            res['ves_currency_id'] = self.env.company.currency_id.id
+            res['base_amount_foreign_currency'] = foreign_res['base_amount_currency']
+            res['tax_amount_foreign_currency'] = foreign_res['tax_amount_currency']
+            res['total_amount_foreign_currency'] = foreign_res['total_amount_currency']
         #discount amount 
         res['formatted_total_discount'] = formatted_total_discount
         res['formatted_total_discount_ves'] = formatted_total_discount_ves
@@ -354,9 +368,16 @@ class AccountTax(models.Model):
         def load(field, fallback, from_base_line=False):
             return self._get_base_line_field_value_from_record(record, field, kwargs, fallback, from_base_line=from_base_line)
 
+        # Never let this resolve to an empty res.currency(): the core taxes helpers round the
+        # base line against base_line['currency_id'], and an empty recordset raises
+        # "Expected singleton: res.currency()". Callers such as
+        # sale.order.line._prepare_foreign_base_line_for_taxes_computation already pass a safe
+        # currency_id in kwargs, so honour it before falling back to the company currency.
         currency = (
             load('foreign_currency_id', None)
-            or self.env.company.foreign_currency_id)
+            or self.env.company.foreign_currency_id
+            or kwargs.get('currency_id')
+            or self.env.company.currency_id)
         base_line = {
             **kwargs,
             'record': record,

--- a/l10n_ve_accountant/tests/__init__.py
+++ b/l10n_ve_accountant/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_account_tax_foreign
 from . import test_coverage_gaps
 from . import test_product_template
 from . import test_action_cancel
+from . import test_tax_totals_without_foreign_currency

--- a/l10n_ve_accountant/tests/test_tax_totals_without_foreign_currency.py
+++ b/l10n_ve_accountant/tests/test_tax_totals_without_foreign_currency.py
@@ -1,0 +1,148 @@
+import logging
+
+from odoo import Command, fields
+from odoo.tests import TransactionCase, tagged
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install", "l10n_ve_accountant_no_foreign_currency")
+class TestTaxTotalsWithoutForeignCurrency(TransactionCase):
+    """
+    Regression tests for a company WITHOUT `foreign_currency_id`.
+
+    `res.company.foreign_currency_id` has no default and is not required, so on any
+    freshly created database it is empty. In that state
+    `account.tax._get_tax_totals_summary` used to hand an empty `res.currency()` to the
+    core taxes helpers, which round against it and raise:
+
+        ValueError: Expected singleton: res.currency()
+
+    Because `sale.order.tax_totals` is a stored computed field, the ORM recomputes it
+    while installing modules, so the crash aborted the installation of *any* module on
+    a fresh database, not just a sale flow at runtime.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.currency_vef = self.env.ref("base.VEF")
+        self.company = self.env.company
+        self.country_ve = self.env.ref("base.ve")
+
+        self.company.write({
+            "currency_id": self.currency_vef.id,
+            "account_fiscal_country_id": self.country_ve.id,
+            "country_id": self.country_ve.id,
+        })
+        # The condition under test: no foreign currency configured at all.
+        self.company.foreign_currency_id = False
+
+        self.partner = self.env["res.partner"].create({"name": "Cliente sin moneda extranjera"})
+        self.tax = self._get_tax("sale")
+        self.tax_purchase = self._get_tax("purchase")
+        # `l10n_ve_accountant` enforces exactly one sales tax and one purchase tax per
+        # product, so both have to be set explicitly instead of inheriting the company
+        # defaults (which carry more than one).
+        self.product = self.env["product.product"].create({
+            "name": "Producto sin moneda extranjera",
+            "type": "service",
+            "list_price": 100.0,
+            "taxes_id": [Command.set([self.tax.id])],
+            "supplier_taxes_id": [Command.set([self.tax_purchase.id])],
+        })
+
+    def _get_tax(self, type_tax_use):
+        """
+        Reuse a tax already installed by the localisation. Creating one here is not
+        practical: `account.tax` validates that its tax group shares the same
+        `country_id`, so a hand-made tax/group pair has to reproduce the fiscal
+        country wiring that the localisation data already sets up correctly.
+        """
+        tax = self.env["account.tax"].search([
+            ("type_tax_use", "=", type_tax_use),
+            ("company_id", "=", self.company.id),
+            ("amount_type", "=", "percent"),
+        ], limit=1)
+        self.assertTrue(
+            tax,
+            f"No '{type_tax_use}' percent tax found for company {self.company.display_name}; "
+            "the localisation data is expected to provide one.",
+        )
+        return tax
+
+    def _create_sale_order(self):
+        return self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+            "company_id": self.company.id,
+            "date_order": fields.Datetime.now(),
+            "order_line": [
+                Command.create({
+                    "product_id": self.product.id,
+                    "product_uom_qty": 2,
+                    "price_unit": 100.0,
+                    "tax_ids": [Command.set([self.tax.id])],
+                })
+            ],
+        })
+
+    def test_sale_order_tax_totals_does_not_raise(self):
+        """The whole point of the fix: computing tax_totals must not raise."""
+        self.assertFalse(
+            self.company.foreign_currency_id,
+            "The company must have no foreign currency for this test to be meaningful.",
+        )
+        order = self._create_sale_order()
+
+        totals = order.tax_totals
+
+        self.assertTrue(totals, "tax_totals must still be computed without a foreign currency.")
+        self.assertAlmostEqual(totals["base_amount_currency"], 200.0, places=2)
+        expected_tax = 200.0 * self.tax.amount / 100
+        self.assertAlmostEqual(totals["tax_amount_currency"], expected_tax, places=2)
+
+    def test_foreign_keys_are_neutral_not_missing(self):
+        """
+        Consumers (templates, reports, the website checkout) read these keys
+        unconditionally, so they must exist with neutral values rather than be absent.
+        """
+        order = self._create_sale_order()
+
+        totals = order.tax_totals
+
+        self.assertFalse(totals["foreign_currency_id"])
+        self.assertEqual(totals["ves_currency_id"], self.company.currency_id.id)
+        self.assertEqual(totals["base_amount_foreign_currency"], 0.0)
+        self.assertEqual(totals["tax_amount_foreign_currency"], 0.0)
+        self.assertEqual(totals["total_amount_foreign_currency"], 0.0)
+
+    def test_foreign_base_line_currency_is_never_empty(self):
+        """
+        `_prepare_foreign_base_line_for_taxes_computation` must never produce a base line
+        whose `currency_id` is an empty recordset: the core helpers round against it.
+        It must also honour the `currency_id` the caller passes in kwargs
+        (sale.order.line does pass a safe one) before falling back to the company currency.
+        """
+        order = self._create_sale_order()
+        line = order.order_line[0]
+
+        base_line = line._prepare_foreign_base_line_for_taxes_computation()
+
+        self.assertTrue(
+            base_line["currency_id"],
+            "The foreign base line must carry a non-empty currency.",
+        )
+        self.assertEqual(len(base_line["currency_id"]), 1, "Expected exactly one currency.")
+
+    def test_stored_tax_totals_survive_a_recompute(self):
+        """
+        Mirrors what breaks during installation: forcing the ORM to recompute the stored
+        computed fields must not raise.
+        """
+        order = self._create_sale_order()
+
+        self.env.invalidate_all()
+        self.env["sale.order"].browse(order.id).order_line.price_unit = 150.0
+        self.env.flush_all()
+
+        self.assertAlmostEqual(order.tax_totals["base_amount_currency"], 300.0, places=2)


### PR DESCRIPTION
… sin moneda extranjera

`res.company.foreign_currency_id` no tiene default ni es required, asi que en cualquier base recien creada esta vacio. En ese estado `_get_tax_totals_summary` le entregaba un `res.currency()` vacio a los helpers de impuestos del core, que redondean contra el y levantan:

    ValueError: Expected singleton: res.currency()

Como `sale.order.tax_totals` es un computed almacenado, el ORM lo recalcula durante la instalacion de modulos, asi que el error abortaba la instalacion de CUALQUIER modulo sobre una base nueva -- no solo un flujo de venta en runtime. Eso dejaba el CI de 19.0 en rojo con "0 modulos instalados".

Dos correcciones:

- `_get_tax_totals_summary`: si no hay `foreign_currency_id`, ya no se construyen las lineas ni se llama al super() con una moneda vacia. Las claves `foreign_*` se rellenan con valores neutros para no romper a los consumidores (plantillas, reportes, checkout del website), igual que ya hace el early-return de `if not record`.

- `_prepare_foreign_base_line_for_taxes_computation`: `currency` ya no puede quedar vacio. Ademas respeta el `currency_id` que pasa el llamador en kwargs --`sale.order.line` ya calculaba uno seguro y se descartaba, porque `'currency_id': currency` estaba despues de `**kwargs`-- y cae a la moneda de la compania como ultimo recurso.

Tests: `TestTaxTotalsWithoutForeignCurrency` cubre los 4 invariantes y falla sin este cambio con el ValueError exacto.