### PR TITLE
[FIX] l10n_ve_pos, l10n_ve_pos_igtf: fijar monto alterno POS

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "17.0.0.2.0",
+    "version": "17.0.0.2.1",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/models/pos_session.py
+++ b/l10n_ve_pos/models/pos_session.py
@@ -17,6 +17,32 @@ class PosSession(models.Model):
         string="Foreign Currency",
     )
 
+    def _lock_foreign_amount(self, line, foreign_amount):
+        """
+        Permanently pin the alternate-currency (foreign) debit/credit of a POS
+        payment journal line to `foreign_amount`.
+
+        `not_foreign_recalculate` alone only protects this value while this exact
+        line record survives untouched. If the line is ever recreated (e.g. a
+        draft/repost cycle done on the move, or the move being deleted and
+        regenerated), the flag is lost and account_move_line._compute_foreign_debit_credit
+        falls back to `debit * foreign_inverse_rate`, using whatever rate is on the
+        move at that later time instead of the rate(s) of the original POS
+        payment(s) this line represents, producing a wrong "monto alterno".
+
+        Also setting `foreign_debit_adjustment`/`foreign_credit_adjustment` makes the
+        correct value durable, since the compute method honors those fields first,
+        regardless of `not_foreign_recalculate`.
+        """
+        line.not_foreign_recalculate = True
+        foreign_amount = abs(foreign_amount)
+        if line.credit > 0:
+            line.foreign_credit = foreign_amount
+            line.foreign_credit_adjustment = foreign_amount
+        if line.debit > 0:
+            line.foreign_debit = foreign_amount
+            line.foreign_debit_adjustment = foreign_amount
+
     # @override
     def _loader_params_res_company(self):
         return {
@@ -334,21 +360,11 @@ class PosSession(models.Model):
 
         for payment_method, amounts in combine_invoice_receivables.items():
             line = combine_invoice_receivable_lines[payment_method]
-            if line.credit > 0:
-                line.not_foreign_recalculate = True
-                line.foreign_credit = abs(amounts["foreign_amount"])
-            if line.debit > 0:
-                line.not_foreign_recalculate = True
-                line.foreign_debit = abs(amounts["foreign_amount"])
+            self._lock_foreign_amount(line, amounts["foreign_amount"])
 
         for payment in split_invoice_receivable_lines.keys():
             line = split_invoice_receivable_lines[payment]
-            if line.credit > 0:
-                line.not_foreign_recalculate = True
-                line.foreign_credit = abs(payment["foreign_amount"])
-            if line.debit > 0:
-                line.not_foreign_recalculate = True
-                line.foreign_debit = abs(payment["foreign_amount"])
+            self._lock_foreign_amount(line, payment["foreign_amount"])
 
         return res
 
@@ -363,22 +379,12 @@ class PosSession(models.Model):
         for payment_method, amounts in combine_receivables_bank.items():
             lines = payment_method_to_receivable_lines[payment_method]
             for line in lines:
-                if line.credit > 0:
-                    line.not_foreign_recalculate = True
-                    line.foreign_credit = abs(amounts["foreign_amount"])
-                if line.debit > 0:
-                    line.not_foreign_recalculate = True
-                    line.foreign_debit = abs(amounts["foreign_amount"])
+                self._lock_foreign_amount(line, amounts["foreign_amount"])
 
         for payment in payment_to_receivable_lines.keys():
             lines = payment_to_receivable_lines[payment]
             for line in lines:
-                if line.credit > 0:
-                    line.not_foreign_recalculate = True
-                    line.foreign_credit = abs(payment["foreign_amount"])
-                if line.debit > 0:
-                    line.not_foreign_recalculate = True
-                    line.foreign_debit = abs(payment["foreign_amount"])
+                self._lock_foreign_amount(line, payment["foreign_amount"])
         return res
 
     def _create_cash_statement_lines_and_cash_move_lines(self, data):
@@ -422,8 +428,11 @@ class PosSession(models.Model):
             ):
                 line.not_foreign_recalculate = True
                 line.foreign_credit = abs(foreign_amount)
