### PR TITLE
[FIX] l10n_ve_payment_extension: referencia estable de UT

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.24",
+    "version": "19.0.2.0.25",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/data/fees_retention_data.xml
+++ b/l10n_ve_payment_extension/data/fees_retention_data.xml
@@ -7,7 +7,7 @@
             <field name="percentage">3</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <field name="tax_unit_ids">1</field>
+            <field name="tax_unit_ids" ref="l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension"/>
         </record>
 
         <record id="fees_retention_data_percentage_one_l10n_ve_payment_extension" model="fees.retention">
@@ -16,7 +16,7 @@
             <field name="percentage">5</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <field name="tax_unit_ids">1</field>
+            <field name="tax_unit_ids" ref="l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension"/>
         </record>
 
         <record id="fees_retention_data_percentage_two_l10n_ve_payment_extension" model="fees.retention">
@@ -25,7 +25,7 @@
             <field name="percentage">34</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <field name="tax_unit_ids">1</field>
+            <field name="tax_unit_ids" ref="l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension"/>
         </record>
 
         <record id="fees_retention_data_substrat_second_l10n_ve_payment_extension" model="fees.retention">
@@ -34,7 +34,7 @@
             <field name="percentage">1</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <field name="tax_unit_ids">1</field>
+            <field name="tax_unit_ids" ref="l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension"/>
         </record>
 
         <record id="fees_retention_data_l10n_ve_percentage_three_payment_extension" model="fees.retention">
@@ -43,7 +43,7 @@
             <field name="percentage">2</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <field name="tax_unit_ids">1</field>
+            <field name="tax_unit_ids" ref="l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension"/>
         </record>
 
         <record id="fees_retention_data_percentage_four_l10n_ve_payment_extension" model="fees.retention">
@@ -52,7 +52,7 @@
             <field name="percentage">3</field>
             <field name="status">True</field>
             <field name="accumulated_rate">False</field>
-            <field name="tax_unit_ids">1</field>
+            <field name="tax_unit_ids" ref="l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension"/>
         </record>
 
         <record id="fees_retention_data_percentage_five_l10n_ve_payment_extension" model="fees.retention">
@@ -61,7 +61,7 @@
             <field name="percentage">0</field>
             <field name="status">True</field>
             <field name="accumulated_rate">True</field>
-            <field name="tax_unit_ids">1</field>
+            <field name="tax_unit_ids" ref="l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension"/>
             <field name="accumulated_rate_ids" eval="[
                 (0,0,{
                     'name': 0.15,

--- a/l10n_ve_payment_extension/tests/test_data_files.py
+++ b/l10n_ve_payment_extension/tests/test_data_files.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+from xml.etree import ElementTree
+
+from odoo.modules.module import get_module_path
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 import logging
@@ -32,3 +36,35 @@ class TestDataFiles(TransactionCase):
         wt = self.env.ref("l10n_ve_payment_extension.account_withholding_type_100", raise_if_not_found=False)
         self.assertTrue(wt)
         _logger.info("========= test_05 passed =========")
+
+    def test_06_default_fees_use_canonical_tax_unit(self):
+        canonical_xmlid = (
+            "l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension"
+        )
+        data_path = Path(
+            get_module_path("l10n_ve_payment_extension"),
+            "data",
+            "fees_retention_data.xml",
+        )
+        # Source-controlled module data, not user-supplied XML.
+        tax_unit_fields = ElementTree.parse(data_path).findall(
+            ".//field[@name='tax_unit_ids']"
+        )
+        self.assertEqual(len(tax_unit_fields), 7)
+        self.assertTrue(
+            all(field.get("ref") == canonical_xmlid for field in tax_unit_fields)
+        )
+
+        tax_unit = self.env.ref(canonical_xmlid)
+        fee_xmlids = (
+            "fees_retention_data_substrat_l10n_ve_payment_extension",
+            "fees_retention_data_percentage_one_l10n_ve_payment_extension",
+            "fees_retention_data_percentage_two_l10n_ve_payment_extension",
+            "fees_retention_data_substrat_second_l10n_ve_payment_extension",
+            "fees_retention_data_l10n_ve_percentage_three_payment_extension",
+            "fees_retention_data_percentage_four_l10n_ve_payment_extension",
+            "fees_retention_data_percentage_five_l10n_ve_payment_extension",
+        )
+        for xmlid in fee_xmlids:
+            fee = self.env.ref(f"l10n_ve_payment_extension.{xmlid}")
+            self.assertEqual(fee.tax_unit_ids, tax_unit)


### PR DESCRIPTION
## Problema

Las siete tarifas precargadas asignan `tax_unit_ids` usando el ID numérico `1`. Los IDs de base de datos no son estables y pueden enlazar las tarifas con una Unidad Tributaria ajena en una instalación nueva.

## Cambio

- Reemplaza el ID numérico por el XML ID canónico `l10n_ve_accountant.tax_unit_data_l10n_ve_payment_extension`, provisto por una dependencia ya declarada.
- Incrementa la versión del módulo a `19.0.2.0.25`.
- Añade una prueba que inspecciona el XML fuente y las relaciones cargadas para las siete tarifas.

## Alcance de actualización

`fees_retention_data.xml` usa `noupdate=1`, por lo que esta corrección protege instalaciones nuevas. No reasigna automáticamente tarifas de bases existentes porque no puede distinguir de forma segura una relación errónea de una configuración fiscal intencional. Esas bases deben auditarse antes de cualquier remapeo.

## Verificación

- Commit exacto: `f96a926413f1c90c2d4af712fe286470efb64206`.
- La prueba de regresión distingue el XML anterior del corregido: base falla, candidato pasa.
- `git diff --check`, parseo de manifiesto/XML y compilación Python: correctos.
- La instalación completa no pudo ejecutarse en nuestro entorno Odoo Community porque la rama upstream `19.0` requiere `account_reports`, que no está disponible allí. Se mantiene el PR como draft para revisión y CI upstream.
