### PR TITLE
FIX #13998: l10n_ve_sale tasa alterna al duplicar

### DIFF
--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -45,6 +45,7 @@ class SaleOrder(models.Model):
         store=True,
         readonly=False,
         tracking=True,
+        copy=False,
     )
     foreign_inverse_rate = fields.Float(
         help="Rate that will be used as factor to multiply of the foreign currency for this move.",
@@ -52,10 +53,16 @@ class SaleOrder(models.Model):
         compute="_compute_rate",
         store=True,
         readonly=False,
+        copy=False,
     )
 
     last_foreign_rate = fields.Float(copy=False)
-    manually_set_rate = fields.Boolean(default=False)
+    # copy=False: duplicating an order must always pick up the alterno rate
+    # in effect today (ticket #13998), not carry over a manually-set rate --
+    # manually_set_rate is not a user-facing "I typed this rate by hand"
+    # choice (the field isn't exposed on the client-facing view), so there is
+    # no user intent to preserve across a duplicate.
+    manually_set_rate = fields.Boolean(default=False, copy=False)
 
     total_taxed = fields.Many2one(
         "account.tax",
@@ -252,8 +259,6 @@ class SaleOrder(models.Model):
             else:
                 sale.foreign_rate = 0.0
                 sale.foreign_inverse_rate = 0.0
-
-    
 
     @api.model
     def _has_significant_invoiceable_quantity(self, line):

--- a/l10n_ve_sale/tests/test_sale_order.py
+++ b/l10n_ve_sale/tests/test_sale_order.py
@@ -3,6 +3,7 @@ from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import UserError
 from odoo.tests import tagged
+from datetime import timedelta
 import logging
 import random
 
@@ -347,6 +348,100 @@ class TestSaleOrderInvoice(TransactionCase):
         finally:
             dp.digits = original
             self.env.registry.clear_cache()
+
+    def test_05_duplicate_order_updates_foreign_rate(self):
+        """Duplicating an old sale order must refresh the alterno rate to the
+        one in effect today, instead of keeping the original order's rate
+        frozen (ticket #13998)."""
+        # Explicit, not relied-upon-by-default: this is the setting under
+        # which the bug reproduces (INDUVAR runs with it False).
+        self.company.update_sale_order_rate_using_date_order = False
+
+        old_date = fields.Datetime.now() - timedelta(days=60)
+        rate_model = self.env["res.currency.rate"]
+        rate_model.search([
+            ("currency_id", "=", self.currency_usd.id),
+            ("company_id", "=", self.company.id),
+            ("name", "in", [old_date.date(), fields.Date.today()]),
+        ]).unlink()
+        rate_model.create({
+            "currency_id": self.currency_usd.id,
+            "company_id": self.company.id,
+            "name": old_date.date(),
+            "rate": 1 / 100.0,
+        })
+        rate_model.create({
+            "currency_id": self.currency_usd.id,
+            "company_id": self.company.id,
+            "name": fields.Date.today(),
+            "rate": 1 / 200.0,
+        })
+
+        order = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+            "date_order": old_date,
+        })
+        self.assertAlmostEqual(
+            order.foreign_rate, 100.0, places=4,
+            msg="test premise: the original order must pick up the old rate",
+        )
+
+        duplicate = order.copy()
+
+        self.assertAlmostEqual(
+            duplicate.foreign_rate, 200.0, places=4,
+            msg="duplicating an old order must refresh the alterno rate to "
+                "today's, not keep it frozen at the original order's rate",
+        )
+        _logger.info("test_05_duplicate_order_updates_foreign_rate --- successfully")
+
+    def test_06_duplicate_manual_rate_order_also_updates_rate(self):
+        """manually_set_rate isn't a user-facing "I typed this by hand"
+        choice (it's not exposed on the client view) -- it must not survive
+        a duplicate either. Duplicating an order that had it set must clear
+        the flag and refresh the rate to today's, same as any other order."""
+        self.company.update_sale_order_rate_using_date_order = False
+
+        old_date = fields.Datetime.now() - timedelta(days=60)
+        rate_model = self.env["res.currency.rate"]
+        rate_model.search([
+            ("currency_id", "=", self.currency_usd.id),
+            ("company_id", "=", self.company.id),
+            ("name", "in", [old_date.date(), fields.Date.today()]),
+        ]).unlink()
+        rate_model.create({
+            "currency_id": self.currency_usd.id,
+            "company_id": self.company.id,
+            "name": old_date.date(),
+            "rate": 1 / 100.0,
+        })
+        rate_model.create({
+            "currency_id": self.currency_usd.id,
+            "company_id": self.company.id,
+            "name": fields.Date.today(),
+            "rate": 1 / 200.0,
+        })
+
+        order = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+            "date_order": old_date,
+            "manually_set_rate": True,
+            "foreign_rate": 999.99,
+            "foreign_inverse_rate": 1 / 999.99,
+        })
+
+        duplicate = order.copy()
+
+        self.assertFalse(
+            duplicate.manually_set_rate,
+            "manually_set_rate must not survive a duplicate",
+        )
+        self.assertAlmostEqual(
+            duplicate.foreign_rate, 200.0, places=4,
+            msg="a duplicate must get today's alterno rate even if the "
+                "original had manually_set_rate=True",
+        )
+        _logger.info("test_06_duplicate_manual_rate_order_also_updates_rate --- successfully")
 
 
 @tagged("post_install", "-at_install", "l10n_ve_sale")


### PR DESCRIPTION
## Problema
Al duplicar una orden de venta antigua, la tasa alterna (`foreign_rate`) quedaba congelada con el valor de la orden original en vez de actualizarse a la tasa vigente del día de la duplicación. `date_order` sí se reseteaba a hoy en el `copy()`, pero `foreign_rate`/`foreign_inverse_rate` no tenían `copy=False`, así que el ORM los arrastraba tal cual y `_compute_rate` nunca los recalculaba (su guard descarta el recálculo cuando la tasa ya es distinta de cero y `update_sale_order_rate_using_date_order` está en `False`, como está configurado INDUVAR).

## Solución
- `foreign_rate` y `foreign_inverse_rate` pasan a `copy=False` para que el ORM los omita del `create()` al duplicar y dispare su recálculo real.
- `manually_set_rate` también pasa a `copy=False`: no es un campo visible para el cliente ni una tasa tipeada a mano por el usuario, así que tampoco debe sobrevivir la duplicación ni bloquear el recálculo vía el guard de `_compute_rate`.

## Tests
- `test_05_duplicate_order_updates_foreign_rate`: duplicar una orden vieja recalcula a la tasa vigente hoy.
- `test_06_duplicate_manual_rate_order_also_updates_rate`: una orden con `manually_set_rate=True` también se recalcula al duplicar, sin excepción.

Corrido contra bd fresca (`-i l10n_ve_sale`): 20/20 tests en verde. Precommit (`pylint_odoo`) en verde.

## Fuera de alcance (reportado, no tocado en este PR)
`_compute_rate` calcula contra `self.env.company` en vez de `sale.company_id` — riesgo preexistente en multi-compañía, ahora alcanzable desde `copy()`. Requiere decisión de líder técnico, se deja documentado como hallazgo separado.

link: https://binaural.odoo.com/odoo/action-390/13998
ticket de triaje-atc [x]