+                line.foreign_credit_adjustment = abs(foreign_amount)
                 if other_line.foreign_debit != line.foreign_credit:
+                    other_line.not_foreign_recalculate = True
                     other_line.foreign_debit = abs(line.foreign_credit)
+                    other_line.foreign_debit_adjustment = abs(line.foreign_credit)
             if (
                 abs(line.debit) > 0
                 and float_compare(
@@ -435,8 +444,11 @@ class PosSession(models.Model):
             ):
                 line.not_foreign_recalculate = True
                 line.foreign_debit = abs(foreign_amount)
+                line.foreign_debit_adjustment = abs(foreign_amount)
                 if other_line.foreign_credit != line.foreign_debit:
+                    other_line.not_foreign_recalculate = True
                     other_line.foreign_credit = abs(line.foreign_debit)
+                    other_line.foreign_credit_adjustment = abs(line.foreign_debit)
 
     def _validate_cross_move(self):
         """This function validate cross move, the proposal of this function is the transitory account be zero"""
@@ -582,14 +594,9 @@ class PosSession(models.Model):
                 lambda line: line.account_id == pos_receivable_account
             )
 
-        for line in account_payment.move_id.line_ids:
-            if line.credit > 0 and amounts.get("foreign_amount", False):
-                line.not_foreign_recalculate = True
-                line.foreign_credit = abs(amounts["foreign_amount"])
-
-            if line.debit > 0 and amounts.get("foreign_amount", False):
-                line.not_foreign_recalculate = True
-                line.foreign_debit = abs(amounts["foreign_amount"])
+        if amounts.get("foreign_amount", False):
+            for line in account_payment.move_id.line_ids:
+                self._lock_foreign_amount(line, amounts["foreign_amount"])
         if account_payment.pos_payment_method_id.split_transactions:
             self._create_cross_move_payment(res)
         return res
@@ -630,13 +637,7 @@ class PosSession(models.Model):
         )
 
         for line in account_payment.move_id.line_ids:
-            if line.credit > 0:
-                line.not_foreign_recalculate = True
-                line.foreign_credit = abs(payment.foreign_amount)
-
-            if line.debit > 0:
-                line.not_foreign_recalculate = True
-                line.foreign_debit = abs(payment.foreign_amount)
+            self._lock_foreign_amount(line, payment.foreign_amount)
 
         if float_compare(amounts['amount'], 0, precision_rounding=self.currency_id.rounding) < 0:
             accounting_partner = self.env["res.partner"]._find_accounting_partner(payment.partner_id)
@@ -803,6 +804,7 @@ class PosSession(models.Model):
                             "foreign_credit": 0.0,
                             "debit": total_amount,
                             "foreign_debit": total_foreign_amount,
+                            "foreign_debit_adjustment": total_foreign_amount,
                             "not_foreign_recalculate": True,
                             "foreign_rate": foreign_rate,
                             "currency_id": currency,
@@ -821,6 +823,7 @@ class PosSession(models.Model):
                             "foreign_debit": 0.0,
                             "credit": total_amount,
                             "foreign_credit": total_foreign_amount,
+                            "foreign_credit_adjustment": total_foreign_amount,
                             "not_foreign_recalculate": True,
                             "foreign_rate": foreign_rate,
                             "currency_id": currency,
@@ -879,6 +882,7 @@ class PosSession(models.Model):
                             "foreign_credit": 0.0,
                             "debit": total_amount,
                             "foreign_debit": total_foreign_amount,
+                            "foreign_debit_adjustment": total_foreign_amount,
                             "not_foreign_recalculate": True,
                             "foreign_rate": foreign_rate,
                             "currency_id": currency,
@@ -897,6 +901,7 @@ class PosSession(models.Model):
                             "foreign_debit": 0.0,
                             "credit": total_amount,
                             "foreign_credit": total_foreign_amount,
+                            "foreign_credit_adjustment": total_foreign_amount,
                             "not_foreign_recalculate": True,
                             "foreign_rate": foreign_rate,
                             "currency_id": currency,
@@ -954,6 +959,7 @@ class PosSession(models.Model):
                             "foreign_credit": 0.0,
                             "debit": total_amount,
                             "foreign_debit": total_foreign_amount,
+                            "foreign_debit_adjustment": total_foreign_amount,
                             "not_foreign_recalculate": True,
                             "foreign_rate": foreign_rate,
                             "currency_id": currency,
@@ -972,6 +978,7 @@ class PosSession(models.Model):
                             "foreign_debit": 0.0,
                             "credit": total_amount,
                             "foreign_credit": total_foreign_amount,
+                            "foreign_credit_adjustment": total_foreign_amount,
                             "not_foreign_recalculate": True,
                             "foreign_rate": foreign_rate,
                             "currency_id": currency,
@@ -1031,6 +1038,7 @@ class PosSession(models.Model):
                             "foreign_credit": 0.0,
                             "debit": total_amount,
                             "foreign_debit": total_foreign_amount,
+                            "foreign_debit_adjustment": total_foreign_amount,
                             "not_foreign_recalculate": True,
                             "foreign_rate": foreign_rate,
                             "currency_id": currency,
@@ -1049,6 +1057,7 @@ class PosSession(models.Model):
                             "foreign_debit": 0.0,
                             "credit": total_amount,
                             "foreign_credit": total_foreign_amount,
+                            "foreign_credit_adjustment": total_foreign_amount,
                             "not_foreign_recalculate": True,
                             "foreign_rate": foreign_rate,
                             "currency_id": currency,

--- a/l10n_ve_pos/tests/__init__.py
+++ b/l10n_ve_pos/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_lock_foreign_amount

