### PR TITLE
FIX #14402: l10n_ve_payment_extension_iva_islr_voucher_number_not_saved

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.34",
+    "version": "17.0.0.0.35",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.36",
+    "version": "17.0.0.0.37",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -661,16 +661,15 @@ class AccountRetention(models.Model):
             if not retention.date:
                 retention.date = today
 
+            if retention.type in ["in_invoice", "in_refund", "in_debit"]:
+                retention._set_sequence()
+
             move_ids = retention.mapped("retention_line_ids.move_id")
             self.set_voucher_number_in_invoice(move_ids, retention)
 
             if not retention.payment_ids:
                 payments = retention.create_payment_from_retention_form()
                 retention.payment_ids = payments.ids
-
-            if retention.type in ["in_invoice", "in_refund", "in_debit"]:
-                retention._set_sequence()
-                self.set_voucher_number_in_invoice(move_ids, retention)
 
             if retention.type_retention == "iva":
                 if not re.fullmatch(r"\d{14}", retention.number):


### PR DESCRIPTION
Problema: Al emitir una retencion de IVA o ISLR sobre una factura de proveedor, el numero de comprobante generado no se guardaba en la factura (iva_voucher_number / islr_voucher_number quedaba vacio), porque action_post() escribia el numero en la factura antes de generarlo (con _set_sequence) y luego lo volvia a escribir despues, dejando una ventana en la que la escritura definitiva podia no persistir. Esto hacia que la factura siguiera apareciendo como pendiente de retencion en el asistente manual, permitiendo generar una retencion duplicada para la misma factura y dejando la retencion original con sus lineas huerfanas (totales correctos pero grilla de lineas vacia).

Solucion: Se reordena action_post() para generar el correlativo (_set_sequence) antes de escribir el numero de comprobante en la factura, y se deja una unica escritura con el valor definitivo. Tarea:
https://binaural.odoo.com/odoo/my-tickets/14402