### PR TITLE
Error en los calculos alternos base USD

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -41,7 +41,7 @@ Cambios en UI / Modelos impactados
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.60",
+    "version": "17.0.0.0.61",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -187,7 +187,10 @@ class AccountMove(models.Model):
                     total_residual_currency += line.foreign_amount_residual
             sign = move.direction_sign
             if move.is_invoice(include_receipts=True):
-                move.foreign_amount_residual = -sign * total_residual_currency
+                amount = -sign * total_residual_currency
+                if amount <= 0:
+                    amount = 0.0
+                move.foreign_amount_residual = amount
             else:
                 move.foreign_amount_residual = abs(total_residual_currency)
 

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1050,7 +1050,20 @@ class AccountMove(models.Model):
         taxing each product's OWN `foreign_price` directly (legacy per-line
         method) so the manually-priced line's tax follows ITS price, not
         the document rate.
+
+        The same fallback is also used whenever the company's base
+        currency is USD: `amount_total`/`tl.balance` are then native USD
+        amounts already rounded to 2 decimals, and multiplying that
+        already-rounded value by the (large, VEF-per-USD) `rate` amplifies
+        a fraction-of-a-cent USD rounding difference into several
+        bolivares of drift -- the "sum(native x rate) == amount_total x
+        rate exactly" argument above only holds while the native side
+        keeps enough precision relative to the alterno side, which isn't
+        the case when native is the small-magnitude, 2-decimal currency.
+        Taxing `foreign_price` directly (it keeps its own higher "Foreign
+        Product Price" precision) avoids that amplification.
         """
+        usd = self.env.ref("base.USD", raise_if_not_found=False)
         guarded = self.env.cr.cache.setdefault('_foreign_tax_balanced_set', set())
         for move in moves:
             if move.state != 'draft':
@@ -1081,7 +1094,8 @@ class AccountMove(models.Model):
             guarded.add(move.id)
             try:
                 manual_alterno = any(base_lines.mapped('foreign_price_manual'))
-                if manual_alterno:
+                is_usd_base = bool(usd and move.company_id.currency_id == usd)
+                if manual_alterno or is_usd_base:
                     self._compute_foreign_tax_balance_from_lines(move, fc, tax_amls)
                 else:
                     rate_date = move.invoice_date or move.date or fields.Date.context_today(move)

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -166,7 +166,7 @@ class AccountMoveLine(models.Model):
             if line.foreign_currency_id.compare_amounts(line.foreign_price, expected) != 0:
                 line.foreign_price_manual = True
 
-    @api.depends("foreign_price", "quantity", "discount", "price_total", "price_subtotal",
+    @api.depends("foreign_price", "quantity", "discount", "tax_ids", "price_total", "price_subtotal",
                   "price_unit", "currency_id", "foreign_inverse_rate",
                   "move_id.foreign_inverse_rate")
     def _compute_foreign_subtotal(self):
@@ -187,7 +187,20 @@ class AccountMoveLine(models.Model):
         Converting the native tax amount directly needs no sibling data at
         all, so only the line actually being edited ever changes, and it
         matches the asiento for sales, purchases, and the invoice alike.
+
+        EXCEPT when the company's base currency is USD: there, the native
+        amounts (`price_total`/`price_subtotal`) are already rounded to
+        USD's 2 decimals BEFORE any conversion happens, and multiplying
+        that already-rounded delta by the (large, VEF-per-USD) rate
+        amplifies a fraction-of-a-cent USD rounding difference into
+        several bolivares of drift. Taxing the alterno base directly
+        (`foreign_price`, which keeps its own higher "Foreign Product
+        Price" precision instead of being rounded to 2 decimals) avoids
+        that double-rounding-then-amplify path entirely -- the same
+        reasoning `price_subtotal` itself follows natively (tax the base
+        directly, never convert a foreign delta into it).
         """
+        usd = self.env.ref("base.USD", raise_if_not_found=False)
         for line in self:
             foreign_price_unit_full_precision = line.foreign_price * (
                 1 - (line.discount / 100.0)
@@ -197,13 +210,28 @@ class AccountMoveLine(models.Model):
             )
             line.foreign_subtotal = foreign_subtotal
 
-            foreign_tax_amount = line.currency_id._convert(
-                line.price_total - line.price_subtotal,
-                line.foreign_currency_id,
-                line.company_id,
-                line.move_id.invoice_date or fields.Date.today(),
-                custom_rate=line.foreign_inverse_rate,
-            )
+            if usd and line.company_id.currency_id == usd:
+                if line.tax_ids:
+                    foreign_tax_amount = line.foreign_currency_id.round(
+                        line.tax_ids.compute_all(
+                            foreign_price_unit_full_precision,
+                            quantity=line.quantity,
+                            currency=line.foreign_currency_id,
+                            product=line.product_id,
+                            partner=line.partner_id,
+                            is_refund=line.is_refund,
+                        )["total_included"]
+                    ) - foreign_subtotal
+                else:
+                    foreign_tax_amount = 0.0
+            else:
+                foreign_tax_amount = line.currency_id._convert(
+                    line.price_total - line.price_subtotal,
+                    line.foreign_currency_id,
+                    line.company_id,
+                    line.move_id.invoice_date or fields.Date.today(),
+                    custom_rate=line.foreign_inverse_rate,
+                )
             line.foreign_price_total = foreign_subtotal + foreign_tax_amount
 
     def _set_foreign(self, value):

--- a/l10n_ve_accountant/tests/test_coverage_gaps.py
+++ b/l10n_ve_accountant/tests/test_coverage_gaps.py
@@ -1126,6 +1126,152 @@ class TestCoverageGaps(TransactionCase):
             self.assertGreater(rec_line.foreign_debit, 0)
             self.assertEqual(rec_line.foreign_credit, 0.0)
 
+    # ═══════════════════════════════════════════════════════════════
+    # account_move_line.py - _compute_foreign_subtotal: base VEF vs base
+    # USD must use DIFFERENT formulas for the tax portion of
+    # foreign_price_total (base VEF converts the native tax delta; base
+    # USD taxes the alterno base directly, since converting an
+    # already-2-decimal-rounded USD tax amount by a large VEF rate
+    # amplifies sub-cent noise into several bolivares -- see
+    # _compute_foreign_subtotal's docstring).
+    # ═══════════════════════════════════════════════════════════════
+
+    def _direct_foreign_tax(self, line):
+        """Replicates taxing the alterno base directly (compute_all on
+        `foreign_price`), the formula base USD must use."""
+        foreign_price_unit = line.foreign_price * (1 - line.discount / 100.0)
+        taxed = line.tax_ids.compute_all(
+            foreign_price_unit, quantity=line.quantity,
+            currency=line.foreign_currency_id, product=line.product_id,
+            partner=line.partner_id, is_refund=line.is_refund,
+        )["total_included"]
+        return line.foreign_currency_id.round(taxed) - line.foreign_subtotal
+
+    def _converted_native_tax(self, line):
+        """Replicates converting the native tax delta, the formula base
+        VEF must use."""
+        return line.currency_id._convert(
+            line.price_total - line.price_subtotal, line.foreign_currency_id,
+            line.company_id, line.move_id.invoice_date or fields.Date.today(),
+            custom_rate=line.foreign_inverse_rate,
+        )
+
+    def test_foreign_price_total_vef_base_converts_native_tax(self):
+        """Base VEF (this class' default setUp): `foreign_price_total`'s
+        tax portion must match converting the native tax delta, not
+        taxing the alterno base directly -- the two formulas are
+        expected to diverge slightly (see the USD-base test below), and
+        this asserts the VEF-base branch picks the conversion one."""
+        invoice = self._create_invoice(self.currency_vef, 99.99)
+        line = invoice.invoice_line_ids[:1]
+        self.assertTrue(line)
+        actual_tax = line.foreign_price_total - line.foreign_subtotal
+        self.assertAlmostEqual(
+            actual_tax, self._converted_native_tax(line), places=2,
+            msg="base VEF must convert the native tax delta")
+
+    def test_foreign_price_total_usd_base_taxes_alterno_directly(self):
+        """Base USD: `foreign_price_total`'s tax portion must tax the
+        alterno base directly (like `price_subtotal` is taxed natively),
+        NOT convert the native (already USD-2-decimal-rounded) tax delta
+        -- converting it would amplify the native rounding noise by the
+        (large) VEF rate into a visibly wrong bolivar amount.
+
+        99.99 x 16% = 15.9984, which native tax rounds to 16.00 (a real
+        +0.0016 USD rounding bump); multiplied by a ~710 VEF rate that
+        alone is already a ~1.1 Bs difference from the direct-tax
+        result, well above float noise, proving which formula actually
+        ran.
+        """
+        self.company.write({
+            "currency_id": self.currency_usd.id,
+            "currency_foreign_id": self.currency_vef.id,
+        })
+        invoice = self.env["account.move"].with_context(
+            check_move_validity=False,
+        ).create({
+            "move_type": "out_invoice",
+            "partner_id": self.partner.id,
+            "journal_id": self.sale_journal.id,
+            "currency_id": self.currency_usd.id,
+            "date": fields.Date.today(),
+            "manually_set_rate": True,
+            "foreign_rate": 709.6935,
+            "foreign_inverse_rate": 709.6935,
+            "invoice_line_ids": [
+                Command.create({
+                    "product_id": self.product.id,
+                    "quantity": 1.0, "price_unit": 99.99,
+                    "account_id": self.acc_inc.id,
+                    "tax_ids": [(6, 0, [self.tax_16.id])],
+                }),
+            ],
+        })
+        line = invoice.invoice_line_ids[:1]
+        self.assertTrue(line)
+        actual_tax = line.foreign_price_total - line.foreign_subtotal
+        direct_tax = self._direct_foreign_tax(line)
+        converted_tax = self._converted_native_tax(line)
+
+        self.assertNotAlmostEqual(
+            direct_tax, converted_tax, places=1,
+            msg="test premise: the two formulas must actually diverge here")
+        self.assertAlmostEqual(
+            actual_tax, direct_tax, places=2,
+            msg="base USD must tax the alterno base directly")
+        self.assertNotAlmostEqual(
+            actual_tax, converted_tax, places=1,
+            msg="base USD must NOT convert the native tax delta")
+
+    def test_compute_foreign_tax_balance_usd_base_matches_direct_lines(self):
+        """The REAL posted tax line (`_compute_foreign_tax_balance` in
+        account_move.py) must follow the same base-USD rule: its
+        `foreign_debit`/`foreign_credit` must match
+        `_compute_foreign_tax_balance_from_lines` (taxing each product's
+        `foreign_price` directly), not the `amount_total x rate`-anchored
+        apportionment used for base VEF.
+        """
+        self.company.write({
+            "currency_id": self.currency_usd.id,
+            "currency_foreign_id": self.currency_vef.id,
+        })
+        invoice = self.env["account.move"].with_context(
+            check_move_validity=False,
+        ).create({
+            "move_type": "out_invoice",
+            "partner_id": self.partner.id,
+            "journal_id": self.sale_journal.id,
+            "currency_id": self.currency_usd.id,
+            "invoice_date": fields.Date.today(),
+            "date": fields.Date.today(),
+            "manually_set_rate": True,
+            "foreign_rate": 709.6935,
+            "foreign_inverse_rate": 709.6935,
+            "invoice_line_ids": [
+                Command.create({
+                    "product_id": self.product.id,
+                    "quantity": 1.0, "price_unit": 99.99,
+                    "account_id": self.acc_inc.id,
+                    "tax_ids": [(6, 0, [self.tax_16.id])],
+                }),
+            ],
+        })
+        invoice.with_context(move_action_post_alert=True).action_post()
+
+        tax_line = invoice.line_ids.filtered(lambda l: l.display_type == 'tax')[:1]
+        self.assertTrue(tax_line)
+        product_line = invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'product')[:1]
+        self.assertTrue(product_line)
+        expected_per_key = self._foreign_tax_expected(invoice)
+        # _foreign_tax_expected keys by the BASE (product) line's account,
+        # not the tax line's own account -- see its docstring.
+        key = (tax_line.tax_repartition_line_id.id, product_line.account_id.id)
+        expected_amount = sum(expected_per_key.get(key, []))
+        self.assertAlmostEqual(
+            tax_line.foreign_debit - tax_line.foreign_credit,
+            expected_amount, places=2,
+            msg="posted tax line must match the direct per-line method under base USD")
+
     def test_inverse_foreign_price(self):
         invoice = self._create_invoice(self.currency_usd, 100.0)
         line = invoice.line_ids.filtered(lambda l: l.display_type == 'product')[:1]

