### PR TITLE
[FIX] #79618?: l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.10",
+    "version": "19.0.1.0.11",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1090,6 +1090,29 @@ class AccountMove(models.Model):
                     ):
                         line.account_id = move.journal_id.default_account_id
 
+    def _is_subject_to_credit_limit(self):
+        """Whether this move must be validated against the partner's credit limit.
+
+        Only documents that *increase* the customer's receivable are checked.
+        Excluded on purpose:
+
+        - ``out_refund``: credit notes reduce the receivable.
+        - ``entry``: payments, advances and IVA/ISLR withholding vouchers, all of
+          which either reduce the receivable or do not affect it.
+        - ``in_*``: vendor documents do not touch the customer's receivable.
+
+        Blocking those made it impossible to collect from a customer that was
+        already over the limit, which is the opposite of what the limit is for.
+
+        The ``skip_credit_limit_check`` context key bypasses the check for flows
+        that carry an explicit authorization (e.g. a manually unlocked sale
+        order). It is opt-in and never set by default.
+        """
+        self.ensure_one()
+        if self.env.context.get("skip_credit_limit_check"):
+            return False
+        return self.move_type in ("out_invoice", "out_receipt")
+
     def action_post(self):
         if not self.env.context.get("move_action_post_alert"):
             for move in self:
@@ -1104,7 +1127,7 @@ class AccountMove(models.Model):
                         'context': {'default_move_id': move.id},
                     }
 
-        for invoice in self:
+        for invoice in self.filtered(lambda move: move._is_subject_to_credit_limit()):
             if (
                 invoice.company_id.account_use_credit_limit
                 and invoice.partner_id.use_partner_credit_limit

--- a/l10n_ve_accountant/tests/__init__.py
+++ b/l10n_ve_accountant/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_account_tax_foreign
 from . import test_coverage_gaps
 from . import test_product_template
 from . import test_action_cancel
+from . import test_credit_limit_scope

--- a/l10n_ve_accountant/tests/test_credit_limit_scope.py
+++ b/l10n_ve_accountant/tests/test_credit_limit_scope.py
@@ -1,0 +1,45 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("l10n_ve_accountant", "credit_limit", "-at_install", "post_install")
+class TestCreditLimitScope(TransactionCase):
+    """The credit limit must only gate documents that increase the receivable.
+
+    Before this scope existed the check ran over every move type, so credit
+    notes, payments and IVA/ISLR withholding vouchers were rejected for a
+    customer that was already over the limit -- blocking exactly the documents
+    used to bring the balance back down.
+    """
+
+    def _move(self, move_type):
+        return self.env["account.move"].new({"move_type": move_type})
+
+    def test_customer_invoice_is_checked(self):
+        self.assertTrue(self._move("out_invoice")._is_subject_to_credit_limit())
+
+    def test_customer_receipt_is_checked(self):
+        self.assertTrue(self._move("out_receipt")._is_subject_to_credit_limit())
+
+    def test_credit_note_is_not_checked(self):
+        """Credit notes reduce the receivable, so they must never be blocked."""
+        self.assertFalse(self._move("out_refund")._is_subject_to_credit_limit())
+
+    def test_journal_entry_is_not_checked(self):
+        """Payments, advances and withholding vouchers are posted as entries."""
+        self.assertFalse(self._move("entry")._is_subject_to_credit_limit())
+
+    def test_vendor_documents_are_not_checked(self):
+        for move_type in ("in_invoice", "in_refund", "in_receipt"):
+            with self.subTest(move_type=move_type):
+                self.assertFalse(self._move(move_type)._is_subject_to_credit_limit())
+
+    def test_context_key_waives_the_check(self):
+        """skip_credit_limit_check lets an authorized flow post a blocked invoice."""
+        move = self._move("out_invoice")
+        self.assertTrue(move._is_subject_to_credit_limit())
+        waived = move.with_context(skip_credit_limit_check=True)
+        self.assertFalse(waived._is_subject_to_credit_limit())
+
+    def test_context_key_is_not_set_by_default(self):
+        """The waiver must be opt-in, never inherited from an ambient context."""
+        self.assertFalse(self.env.context.get("skip_credit_limit_check"))


### PR DESCRIPTION
  Problema: el chequeo de limite de credito en action_post recorria todos los
  movimientos sin filtrar por move_type, por lo que se aplicaba a cualquier
  documento del cliente y no solo a los que aumentan la cuenta por cobrar.
  Con un cliente sobregirado quedaban bloqueadas las notas de credito
  (out_refund), los pagos y anticipos, y los comprobantes de retencion de
  IVA e ISLR, que se postean como asientos (entry). Es decir, se bloqueaban
  justamente los documentos que reducen la deuda del cliente o que sirven
  para cobrarle, que es lo contrario de lo que un limite de credito busca.

  Reproducido en instancia local con datos reales: cliente con deuda de
  3.146.058,84 Bs contra un cupo de 1.000 USD. Se instrumento el chequeo para
  capturar el move_type de cada documento rechazado y se obtuvo out_refund
  para la nota de credito y entry para el registro de pago y para la retencion
  de IVA. Ninguno de los tres era out_invoice. En esos casos el mensaje de
  error indicaba "mas 0.0 en factura", porque el documento no aportaba monto:
  la deuda previa por si sola ya superaba el cupo.

  Solucion: se agrega _is_subject_to_credit_limit(), que decide si un
  movimiento esta sujeto al chequeo, y action_post lo usa para filtrar antes
  de evaluar. Solo quedan sujetos out_invoice y out_receipt. Quedan excluidos
  out_refund, entry y los documentos de proveedor (in_*), que no afectan la
  cuenta por cobrar del cliente.

  Se agrega ademas la clave de contexto skip_credit_limit_check, opt-in y
  nunca activada por defecto, para que un flujo con autorizacion explicita
  pueda saltar el chequeo sin escribir en la ficha del cliente. La usa
  lagiralda_account (repo giralda) para honrar una orden de venta liberada
  con Desbloqueo Manual y la autorizacion por factura.

  Impacto: las facturas de cliente se siguen bloqueando exactamente igual;
  se verifico apagando la autorizacion y comprobando que el rechazo persiste.
  El cambio solo puede permitir posteos que antes fallaban, nunca bloquear
  posteos que antes pasaban.

  Tests: 7 nuevos en tests/test_credit_limit_scope.py, que cubren el alcance
  por tipo de documento y el comportamiento de la clave de contexto. La suite
  del modulo queda en verde. Los 5 errores de TestRealPortion son
  preexistentes: se verifico corriendo la clase sin este cambio, donde fallan
  8 en lugar de 5, o sea que este cambio corrige 3 de ellos.

References:
- Ticket:
- Tarea: https://binaural.odoo.com/odoo/action-341/79618?debug=1
- PR:
- Otros: