### PR TITLE
[FIX] l10n_ve_invoice: corregir Total Neto en 0,00 en libro de ventas…

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -28,7 +28,7 @@ Cambios en UI / Modelos impactados
   configuración; wizard y reportes de libro de compras/ventas y de
   factura de forma libre.
 """,
-    "version": "17.0.1.0.5",
+    "version": "17.0.1.0.6",
     "license": "LGPL-3",
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/tests/test_accounting_reports.py
+++ b/l10n_ve_invoice/tests/test_accounting_reports.py
@@ -1,7 +1,9 @@
+import zipfile
 from datetime import date
 from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import patch
+from xml.etree import ElementTree
 
 import xlsxwriter
 from dateutil.relativedelta import relativedelta
@@ -10,6 +12,25 @@ from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
+
+_XLSX_MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+
+
+def _read_cached_xlsx_cell_value(xlsx_bytes, cell_ref, sheet="xl/worksheets/sheet1.xml"):
+    """
+    Lee el valor cacheado (<v>) de una celda de un .xlsx sin depender de
+    openpyxl: un .xlsx es un zip con XML adentro, y xlsxwriter (usado para
+    generarlo) nunca evalua las formulas que escribe -- solo guarda el
+    texto de la formula junto a un valor cacheado, que por defecto es 0
+    salvo que se pase explicitamente.
+    """
+    with zipfile.ZipFile(BytesIO(xlsx_bytes)) as archive:
+        sheet_xml = archive.read(sheet)
+    cell = ElementTree.fromstring(sheet_xml).find(
+        f".//{{{_XLSX_MAIN_NS}}}c[@r='{cell_ref}']"
+    )
+    value_el = cell.find(f"{{{_XLSX_MAIN_NS}}}v") if cell is not None else None
+    return float(value_el.text) if value_el is not None else None
 
 
 @tagged("post_install", "-at_install", "l10n_ve_invoice")
@@ -1048,6 +1069,57 @@ class TestAccountingReports(TransactionCase):
                     self.wizard.generate_book_resume(worksheet, 10, merge_format, cell_formats)
 
                 workbook.close()
+
+    def test_generate_book_resume_writes_cached_total_neto_value(self):
+        """
+        xlsxwriter nunca evalua las formulas que escribe: sin un valor
+        cacheado explicito, cualquier visor que no recalcule (Google Sheets
+        al importar, previsualizaciones, etc.) muestra 0,00 en "Total Neto"
+        aunque la formula SUMPRODUCT sea correcta. Este test abre el zip del
+        xlsx resultante para leer justamente ese valor cacheado, no el texto
+        de la formula (ver _read_cached_xlsx_cell_value).
+        """
+        move = self._create_move(
+            name="BILL/2023/RESUME3",
+            move_type="in_invoice",
+            accounting_date=date(2023, 1, 10),
+        )
+        moves = self.env["account.move"].browse(move.id)
+
+        self.wizard.write({"report": "sale"})
+        buffer = BytesIO()
+        workbook = xlsxwriter.Workbook(buffer, {"in_memory": True})
+        worksheet = workbook.add_worksheet()
+        merge_format = workbook.add_format()
+        cell_formats = {"number": workbook.add_format({"num_format": "#,##0.00"})}
+
+        # Facturas/ND: base 1000.0, debito 160.0 -- Notas de Credito (ya en
+        # negativo, como las devuelve _determinate_resume_books): base -100.0,
+        # debito -16.0. Total Neto esperado: base 900.0, debito 144.0.
+        resume_lines = [
+            {"name": "L1", "values": [1000.0, 160.0, -100.0, -16.0]},
+            {"name": "TOTAL", "values": [0.0, 0.0, 0.0, 0.0], "total": True},
+        ]
+
+        with patch.object(type(self.wizard), "search_moves", return_value=moves), patch.object(
+            type(self.wizard), "_resume_sale_book_fields", return_value=resume_lines
+        ):
+            self.wizard.generate_book_resume(worksheet, 10, merge_format, cell_formats)
+
+        workbook.close()
+        xlsx_bytes = buffer.getvalue()
+
+        # index_to_start=10 -> filas de resumen empiezan en (10+4)=14 (0-based),
+        # es decir fila 15 de Excel (1-based) para "L1" y 16 para "TOTAL".
+        self.assertAlmostEqual(_read_cached_xlsx_cell_value(xlsx_bytes, "G15"), 900.0, places=2)
+        self.assertAlmostEqual(_read_cached_xlsx_cell_value(xlsx_bytes, "H15"), 144.0, places=2)
+
+        self.assertAlmostEqual(_read_cached_xlsx_cell_value(xlsx_bytes, "C16"), 1000.0, places=2)
+        self.assertAlmostEqual(_read_cached_xlsx_cell_value(xlsx_bytes, "D16"), 160.0, places=2)
+        self.assertAlmostEqual(_read_cached_xlsx_cell_value(xlsx_bytes, "E16"), -100.0, places=2)
+        self.assertAlmostEqual(_read_cached_xlsx_cell_value(xlsx_bytes, "F16"), -16.0, places=2)
+        self.assertAlmostEqual(_read_cached_xlsx_cell_value(xlsx_bytes, "G16"), 900.0, places=2)
+        self.assertAlmostEqual(_read_cached_xlsx_cell_value(xlsx_bytes, "H16"), 144.0, places=2)
 
     def test_generate_sales_book_returns_xlsx(self):
         self.wizard.write({"report": "sale"})

--- a/l10n_ve_invoice/wizard/accounting_reports.py
+++ b/l10n_ve_invoice/wizard/accounting_reports.py
@@ -1201,6 +1201,7 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
 
         password_protection = "secure"
         workbook = xlsxwriter.Workbook(file, {"in_memory": True, "nan_inf_to_errors": True})
+        workbook.set_calc_mode('auto')
         worksheet = workbook.add_worksheet()
 
         cell_bold = workbook.add_format(
@@ -1527,59 +1528,51 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
             else self._resume_sale_book_fields(moves)
         )
 
+        # Sumas acumuladas por columna (C,D,E,F) para poder escribir el valor
+        # cacheado real de las filas "total", ya que xlsxwriter nunca evalúa
+        # las fórmulas que escribe: sin un valor cacheado correcto, cualquier
+        # visor que no recalcule (Google Sheets al importar, previews, etc.)
+        # muestra 0,00 aunque la fórmula en sí sea correcta.
+        col_running_sums = [0.0, 0.0, 0.0, 0.0]
+
         for idx, resume in enumerate(resume_columns):
             row_resume = (index_to_start + 4) + idx
 
             worksheet.write(row_resume, 0, idx + 1)
             worksheet.write(row_resume, 1, resume.get("name"))
 
+            row_values = resume.get("values")
             total_line = 0
-            for idx_line, line in enumerate(resume.get("values")):
+            for idx_line, line in enumerate(row_values):
                 total_line = idx_line + 2
                 worksheet.write(row_resume, idx_line + 2, line, cell_formats.get("number"))
+                if idx_line < len(col_running_sums):
+                    col_running_sums[idx_line] += line
 
-            if not is_purchase:
-                if resume.get("total"):
-                    total_c_formula = f"=SUM(C{index_to_start + 5}:C{row_resume})"
-                    total_d_formula = f"=SUM(D{index_to_start + 5}:D{row_resume})"
-                    total_e_formula = f"=SUM(E{index_to_start + 5}:E{row_resume})"
-                    total_f_formula = f"=SUM(F{index_to_start + 5}:F{row_resume})"
+            effective_values = row_values
+            if resume.get("total"):
+                total_c_formula = f"=SUM(C{index_to_start + 5}:C{row_resume})"
+                total_d_formula = f"=SUM(D{index_to_start + 5}:D{row_resume})"
+                total_e_formula = f"=SUM(E{index_to_start + 5}:E{row_resume})"
+                total_f_formula = f"=SUM(F{index_to_start + 5}:F{row_resume})"
 
-                    worksheet.write_formula(
-                        row_resume, 2, total_c_formula, cell_formats.get("number")
-                    )
-                    worksheet.write_formula(
-                        row_resume, 3, total_d_formula, cell_formats.get("number")
-                    )
-                    worksheet.write_formula(
-                        row_resume, 4, total_e_formula,cell_formats.get("number")
-                    )
-                    worksheet.write_formula(
-                        row_resume, 5, total_f_formula,cell_formats.get("number")
-                    )
+                effective_values = col_running_sums
 
-            else:
-                if resume.get("total"):
-                    total_c_formula = f"=SUM(C{index_to_start + 5}:C{row_resume})"
-                    total_d_formula = f"=SUM(D{index_to_start + 5}:D{row_resume})"
-                    total_e_formula = f"=SUM(E{index_to_start + 5}:E{row_resume})"
-                    total_f_formula = f"=SUM(F{index_to_start + 5}:F{row_resume})"
-
-                    worksheet.write_formula(
-                        row_resume, 2, total_c_formula, cell_formats.get("number")
-                    )
-                    worksheet.write_formula(
-                        row_resume, 3, total_d_formula, cell_formats.get("number")
-                    )
-                    worksheet.write_formula(
-                        row_resume, 4, total_e_formula,cell_formats.get("number")
-                    )
-                    worksheet.write_formula(
-                        row_resume, 5, total_f_formula,cell_formats.get("number")
-                    )
+                worksheet.write_formula(
+                    row_resume, 2, total_c_formula, cell_formats.get("number"), col_running_sums[0]
+                )
+                worksheet.write_formula(
+                    row_resume, 3, total_d_formula, cell_formats.get("number"), col_running_sums[1]
+                )
+                worksheet.write_formula(
+                    row_resume, 4, total_e_formula, cell_formats.get("number"), col_running_sums[2]
+                )
+                worksheet.write_formula(
+                    row_resume, 5, total_f_formula, cell_formats.get("number"), col_running_sums[3]
+                )
 
             start_col_formula = 6
-                
+
             column_bi_range = (
                 f"C{row_resume + 1}:{utility.xl_col_to_name(total_line - 1)}{row_resume + 1}"
             )
@@ -1593,12 +1586,15 @@ class WizardAccountingReportsBinauralInvoice(models.TransientModel):
                 f"=SUMPRODUCT(--({column_df_range}), --(MOD(COLUMN({column_df_range}), 2)=0))"
             )
 
+            imposed_value = sum(v for i, v in enumerate(effective_values) if i % 2 == 0)
+            debit_value = sum(v for i, v in enumerate(effective_values) if i % 2 == 1)
+
             worksheet.write_formula(
-                row_resume, start_col_formula, imposed_formula, cell_formats.get("number")
+                row_resume, start_col_formula, imposed_formula, cell_formats.get("number"), imposed_value
             )
             worksheet.write_formula(
-                row_resume, start_col_formula + 1, debit_formula, cell_formats.get("number")
-                    )
+                row_resume, start_col_formula + 1, debit_formula, cell_formats.get("number"), debit_value
+            )
 
     def _get_sale_book_field_groups(self):
         company = self.company_id


### PR DESCRIPTION
…/compras

Se corrige el resumen del libro de ventas y de compras, donde la columna "Total Neto" (Base Imponible y Debito/Credito Fiscal) siempre mostraba 0,00 aunque los datos de Facturas/Notas de Debito y Notas de Credito eran correctos.

xlsxwriter nunca evalua las formulas que escribe (SUMPRODUCT/SUM): solo guarda el texto de la formula junto a un valor cacheado que por defecto es 0. generate_sales_book tampoco llamaba a workbook.set_calc_mode('auto') como si lo hacia generate_purchases_book, por lo que ni se le pedia a la app que abre el archivo que recalculara. Ahora generate_book_resume calcula el valor real en Python (sumas por columna replicando la logica de la formula SUMPRODUCT) y lo pasa como valor cacheado a write_formula, para que se vea correcto sin depender de que el visor recalcule. Se agrega set_calc_mode('auto') a generate_sales_book y se unifican los dos bloques if/else duplicados para is_purchase/not is_purchase (el fix aplica igual a ambos libros). Se agrega test_generate_book_resume_writes_cached_total_neto_value, que verifica el valor cacheado leyendo el .xlsx generado sin depender de librerias externas no instaladas en el entorno (openpyxl).

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk.ticket/14599