--- a/l10n_ve_tax/__manifest__.py
+++ b/l10n_ve_tax/__manifest__.py
@@ -39,7 +39,7 @@ Cambios en UI / Modelos impactados
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.1.0.2",
+    "version": "17.0.1.0.3",
     # any module necessary for this one to work correctly
     "depends": ["base", "account", "l10n_ve_base", "l10n_ve_rate"],
     "data": [

--- a/l10n_ve_tax/models/account_tax.py
+++ b/l10n_ve_tax/models/account_tax.py
@@ -272,7 +272,19 @@ class AccountTax(models.Model):
         invoice it will turn into. No new field is introduced here --
         `price_total`/`price_subtotal` are core fields already present on
         both `sale.order.line` and `purchase.order.line`.
+
+        EXCEPT when the company's base currency is USD: `price_total`/
+        `price_subtotal` are then already rounded to USD's 2 decimals
+        before any conversion, and multiplying that already-rounded delta
+        by the (large, VEF-per-USD) rate amplifies a fraction-of-a-cent
+        USD rounding difference into several bolivares of drift. There,
+        the ideal per-tax breakdown computed below (taxing `foreign_price`
+        -- which keeps its own higher precision -- directly) is used
+        as-is instead of being discarded in favor of the converted delta,
+        same reasoning as `account.move.line._compute_foreign_subtotal`.
         """
+        usd = self.env.ref("base.USD", raise_if_not_found=False)
+        is_usd_base = bool(usd and order.company_id.currency_id == usd)
         product_lines = order.order_line.filtered(lambda l: not l.display_type)
         if not product_lines or 'foreign_price' not in product_lines._fields:
             return
@@ -305,17 +317,25 @@ class AccountTax(models.Model):
             ideal_tax_by_id = {t['id']: abs(t['amount']) for t in foreign_res['taxes']}
             ideal_line_total = sum(ideal_tax_by_id.values())
 
-            # Anchor this line's REAL tax portion to the direct conversion
-            # of its own native tax amount; the ideal breakdown above is
-            # only used to split that real total across the line's own
-            # tax groups when it carries more than one.
-            line_tax_total = abs(pl.currency_id._convert(
-                pl.price_total - pl.price_subtotal,
-                fc,
-                order.company_id,
-                order.date_order.date() if getattr(order, "date_order", False) else fields.Date.today(),
-                custom_rate=pl.foreign_inverse_rate,
-            ))
+            if is_usd_base:
+                # Base USD: tax the alterno base directly (the ideal
+                # breakdown already computed above) instead of converting
+                # an already-2-decimal-rounded native delta, which would
+                # amplify sub-cent USD noise into several bolivares.
+                line_tax_total = ideal_line_total
+            else:
+                # Anchor this line's REAL tax portion to the direct
+                # conversion of its own native tax amount; the ideal
+                # breakdown above is only used to split that real total
+                # across the line's own tax groups when it carries more
+                # than one.
+                line_tax_total = abs(pl.currency_id._convert(
+                    pl.price_total - pl.price_subtotal,
+                    fc,
+                    order.company_id,
+                    order.date_order.date() if getattr(order, "date_order", False) else fields.Date.today(),
+                    custom_rate=pl.foreign_inverse_rate,
+                ))
 
             for tax_id, ideal_amount in ideal_tax_by_id.items():
                 grp_id = self.browse(tax_id).tax_group_id.id


### PR DESCRIPTION
[FIX] l10n_ve_accountant/l10n_ve_tax: gravar la base alterna directamente cuando la base es USD

Ticket: https://www.binauraldev.com/odoo/my-tickets/14587

El anclaje del impuesto alterno a la conversion del monto nativo (introducido en commits previos de este mismo ticket 14463, para que cotizacion y factura coincidieran) funciona bien cuando la moneda nativa de la compania es VEF (magnitud grande, alterno USD de magnitud pequena): convertir un monto VEF ya redondeado hacia USD amortigua cualquier ruido de redondeo, porque se divide por una tasa grande.

Cuando la base de la compania es USD, ocurre lo contrario: los montos nativos (price_total/price_subtotal, y el balance de la linea de impuesto ya posteada) ya vienen redondeados a 2 decimales de dolar ANTES de cualquier conversion. Multiplicar ese delta ya redondeado por la tasa (grande, VEF por USD) amplifica una diferencia de fraccion de centavo de dolar en varios bolivares de deriva -- un caso tan simple como 99.99 x 16% (impuesto nativo 15.9984, redondeado a 16.00) ya produce ~1.1 Bs de diferencia solo por ese redondeo, con una tasa de ~710.

Se condiciona por company.currency_id == USD en los tres lugares donde existe este anclaje, para que en ese caso graven la base alterna directamente (mismo criterio que ya usa price_subtotal nativamente, aprovechando que foreign_price conserva su propia precision alta en vez de redondearse a 2 decimales):

- l10n_ve_accountant/models/account_move_line.py: _compute_foreign_subtotal (foreign_price_total por linea de factura).
- l10n_ve_tax/models/account_tax.py: _anchor_foreign_taxes_for_order (tax_totals de cotizacion/orden de compra), reutilizando el desglose ideal por tax_id que ya se calculaba ahi mismo.
- l10n_ve_accountant/models/account_move.py: _compute_foreign_tax_balance (el monto REAL posteado en la linea de impuesto), reutilizando el metodo legacy _compute_foreign_tax_balance_from_lines que ya gravaba foreign_price directamente (antes solo usado para el caso de alterno manual).

Se agregan pruebas en l10n_ve_accountant/tests/test_coverage_gaps.py que demuestran la divergencia real entre ambas formulas y verifican que cada base (VEF/USD) usa la que le corresponde, tanto para el campo de display (foreign_price_total) como para el monto realmente posteado en el asiento (_compute_foreign_tax_balance).