--- a/l10n_ve_pos/tests/test_lock_foreign_amount.py
+++ b/l10n_ve_pos/tests/test_lock_foreign_amount.py
@@ -1,0 +1,172 @@
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "l10n_ve_pos", "foreign_amount")
+class TestLockForeignAmount(TransactionCase):
+    """
+    Regression tests for pos.session._lock_foreign_amount (Ticket #13055).
+
+    Context: the "monto alterno" (foreign_debit/foreign_credit) of a POS
+    combined/split payment line is a computed field. pos_session.py fixes its
+    value once, at session-close time, by writing it directly and setting
+    not_foreign_recalculate=True. That flag only protects the value while the
+    exact same account.move.line record survives untouched: if the line is
+    ever recreated (e.g. an asiento reset to draft and reposted to "fix"
+    something unrelated), the new line starts with not_foreign_recalculate
+    False, and account.move.line._compute_foreign_debit_credit falls back to
+    `debit * foreign_inverse_rate` using whatever rate the move has *at that
+    later moment* -- not the rate(s) of the original POS payment(s) -- which
+    is exactly how a correct amount (e.g. $683,19) turned into a wildly wrong
+    one (e.g. $13.640.153,61) in the reported bug.
+
+    The fix also pins foreign_debit_adjustment/foreign_credit_adjustment,
+    which _compute_foreign_debit_credit honors unconditionally, regardless of
+    not_foreign_recalculate. These tests exercise that mechanism directly,
+    without needing to spin up a full POS session.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.currency_usd = cls.env.ref("base.USD")
+        cls.currency_vef = cls.env.ref("base.VEF")
+        cls.company = cls.env.ref("base.main_company")
+        cls.company.write(
+            {
+                "currency_id": cls.currency_usd.id,
+                "currency_foreign_id": cls.currency_vef.id,
+            }
+        )
+
+        cls.account_a = cls.env["account.account"].create(
+            {
+                "name": "Test Receivable A",
+                "code": "TST001",
+                "account_type": "asset_current",
+            }
+        )
+        cls.account_b = cls.env["account.account"].create(
+            {
+                "name": "Test Receivable B",
+                "code": "TST002",
+                "account_type": "asset_current",
+            }
+        )
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "general"), ("company_id", "=", cls.company.id)], limit=1
+        ) or cls.env["account.journal"].create(
+            {
+                "name": "Test Misc Ops",
+                "type": "general",
+                "code": "TMISC",
+                "company_id": cls.company.id,
+            }
+        )
+
+        # Rate deliberately different from the historical/pinned amount used in
+        # each test, so a value coming from the buggy generic recompute
+        # (debit * foreign_inverse_rate) is unmistakably distinct from the
+        # correct, pinned "monto alterno".
+        cls.foreign_rate = 50.0
+        cls.foreign_inverse_rate = 0.02  # 1 / 50
+
+    def _create_move(self, debit_amount=1000.0):
+        move = self.env["account.move"].create(
+            {
+                "journal_id": self.journal.id,
+                "manually_set_rate": True,
+                "foreign_rate": self.foreign_rate,
+                "foreign_inverse_rate": self.foreign_inverse_rate,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "name": "Debit line",
+                            "account_id": self.account_a.id,
+                            "currency_id": self.company.currency_id.id,
+                            "debit": debit_amount,
+                            "credit": 0.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "name": "Credit line",
+                            "account_id": self.account_b.id,
+                            "currency_id": self.company.currency_id.id,
+                            "debit": 0.0,
+                            "credit": debit_amount,
+                        }
+                    ),
+                ],
+            }
+        )
+        debit_line = move.line_ids.filtered(lambda l: l.debit > 0)
+        credit_line = move.line_ids.filtered(lambda l: l.credit > 0)
+        return move, debit_line, credit_line
+
+    def test_lock_foreign_amount_pins_debit_and_credit(self):
+        """_lock_foreign_amount must set the raw amount, the flag and the
+        durable adjustment field on both sides of the entry."""
+        _move, debit_line, credit_line = self._create_move()
+        pinned_amount = 42.5
+
+        self.env["pos.session"]._lock_foreign_amount(debit_line, pinned_amount)
+        self.env["pos.session"]._lock_foreign_amount(credit_line, pinned_amount)
+
+        self.assertTrue(debit_line.not_foreign_recalculate)
+        self.assertAlmostEqual(debit_line.foreign_debit, pinned_amount)
+        self.assertAlmostEqual(debit_line.foreign_debit_adjustment, pinned_amount)
+        self.assertAlmostEqual(debit_line.foreign_credit, 0.0)
+
+        self.assertTrue(credit_line.not_foreign_recalculate)
+        self.assertAlmostEqual(credit_line.foreign_credit, pinned_amount)
+        self.assertAlmostEqual(credit_line.foreign_credit_adjustment, pinned_amount)
+
+    def test_pinned_amount_survives_flag_loss(self):
+        """
+        This is the actual bug fix: if not_foreign_recalculate is ever lost on
+        an already-pinned line (e.g. because the line was recreated by a
+        generic repost/recompute flow), the amount must stay correct instead
+        of silently falling back to debit * foreign_inverse_rate.
+        """
+        _move, debit_line, _credit_line = self._create_move()
+        pinned_amount = 42.5
+
+        self.env["pos.session"]._lock_foreign_amount(debit_line, pinned_amount)
+        self.assertAlmostEqual(debit_line.foreign_debit, pinned_amount)
+
+        # Simulate the flag being lost (e.g. a fresh line created without
+        # going through pos_session.py) and force a recompute, as would
+        # happen when any of the real @api.depends fields changes.
+        debit_line.not_foreign_recalculate = False
+        debit_line._compute_foreign_debit_credit()
+
+        self.assertAlmostEqual(
+            debit_line.foreign_debit,
+            pinned_amount,
+            msg="foreign_debit_adjustment should have kept the historical "
+            "amount even though not_foreign_recalculate was reset.",
+        )
+
+    def test_without_the_fix_the_amount_would_be_corrupted(self):
+        """
+        Documents the bug being fixed: pinning only foreign_debit +
+        not_foreign_recalculate (the old behaviour, without the adjustment
+        field) does NOT survive the flag being lost -- the generic recompute
+        overwrites it with debit * foreign_inverse_rate, reproducing the
+        reported regression (a correct amount replaced by an unrelated one).
+        """
+        _move, debit_line, _credit_line = self._create_move(debit_amount=1000.0)
+        pinned_amount = 42.5
+
+        # Old (buggy) protection: raw value + flag, no adjustment field.
+        debit_line.not_foreign_recalculate = True
+        debit_line.foreign_debit = pinned_amount
+        self.assertAlmostEqual(debit_line.foreign_debit, pinned_amount)
+
+        debit_line.not_foreign_recalculate = False
+        debit_line._compute_foreign_debit_credit()
+
+        expected_wrong_amount = 1000.0 * self.foreign_inverse_rate  # 20.0
+        self.assertNotAlmostEqual(debit_line.foreign_debit, pinned_amount)
+        self.assertAlmostEqual(debit_line.foreign_debit, expected_wrong_amount)

--- a/l10n_ve_pos_igtf/__manifest__.py
+++ b/l10n_ve_pos_igtf/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "depends": [
         "base",
         "l10n_ve_pos",

--- a/l10n_ve_pos_igtf/models/pos_payment.py
+++ b/l10n_ve_pos_igtf/models/pos_payment.py
@@ -116,12 +116,15 @@ class PosPayment(models.Model):
                 amounts["amount_converted"],
             )
 
+            pos_session_model = self.env["pos.session"]
+
             if add_credit_line_vals:
                 receivable_line = self.env["account.move.line"].with_context(check_move_validity=False).create(
                     [add_credit_line_vals]
                 )
-                receivable_line.not_foreign_recalculate = True
-                receivable_line.foreign_credit = abs(payment.foreign_amount - payment.foreign_igtf_amount)
+                pos_session_model._lock_foreign_amount(
+                    receivable_line, payment.foreign_amount - payment.foreign_igtf_amount
+                )
 
             other_lines = self.env["account.move.line"].with_context(check_move_validity=False).create(
                 [credit_line_vals, debit_line_vals]
@@ -129,16 +132,12 @@ class PosPayment(models.Model):
             igtf_or_receivable_line = other_lines[0]
             debit_line = other_lines[1]
 
-            # Setear Bs correctos en la línea de débito (CUENTA POR COBRAR POS)
-            debit_line.not_foreign_recalculate = True
-            debit_line.foreign_debit = abs(payment.foreign_amount)
+            pos_session_model._lock_foreign_amount(debit_line, payment.foreign_amount)
 
-            # Setear Bs correctos en crédito IGTF o cuenta por cobrar (pago sin IGTF split)
-            igtf_or_receivable_line.not_foreign_recalculate = True
-            if payment.include_igtf:
-                igtf_or_receivable_line.foreign_credit = abs(payment.foreign_igtf_amount)
-            else:
-                igtf_or_receivable_line.foreign_credit = abs(payment.foreign_amount)
+            pos_session_model._lock_foreign_amount(
+                igtf_or_receivable_line,
+                payment.foreign_igtf_amount if payment.include_igtf else payment.foreign_amount,
+            )
 
             payment_move._post()
         return result


### PR DESCRIPTION
Hace durable la proteccion del monto alterno (foreign_debit/foreign_credit) de las lineas contables generadas al cerrar sesiones de POS (pagos combinados, split e IGTF).

El monto alterno correcto se fijaba una sola vez al cerrar la sesion, protegido solo por el flag transitorio not_foreign_recalculate. Si la linea contable se recreaba (p. ej. al llevar el asiento a borrador y volver a postearlo para "corregir" algo), la linea nueva nacia sin la proteccion y _compute_foreign_debit_credit recalculaba con debit * foreign_inverse_rate usando la tasa vigente en ese momento, no la tasa historica de cada pago original -produciendo montos alternos sin relacion con la transaccion (caso real: un pago combinado paso de tener un monto alterno correcto de $683,19 a $13.640.153,61).

_calculate_from_adjustment tiene prioridad sobre ese fallback sin importar el estado del flag, asi que ahora tambien se fijan foreign_debit_adjustment/foreign_credit_adjustment con el mismo valor historico, dejando la proteccion vigente aunque la linea se recree.

Se agrega test unitario (l10n_ve_pos/tests/test_lock_foreign_amount.py) que reproduce el mecanismo del bug (perdida del flag) y confirma que el monto se mantiene correcto con el fix. Validado corriendo

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/13055
- Tarea:
- PR:
- Otros: