### PR TITLE
fix(l10n_ve_pos_mf): no mostrar Reimprimir en pedidos sin factura fiscal

### DIFF
--- a/l10n_ve_pos_mf/__manifest__.py
+++ b/l10n_ve_pos_mf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
-    "version": "17.0.2.1.0",
+    "version": "17.0.2.1.1",
     "category": "Accounting",
     "summary": "Venezuela - Integración de Punto de Venta con Maquina Fiscal",
     "sequence": "1",

--- a/l10n_ve_pos_mf/static/src/xml/TicketScreen.xml
+++ b/l10n_ve_pos_mf/static/src/xml/TicketScreen.xml
@@ -2,7 +2,7 @@
     <t t-name="TicketScreen" t-inherit="point_of_sale.TicketScreen" t-inherit-mode="extension" owl="1">
         <xpath expr="//div[hasclass('control-buttons')]" position="inside">
         <t t-if="_selectedSyncedOrder">
-                <t t-if="_selectedSyncedOrder &amp;&amp; _selectedSyncedOrder.get_total_with_tax() > 0">
+                <t t-if="_selectedSyncedOrder.mf_invoice_number &amp;&amp; _selectedSyncedOrder.get_total_with_tax() > 0">
                     <ReprintInvoiceButton order="_selectedSyncedOrder" />
                 </t>
                 <t t-if="!_selectedSyncedOrder.mf_invoice_number">


### PR DESCRIPTION
## Resumen
- `ReprintInvoiceButton` solo validaba `total > 0` para mostrarse en `TicketScreen`, sin comprobar `mf_invoice_number`. Un pedido "pendiente por facturar" (sin número fiscal, ej. porque la MF estaba apagada al validar) mostraba a la vez "Reimprimir" e "Imprimir pedido pendiente".
- El botón de reimprimir ya rechazaba el click con "Nada que reimprimir" en ese caso, pero confundía al cajero sobre cuál botón usar.
- Ahora ambos botones son mutuamente excluyentes según `mf_invoice_number`: sin número fiscal → solo "Imprimir pedido pendiente"; con número fiscal → solo "Reimprimir".

## Nota
El PR #1146 (mergeado el 2026-08-10) ya integró a `17.0` la migración completa a Web Serial API más el fix de conexión bajo demanda del backend (`l10n_ve_iot_mf`, evita que una pestaña de backoffice retenga el puerto serial indefinidamente). Este PR contiene únicamente el commit posterior a ese merge.

## Test plan
- [x] Validar un pedido "Factura" con la MF apagada/desconectada, confirmar que en TicketScreen solo aparece "Imprimir pedido pendiente" (no "Reimprimir")
- [x] Imprimir el pedido pendiente con la MF encendida, confirmar que tras obtener `mf_invoice_number` el botón cambia a "Reimprimir"