### PR TITLE
Ajustes montos de pagos indexads/no indexados e IGTF

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.10",
+    "version": "19.0.1.0.11",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -1421,6 +1421,16 @@ msgstr ""
 #. module: l10n_ve_accountant
 #. odoo-python
 #: code:addons/l10n_ve_accountant/models/account_move_line.py:0
+msgid ""
+"The journal %(journal)s only accepts entries in %(journal_currency)s, but "
+"this line is in %(line_currency)s."
+msgstr ""
+"El diario %(journal)s solo acepta asientos en %(journal_currency)s, pero "
+"esta línea está en %(line_currency)s."
+
+#. module: l10n_ve_accountant
+#. odoo-python
+#: code:addons/l10n_ve_accountant/models/account_move_line.py:0
 msgid "The price entered cannot be negative"
 msgstr "El precio ingresado no puede ser negativo."
 

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -828,7 +828,7 @@ msgstr "Es Compra Internacional"
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__invoice_date_display
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__invoice_date_display
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.l10n_ve_accountant_view_account_invoice_filter
-msgid "Invoice Date"
+msgid "Date of Invoice"
 msgstr "Fecha de factura"
 
 #. module: l10n_ve_accountant
@@ -1742,20 +1742,6 @@ msgstr "Total sin impuestos BS"
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_payment_tree
 msgid "Bill Date"
-msgstr "Fecha de tasa"
-
-#. module: account
-#: model:ir.model.fields,field_description:account.field_account_invoice_report__invoice_date
-#: model_terms:ir.ui.view,arch_db:account.portal_my_invoices
-#: model_terms:ir.ui.view,arch_db:account.view_account_invoice_filter
-#: model_terms:ir.ui.view,arch_db:account.view_account_move_filter
-#: model_terms:ir.ui.view,arch_db:account.view_account_move_line_filter
-#: model_terms:ir.ui.view,arch_db:account.view_account_move_line_payment_filter
-#: model_terms:ir.ui.view,arch_db:account.view_invoice_tree
-#: model_terms:ir.ui.view,arch_db:account.view_move_form
-#: model_terms:ir.ui.view,arch_db:account.view_move_line_tree
-#: model_terms:ir.ui.view,arch_db:account.view_move_tree
-msgid "Invoice Date"
 msgstr "Fecha de tasa"
 
 #. module: l10n_ve_accountant

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -18,7 +18,7 @@ _logger = logging.getLogger(__name__)
 class AccountMove(models.Model):
     _inherit = "account.move"
     
-    invoice_date_display = fields.Date(string="Invoice Date", default=fields.Date.context_today)
+    invoice_date_display = fields.Date(string="Date of Invoice", default=fields.Date.context_today)
     is_purchase_international = fields.Boolean(related="journal_id.is_purchase_international")
 
     @api.depends('invoice_date_display')

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -498,3 +498,23 @@ class AccountMoveLine(models.Model):
                         "discount": discount_val,
                     }
                 )
+
+    def _check_constrains_account_id_journal_id(self):
+        for line in self.filtered(
+            lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note')
+        ):
+            journal = line.move_id.journal_id
+            journal_currency = journal.currency_id
+            # If the journal has no currency of its own, it accepts entries in
+            # any currency (core behavior). If it DOES force a currency, no
+            # line may use a different one -- block before running the core's
+            # own validations (archived account, account secondary currency).
+            if journal_currency and line.currency_id != journal_currency:
+                raise UserError(_(
+                    'The journal %(journal)s only accepts entries in %(journal_currency)s, '
+                    'but this line is in %(line_currency)s.',
+                    journal=journal.name,
+                    journal_currency=journal_currency.name,
+                    line_currency=line.currency_id.name,
+                ))
+        return super()._check_constrains_account_id_journal_id()

--- a/l10n_ve_accountant/models/account_payment.py
+++ b/l10n_ve_accountant/models/account_payment.py
@@ -1,4 +1,5 @@
 from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 import logging
 
@@ -68,6 +69,85 @@ class AccountPayment(models.Model):
     company_currency_symbol = fields.Char(related="company_id.currency_id.symbol")
 
     foreign_amount = fields.Monetary('foreign_amount',currency_field="foreign_currency_id",  compute="_compute_foreign_amount", store=True, readonly=False)
+
+    def _prepare_move_lines_per_type(self, write_off_line_vals=None, force_balance=None):
+        """
+        Same as the core method (account.payment), except the liquidity line is
+        converted to company currency using the l10n_ve_conversion_date context key
+        (the invoice date when the payment is not indexed) instead of always using
+        the payment date. The wizard sets this context key when creating payments
+        (see account_payment_register._create_payments); no field is persisted.
+        Duplicated instead of temporarily reassigning self.date, since that would
+        trigger a real write() on a stored field and cascade recomputes.
+        """
+        self.ensure_one()
+        conversion_date = self.env.context.get('l10n_ve_conversion_date')
+        
+        if not conversion_date:
+            return super()._prepare_move_lines_per_type(
+                write_off_line_vals=write_off_line_vals, force_balance=force_balance
+            )
+
+        if not self.outstanding_account_id:
+            raise UserError(_(
+                "You can't create a new payment without an outstanding payments/receipts account set either on the company or the %(payment_method)s payment method in the %(journal)s journal.",
+                payment_method=self.payment_method_line_id.name, journal=self.journal_id.display_name))
+
+        line_name = ''.join(x[1] for x in self._get_aml_default_display_name_list() if x[1])
+
+        write_off_lines = write_off_line_vals or []
+        write_off_amount_currency = sum(x['amount_currency'] for x in write_off_lines)
+        write_off_balance = sum(x['balance'] for x in write_off_lines)
+
+        withholding_lines = self._prepare_move_withholding_lines({})
+        withholding_amount_currency = sum(x['amount_currency'] for x in withholding_lines)
+        withholding_balance = sum(x['balance'] for x in withholding_lines)
+
+        if withholding_lines and write_off_lines:
+            write_off_lines = []
+            write_off_amount_currency = 0.0
+            write_off_balance = 0.0
+
+        if self.payment_type == 'inbound':
+            liquidity_amount_currency = self.amount
+        elif self.payment_type == 'outbound':
+            liquidity_amount_currency = -self.amount
+        else:
+            liquidity_amount_currency = 0.0
+
+        if not write_off_line_vals and force_balance is not None:
+            sign = 1 if liquidity_amount_currency > 0 else -1
+            liquidity_balance = sign * abs(force_balance)
+        else:
+            liquidity_balance = self.currency_id._convert(
+                liquidity_amount_currency,
+                self.company_id.currency_id,
+                self.company_id,
+                conversion_date,
+            )
+        liquidity_amount_currency -= withholding_amount_currency
+        liquidity_balance -= withholding_balance
+
+        liquidity_lines = self._prepare_move_liquidity_lines({
+            'name': line_name,
+            'balance': liquidity_balance,
+            'amount_currency': liquidity_amount_currency,
+        })
+
+        counterpart_amount_currency = -liquidity_amount_currency - write_off_amount_currency - withholding_amount_currency
+        counterpart_balance = -liquidity_balance - write_off_balance - withholding_balance
+        counterpart_lines = self._prepare_move_counterpart_lines({
+            'name': line_name,
+            'balance': counterpart_balance,
+            'amount_currency': counterpart_amount_currency,
+        })
+
+        return {
+            'liquidity_lines': liquidity_lines,
+            'counterpart_lines': counterpart_lines,
+            'write_off_lines': write_off_lines,
+            'withholding_lines': withholding_lines,
+        }
 
     @api.depends("amount", "currency_id","date")
     def _compute_foreign_amount(self):
@@ -141,11 +221,20 @@ class AccountPayment(models.Model):
     def _compute_rate(self):
         """
         Compute the rate of the payment using the compute_rate method of the res.currency.rate model.
+
+        foreign_rate/foreign_inverse_rate are stored+readonly=False, so the wizard's
+        create() call can set them explicitly with the indexation-aware rate. But
+        being @api.depends("date", "currency_id") means ANY later write to those
+        fields (e.g. a manual date correction) silently recomputes and overwrites
+        that value with today's rate, discarding the invoice-date rate for
+        non-indexed payments. Honor l10n_ve_conversion_date here too so a recompute
+        never reverts what the wizard set.
         """
         Rate = self.env["res.currency.rate"]
         for payment in self:
+            conversion_date = self.env.context.get('l10n_ve_conversion_date') or payment.date or fields.Date.today()
             rate_values = Rate.compute_rate(
-                payment.foreign_currency_id.id, payment.date or fields.Date.today()
+                payment.foreign_currency_id.id, conversion_date
             )
             payment.update(rate_values)
 
@@ -156,12 +245,13 @@ class AccountPayment(models.Model):
         """
         Rate = self.env["res.currency.rate"]
         for payment in self:
+            conversion_date = self.env.context.get('l10n_ve_conversion_date') or payment.date or fields.Date.today()
             if (
                 payment.currency_id != payment.company_id.currency_id
                 and payment.currency_id != payment.company_id.foreign_currency_id
             ):
                 rate_values = Rate.compute_rate(
-                    payment.currency_id.id, payment.date or fields.Date.today()
+                    payment.currency_id.id, conversion_date
                 )
                 payment.other_rate = rate_values.get("foreign_rate", 0)
                 payment.other_rate_inverse = rate_values.get("foreign_inverse_rate", 0)

--- a/l10n_ve_accountant/tests/test_indexed_payments.py
+++ b/l10n_ve_accountant/tests/test_indexed_payments.py
@@ -1,0 +1,481 @@
+import logging
+from datetime import timedelta
+
+from odoo.tests import tagged, Form
+from odoo import fields, Command
+
+from .test_foreign_balance import TestForeignBalance
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install", "l10n_ve_accountant_indexed_payments")
+class TestIndexedPayments(TestForeignBalance):
+    """
+    Validates the indexed/non-indexed payment feature (indexed_default /
+    indexaxion_payment_mode) for invoices booked in company currency (VEF) and
+    paid in a foreign currency, across different foreign currencies.
+
+    Reuses TestForeignBalance's setUp (company VEF/USD/EUR, rates, accounts,
+    journals, partner, product) instead of rebuilding fixtures from scratch.
+    """
+
+    def setUp(self):
+        # Deliberately skip TestForeignBalance.setUp(): it mutates
+        # base.main_company's currency_id/foreign_currency_id, which
+        # l10n_ve_rate forbids once that company already has account.move
+        # entries (as any long-lived database will). Use a fresh company
+        # instead so the same currency/rate configuration can be applied
+        # without hitting "moneda alterna ya tiene movimientos contables".
+        super(TestForeignBalance, self).setUp()
+
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_vef = self.env.ref("base.VEF")
+        self.currency_eur = self.env.ref("base.EUR")
+        self.currency_eur.active = True
+        self.country_ve = self.env.ref("base.ve")
+
+        self.company = self.env["res.company"].create({
+            "name": "Indexed Payments Test Co",
+            "currency_id": self.currency_vef.id,
+            "foreign_currency_id": self.currency_usd.id,
+            "account_fiscal_country_id": self.country_ve.id,
+            "country_id": self.country_ve.id,
+            # The wizard's indexed_default field is only editable when the
+            # company is set to "to be agreed" (see
+            # l10n_ve_accountant/wizard/account_payment_register.xml:
+            # readonly="indexaxion_payment_mode != 'to_agreed' or
+            # company_currency_id == currency_id"). These tests need to
+            # toggle it per payment, so the company must opt into that mode.
+            "indexaxion_payment_mode": "to_agreed",
+        })
+        self.env.user.write({"company_ids": [(4, self.company.id)], "company_id": self.company.id})
+
+        self.invoice_date = fields.Date.today() - timedelta(days=14)
+        self.payment_date = fields.Date.today()
+
+        self.account_receivable = self.env["account.account"].create({
+            "name": "Receivable",
+            "code": "120000",
+            "account_type": "asset_receivable",
+            "company_ids": [(6, 0, [self.company.id])],
+            "reconcile": True,
+        })
+        self.account_income = self.env["account.account"].create({
+            "name": "Income",
+            "code": "400000",
+            "account_type": "income",
+            "company_ids": [(6, 0, [self.company.id])],
+        })
+        self.account_bank = self.env["account.account"].create({
+            "name": "Bank Account",
+            "code": "100100",
+            "account_type": "asset_cash",
+            "company_ids": [(6, 0, [self.company.id])],
+            "reconcile": True,
+        })
+
+        self.manual_in = self.env.ref("account.account_payment_method_manual_in")
+        self.manual_out = self.env.ref("account.account_payment_method_manual_out")
+        self.pm_line_in = self.env["account.payment.method.line"].create({
+            "name": "Manual Inbound",
+            "payment_method_id": self.manual_in.id,
+            "payment_type": "inbound",
+            "payment_account_id": self.account_bank.id,
+        })
+        self.pm_line_out = self.env["account.payment.method.line"].create({
+            "name": "Manual Outbound",
+            "payment_method_id": self.manual_out.id,
+            "payment_type": "outbound",
+            "payment_account_id": self.account_bank.id,
+        })
+
+        exchange_income_account = self.env["account.account"].create({
+            "name": "Exchange Gain",
+            "code": "770000",
+            "account_type": "income_other",
+            "company_ids": [(6, 0, [self.company.id])],
+        })
+        exchange_expense_account = self.env["account.account"].create({
+            "name": "Exchange Loss",
+            "code": "670000",
+            "account_type": "expense",
+            "company_ids": [(6, 0, [self.company.id])],
+        })
+        exchange_journal = self.env["account.journal"].sudo().create({
+            "name": "Exchange Difference",
+            "code": "EXCH",
+            "type": "general",
+            "company_id": self.company.id,
+        })
+        self.company.write({
+            "income_currency_exchange_account_id": exchange_income_account.id,
+            "expense_currency_exchange_account_id": exchange_expense_account.id,
+            "currency_exchange_journal_id": exchange_journal.id,
+        })
+
+        self.sale_journal = self.env["account.journal"].sudo().create({
+            "name": "Sales Test",
+            "code": "SLTST",
+            "type": "sale",
+            "company_id": self.company.id,
+            "default_account_id": self.account_income.id,
+        })
+
+        self.partner = self.env["res.partner"].create({
+            "name": "Test Partner",
+            "country_id": self.country_ve.id,
+            "property_account_receivable_id": self.account_receivable.id,
+        })
+        self.test_tax_group = self.env["account.tax.group"].create({
+            "name": "Test Tax Group",
+            "company_id": self.company.id,
+            "country_id": self.country_ve.id,
+        })
+        self.test_tax = self.env["account.tax"].create({
+            "name": "Test Tax 0%",
+            "amount": 0,
+            "amount_type": "percent",
+            "type_tax_use": "sale",
+            "company_id": self.company.id,
+            "tax_group_id": self.test_tax_group.id,
+        })
+
+        self.product = self.env["product.product"].create({
+            "name": "Product Test",
+            "type": "service",
+            "list_price": 100.0,
+            "taxes_id": [(6, 0, [self.test_tax.id])],
+        })
+
+    # -- helpers (extend the parent's _set_usd_rate to any currency/date) -----
+
+    def _set_rate(self, currency, date, rate):
+        currency_rate = self.env["res.currency.rate"].search(
+            [
+                ("name", "=", date),
+                ("currency_id", "=", currency.id),
+                ("company_id", "=", self.company.id),
+            ],
+            limit=1,
+        )
+        if currency_rate:
+            currency_rate.write({"inverse_company_rate": rate})
+            return currency_rate
+
+        return self.env["res.currency.rate"].create(
+            {
+                "name": date,
+                "currency_id": currency.id,
+                "inverse_company_rate": rate,
+                "company_id": self.company.id,
+            }
+        )
+
+    def _get_foreign_bank_journal(self, currency):
+        journal = self.env["account.journal"].search(
+            [
+                ("type", "=", "bank"),
+                ("currency_id", "=", currency.id),
+                ("company_id", "=", self.company.id),
+            ],
+            limit=1,
+        )
+        if journal:
+            return journal
+        return self.env["account.journal"].sudo().create(
+            {
+                "name": f"Bank {currency.name}",
+                "type": "bank",
+                "code": f"BNK{currency.name}",
+                "currency_id": currency.id,
+                "company_id": self.company.id,
+                "default_account_id": self.account_bank.id,
+                "inbound_payment_method_line_ids": [(6, 0, self.pm_line_in.ids)],
+                "outbound_payment_method_line_ids": [(6, 0, self.pm_line_out.ids)],
+            }
+        )
+
+    def _create_vef_invoice(self, amount=100.0):
+        """Invoice booked directly in company currency (VEF), like the real
+        case reported: a VEF invoice later paid in a foreign currency."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "journal_id": self.sale_journal.id,
+                "currency_id": self.currency_vef.id,
+                "invoice_date": self.invoice_date,
+                "invoice_date_display": self.invoice_date,
+                "date": self.invoice_date,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": amount,
+                            "account_id": self.account_income.id,
+                            "tax_ids": [Command.set([self.test_tax.id])],
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.with_context(move_action_post_alert=True).action_post()
+        return invoice
+
+    def _create_foreign_invoice(self, currency, amount=100.0):
+        """Invoice booked in a foreign currency (USD/EUR). Odoo books the AR
+        line's company-currency (VEF) balance at the invoice date's rate at
+        posting time -- this is what makes a later payment converted at a
+        different rate produce a real exchange difference."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "journal_id": self.sale_journal.id,
+                "currency_id": currency.id,
+                "invoice_date": self.invoice_date,
+                "invoice_date_display": self.invoice_date,
+                "date": self.invoice_date,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": amount,
+                            "account_id": self.account_income.id,
+                            "tax_ids": [Command.set([self.test_tax.id])],
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.with_context(move_action_post_alert=True).action_post()
+        return invoice
+
+    def _register_payment(self, invoice, currency, indexed_default, amount=None):
+        """Open the wizard the same way the existing l10n_ve_igtf test suite
+        does: via Form.from_action + per-field .save(), so each assignment
+        goes through its real onchange chain -- unlike a raw .create(vals),
+        which can have a later-computed field (e.g. amount, triggered by
+        indexed_default/currency_id) silently override an explicitly-passed
+        value."""
+        journal = self._get_foreign_bank_journal(currency)
+        with Form.from_action(self.env, invoice.action_register_payment()) as pay_form:
+            pay_form.journal_id = journal
+            pay_form.save()
+            pay_form.currency_id = currency
+            pay_form.save()
+            pay_form.payment_date = self.payment_date
+            pay_form.save()
+            pay_form.indexed_default = indexed_default
+            pay_form.save()
+            if amount is not None:
+                pay_form.amount = amount
+                pay_form.save()
+        return pay_form.record
+
+    def _exchange_diff_moves(self, invoice):
+        ar_lines = invoice.line_ids.filtered(
+            lambda l: l.account_id.account_type == "asset_receivable"
+        )
+        partials = ar_lines.matched_credit_ids | ar_lines.matched_debit_ids
+        return partials.mapped("exchange_move_id").filtered(lambda m: m)
+
+    # -- tests -----------------------------------------------------------
+
+    def test_indexed_default_uses_payment_date_rate_and_creates_exchange_diff(self):
+        """indexed_default=True (default) must behave like plain Odoo. Here the
+        invoice AND the payment are both in USD: the wizard amount needs no
+        conversion at all (same currency), but the liquidity line still gets
+        booked in VEF using the payment date's rate. Since the invoice's own
+        VEF value was fixed at the invoice date's (different) rate, settling
+        it fully must reproduce a normal rate mismatch -- an exchange
+        difference -- exactly like standard Odoo would.
+
+        (Paying a foreign invoice directly in company currency, VEF, is a
+        different case: the wizard always reuses the invoice's own fixed VEF
+        residual with no re-conversion at all, indexed or not -- so it never
+        produces an exchange difference. That path is covered by the
+        non-indexed tests below via the write-off/liquidity fixes.)"""
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.payment_date, 50.0)
+
+        invoice = self._create_foreign_invoice(self.currency_usd, amount=100.0)
+        residual_usd = invoice.amount_residual
+
+        wizard = self._register_payment(invoice, self.currency_usd, indexed_default=True)
+        conversion_date = wizard._get_conversion_date()
+        self.assertEqual(
+            conversion_date, self.payment_date,
+            "Indexed payments must use the payment date, exactly like core Odoo.",
+        )
+
+        self.assertAlmostEqual(
+            wizard.amount, residual_usd, places=2,
+            msg="Same-currency payment needs no conversion for the wizard amount.",
+        )
+
+        payment = wizard._create_payments()
+        self.assertIn(payment.state, ["posted", "paid"])
+        self.assertEqual(invoice.amount_residual, 0.0)
+
+        diff_moves = self._exchange_diff_moves(invoice)
+        self.assertTrue(
+            diff_moves,
+            "Indexed payment converted at a different rate than the invoice must "
+            "produce an exchange difference, same as standard Odoo.",
+        )
+
+    def test_non_indexed_uses_invoice_date_rate_and_skips_exchange_diff(self):
+        """indexed_default=False must anchor the conversion to the invoice
+        date's rate (reproducing the reported case: 1.011.998,59 VEF /
+        1.351,52 USD invoice paid later, non-indexed) and must NOT generate an
+        exchange difference, since the payment is booked at the exact same
+        VEF value as the invoice."""
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.payment_date, 50.0)
+
+        invoice = self._create_vef_invoice(amount=1000.0)
+        residual_vef = invoice.amount_residual
+
+        wizard = self._register_payment(invoice, self.currency_usd, indexed_default=False)
+        conversion_date = wizard._get_conversion_date()
+        self.assertEqual(
+            conversion_date, self.invoice_date,
+            "Non-indexed payments must be anchored to the invoice date.",
+        )
+
+        expected_amount = self.currency_vef._convert(
+            residual_vef, self.currency_usd, self.company, self.invoice_date,
+        )
+        self.assertAlmostEqual(
+            wizard.amount, expected_amount, places=2,
+            msg="Non-indexed payment amount must be converted at the invoice date's rate, not today's.",
+        )
+
+        payment = wizard._create_payments()
+        self.assertIn(payment.state, ["posted", "paid"])
+        self.assertEqual(
+            invoice.amount_residual, 0.0,
+            "The invoice must be fully settled: the VEF value booked by the "
+            "non-indexed payment must match the invoice's own VEF residual exactly.",
+        )
+
+        diff_moves = self._exchange_diff_moves(invoice)
+        self.assertFalse(
+            diff_moves,
+            "Non-indexed payments must NOT create an exchange difference: the "
+            "whole point is to book the payment at the invoice's original rate.",
+        )
+
+    def test_non_indexed_eur_payment_also_uses_invoice_date_rate(self):
+        """Same non-indexed guarantee, but paying in EUR instead of USD, to
+        confirm the fix is not USD-specific."""
+        self._set_rate(self.currency_eur, self.invoice_date, 44.0)
+        self._set_rate(self.currency_eur, self.payment_date, 55.0)
+
+        invoice = self._create_vef_invoice(amount=880.0)
+        residual_vef = invoice.amount_residual
+
+        wizard = self._register_payment(invoice, self.currency_eur, indexed_default=False)
+        self.assertEqual(wizard._get_conversion_date(), self.invoice_date)
+
+        expected_amount = self.currency_vef._convert(
+            residual_vef, self.currency_eur, self.company, self.invoice_date,
+        )
+        self.assertAlmostEqual(wizard.amount, expected_amount, places=2)
+
+        payment = wizard._create_payments()
+        self.assertIn(payment.state, ["posted", "paid"])
+        self.assertEqual(invoice.amount_residual, 0.0)
+        self.assertFalse(
+            self._exchange_diff_moves(invoice),
+            "EUR non-indexed payment must not create an exchange difference either.",
+        )
+
+    def test_non_indexed_overpayment_writeoff_uses_invoice_date_rate(self):
+        """When overpaying (sobrante/write-off) on a non-indexed payment, the
+        write-off line's VEF balance must also be converted at the invoice
+        date's rate, not today's -- otherwise the sobrante alone would carry
+        an inconsistent rate versus the rest of the entry."""
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.payment_date, 50.0)
+
+        invoice = self._create_vef_invoice(amount=1000.0)
+        residual_vef = invoice.amount_residual
+        residual_usd_at_invoice_rate = self.currency_vef._convert(
+            residual_vef, self.currency_usd, self.company, self.invoice_date,
+        )
+        overpay_extra_usd = 25.0
+        overpay_amount = residual_usd_at_invoice_rate + overpay_extra_usd
+
+        wizard = self._register_payment(
+            invoice, self.currency_usd, indexed_default=False, amount=overpay_amount,
+        )
+        wizard.payment_difference_handling = "reconcile"
+        wizard.writeoff_account_id = self.account_income
+
+        payment_vals = wizard._create_payment_vals_from_wizard(wizard.batches[0])
+        write_off_lines = payment_vals.get("write_off_line_vals", [])
+        self.assertTrue(write_off_lines, "Overpayment must produce a write-off line.")
+
+        for line_vals in write_off_lines:
+            if not line_vals.get("amount_currency"):
+                continue
+            expected_balance = self.currency_usd._convert(
+                line_vals["amount_currency"], self.currency_vef, self.company, self.invoice_date,
+            )
+            wrong_balance_at_payment_date = self.currency_usd._convert(
+                line_vals["amount_currency"], self.currency_vef, self.company, self.payment_date,
+            )
+            self.assertAlmostEqual(
+                line_vals["balance"], expected_balance, places=2,
+                msg="Write-off balance must be converted at the invoice date's rate, not today's.",
+            )
+            self.assertNotAlmostEqual(
+                line_vals["balance"], wrong_balance_at_payment_date, places=2,
+                msg="Write-off balance must NOT match the (different) payment-date rate.",
+            )
+
+    def test_igtf_calculate_for_payment_honors_conversion_date_context(self):
+        """account.payment.calculate_igtf_for_payment (l10n_ve_igtf) must use
+        the l10n_ve_conversion_date context key -- set by the wizard's
+        _create_payments -- instead of always the raw payment_date argument,
+        so IGTF for a non-indexed payment is computed at the invoice date's
+        rate rather than today's."""
+        if "l10n_ve_igtf.utils" not in self.env:
+            self.skipTest("l10n_ve_igtf is not installed")
+
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.payment_date, 50.0)
+
+        invoice = self._create_foreign_invoice(self.currency_usd, amount=100.0)
+        payment = self.env["account.payment"].create({
+            "amount": 50.0,
+            "date": self.payment_date,
+            "currency_id": self.currency_usd.id,
+            "payment_type": "inbound",
+            "partner_type": "customer",
+            "partner_id": self.partner.id,
+            "journal_id": self._get_foreign_bank_journal(self.currency_usd).id,
+            "payment_method_id": self.manual_in.id,
+        })
+
+        # Context wins: must match calling the same util directly with the
+        # invoice date instead of today.
+        igtf_with_context = payment.with_context(
+            l10n_ve_conversion_date=self.invoice_date,
+        ).calculate_igtf_for_payment(
+            invoice, 50.0, self.currency_usd, self.payment_date, base=True,
+        )
+        igtf_reference_at_invoice_date = self.env["l10n_ve_igtf.utils"].calculate_igtf_for_payment(
+            invoice, 50.0, self.currency_usd, self.invoice_date,
+            company=self.company, base=True,
+        )
+
+        self.assertAlmostEqual(
+            igtf_with_context, igtf_reference_at_invoice_date, places=2,
+            msg="l10n_ve_conversion_date context must override payment_date in the IGTF calculation.",
+        )

--- a/l10n_ve_accountant/tests/test_journal_currency_constraint.py
+++ b/l10n_ve_accountant/tests/test_journal_currency_constraint.py
@@ -1,0 +1,79 @@
+import logging
+
+from odoo.tests import tagged
+from odoo import Command
+from odoo.exceptions import UserError
+
+from .test_indexed_payments import TestIndexedPayments
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install", "l10n_ve_accountant_journal_currency")
+class TestJournalCurrencyConstraint(TestIndexedPayments):
+    """
+    Validates the journal-currency guard added to
+    AccountMoveLine._check_constrains_account_id_journal_id: a journal with a
+    forced currency must reject entries in any other currency, while a
+    journal with no currency accepts any.
+
+    Reuses TestIndexedPayments' setUp (company VEF/USD/EUR, rates, accounts,
+    partner, product, tax) instead of rebuilding fixtures.
+    """
+
+    def _create_move(self, journal, currency):
+        return self.env["account.move"].create({
+            "move_type": "entry",
+            "journal_id": journal.id,
+            "date": self.invoice_date,
+            "line_ids": [
+                Command.create({
+                    "account_id": self.account_income.id,
+                    "currency_id": currency.id,
+                    "debit": 100.0,
+                    "credit": 0.0,
+                    "amount_currency": 100.0,
+                }),
+                Command.create({
+                    "account_id": self.account_bank.id,
+                    "currency_id": currency.id,
+                    "debit": 0.0,
+                    "credit": 100.0,
+                    "amount_currency": -100.0,
+                }),
+            ],
+        })
+
+    def test_journal_with_currency_rejects_mismatched_line_currency(self):
+        # Plain try/except instead of assertRaises: the latter wraps the call
+        # in an extra cr.savepoint(), whose eager flush can trigger this fresh
+        # test company's lazy chart-template load at an unlucky moment,
+        # tripping an unrelated pre-existing multi-record bug in
+        # product_template._enforce_single_tax_vals. Not what this test
+        # covers -- avoid it instead of chasing it here.
+        usd_journal = self._get_foreign_bank_journal(self.currency_usd)
+        move = self._create_move(usd_journal, self.currency_vef)
+        try:
+            move.action_post()
+            self.fail("Expected a UserError for a VEF-denominated entry in a USD-only journal.")
+        except UserError:
+            pass
+
+    def test_journal_with_currency_accepts_matching_line_currency(self):
+        usd_journal = self._get_foreign_bank_journal(self.currency_usd)
+        move = self._create_move(usd_journal, self.currency_usd)
+        move.action_post()
+        self.assertEqual(move.state, "posted")
+
+    def test_journal_without_currency_accepts_any_line_currency(self):
+        journal_no_currency = self.env["account.journal"].sudo().create({
+            "name": "Misc Journal No Currency",
+            "type": "general",
+            "code": "MISCNC",
+            "company_id": self.company.id,
+            "currency_id": False,
+            "default_account_id": self.account_income.id,
+        })
+        move = self._create_move(journal_no_currency, self.currency_usd)
+        move.action_post()
+        self.assertEqual(move.state, "posted")

--- a/l10n_ve_accountant/views/res_config_settings_views.xml
+++ b/l10n_ve_accountant/views/res_config_settings_views.xml
@@ -51,7 +51,7 @@
                             <div class="o_setting_right_pane" >
                                 <group>
                                     <field name="indexaxion_payment_mode" />
-                                    <field name="indexed_default" readonly="indexaxion_payment_mode != 'to_agreed'"/>
+                                    <field name="indexed_default" readonly="indexaxion_payment_mode != 'to_agreed'" force_save="1"/>
                                 </group>
                             </div>
                         </div>

--- a/l10n_ve_accountant/wizard/account_payment_register.py
+++ b/l10n_ve_accountant/wizard/account_payment_register.py
@@ -80,7 +80,7 @@ class AccountPaymentRegister(models.TransientModel):
 
     indexed_default = fields.Boolean(default=lambda self: self.env.company.indexed_default, string="Payment indexed")
 
-    @api.depends("currency_id")
+    @api.depends("currency_id", "indexed_default", "payment_date")
     def _compute_rates(self):
         """
         Compute the currency and compute the foreign rate
@@ -91,7 +91,7 @@ class AccountPaymentRegister(models.TransientModel):
                 return
             currency_to_use = payment.currency_id.id if payment.currency_id != payment.company_id.currency_id else payment.company_id.foreign_currency_id.id
             rate_values = Rate.compute_rate(
-                currency_to_use, payment.payment_date
+                currency_to_use, payment._get_conversion_date()
             )
             payment.foreign_rate = rate_values.get("foreign_rate", 0.0)
             payment.foreign_inverse_rate = rate_values.get("foreign_inverse_rate", 0.0)
@@ -121,7 +121,7 @@ class AccountPaymentRegister(models.TransientModel):
             if not bool(payment.payment_date):
                 return
             rate_values = Rate.compute_rate(
-                payment.foreign_currency_id.id, payment.payment_date
+                payment.foreign_currency_id.id, payment._get_conversion_date()
             )
             payment.update(rate_values)
 
@@ -184,6 +184,12 @@ class AccountPaymentRegister(models.TransientModel):
     def _convert_to_wizard_currency(self, installments):
         self.ensure_one()
         conversion_date = self._get_conversion_date()
+        invoice_dates = set(
+            self.line_ids.move_id.filtered(
+                lambda m: m.is_invoice(include_receipts=True)
+            ).mapped('invoice_date')
+        )
+        same_date_as_invoice = len(invoice_dates) == 1 and self.payment_date in invoice_dates
 
         total_per_currency = defaultdict(lambda: {
             'amount_residual': 0.0,
@@ -203,9 +209,12 @@ class AccountPaymentRegister(models.TransientModel):
             if currency == wizard_curr:
                 total_amount += amount_residual_currency
             elif currency != comp_curr and wizard_curr == comp_curr:
-                total_amount += currency._convert(
-                    amount_residual_currency, comp_curr, self.company_id, conversion_date,
-                )
+                if self.indexed_default and same_date_as_invoice:
+                    total_amount += amount_residual
+                else:
+                    total_amount += currency._convert(
+                        amount_residual_currency, comp_curr, self.company_id, conversion_date,
+                    )
             elif currency == comp_curr and wizard_curr != comp_curr:
                 total_amount += comp_curr._convert(
                     amount_residual, wizard_curr, self.company_id, conversion_date,
@@ -228,6 +237,32 @@ class AccountPaymentRegister(models.TransientModel):
                 "foreign_inverse_rate": self.foreign_inverse_rate,
             }
         )
+
+        conversion_date = self._get_conversion_date()
+        if conversion_date != self.payment_date and self.currency_id != self.company_currency_id:
+            for line_vals in payment_vals.get('write_off_line_vals', []):
+                if 'amount_currency' in line_vals and 'balance' in line_vals:
+                    line_vals['balance'] = self.currency_id._convert(
+                        line_vals['amount_currency'],
+                        self.company_id.currency_id,
+                        self.company_id,
+                        conversion_date,
+                    )
+
         return payment_vals
+
+    def _create_payments(self):
+        """
+        Pass the indexation conversion date via context instead of a stored field on
+        account.payment: _prepare_move_lines_per_type (account_payment.py) reads
+        context key 'l10n_ve_conversion_date' to convert the liquidity line using the
+        invoice date when the payment is not indexed.
+        """
+        return super(
+            AccountPaymentRegister,
+            self.with_context(l10n_ve_conversion_date=self._get_conversion_date()),
+        )._create_payments()
+
+  
 
     

--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -19,7 +19,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "19.0.1.2.12",
+    "version": "19.0.1.2.13",
 
     "depends": [
         "base",

--- a/l10n_ve_igtf/models/account_payment.py
+++ b/l10n_ve_igtf/models/account_payment.py
@@ -259,7 +259,15 @@ class AccountPaymentAndIgtf(models.Model):
 
             diff = expected - current
             if comp_curr.is_zero(diff):
-                return
+                continue
+            # Only absorb rounding-level gaps here (the wizard's per-installment
+            # conversion vs. the payment's own aggregate _convert landing a cent
+            # apart) -- a real partial payment settled via write-off produces a
+            # much larger, intentional diff that must NOT be forced to the full
+            # invoice residual; leave the wizard/core's own already-correct
+            # values alone in that case.
+            if not rec._is_same_within_rounding(current, expected, comp_curr):
+                continue
             conversion_date = rec.env.context.get('l10n_ve_conversion_date') or rec.date
 
             # Force counterpart to match the invoice residual (solo balance)

--- a/l10n_ve_igtf/models/account_payment.py
+++ b/l10n_ve_igtf/models/account_payment.py
@@ -175,7 +175,8 @@ class AccountPaymentAndIgtf(models.Model):
                         rec._fix_writeoff_balance(vals, write_off_line_vals)
                     else:
                         fechas_lista = set(rec.invoices_origin_ids.mapped('invoice_date'))
-                        if abs(total_base_residual) - abs(vals[0]['balance']) <= 0.1 and len(fechas_lista) == 1 and  rec.date in fechas_lista:
+                        conversion_date = rec.env.context.get('l10n_ve_conversion_date') or rec.date
+                        if abs(total_base_residual) - abs(vals[0]['balance']) <= 0.1 and len(fechas_lista) == 1 and conversion_date in fechas_lista:
 
                             # FIX balances when diference is decimal
                            
@@ -189,8 +190,9 @@ class AccountPaymentAndIgtf(models.Model):
             return vals
     
     def calculate_igtf_for_payment(self, invoice, amount_payment, payment_currency, payment_date, base=False):
+        conversion_date = self.env.context.get('l10n_ve_conversion_date') or payment_date
         return self.env["l10n_ve_igtf.utils"].calculate_igtf_for_payment(
-            invoice, amount_payment, payment_currency, payment_date,
+            invoice, amount_payment, payment_currency, conversion_date,
             company=self.company_id, base=base,
         )
 
@@ -258,12 +260,13 @@ class AccountPaymentAndIgtf(models.Model):
             diff = expected - current
             if comp_curr.is_zero(diff):
                 return
+            conversion_date = rec.env.context.get('l10n_ve_conversion_date') or rec.date
 
             # Force counterpart to match the invoice residual (solo balance)
             cpart['balance'] = expected
             # Recalculate amount_currency from the forced balance
             amt = comp_curr._convert(
-                abs(expected), currency, rec.company_id, rec.date,
+                abs(expected), currency, rec.company_id, conversion_date,
             )
             cpart['amount_currency'] = amt if expected > 0 else -amt
 
@@ -272,7 +275,7 @@ class AccountPaymentAndIgtf(models.Model):
             w_off['balance'] = w_off.get('balance', 0) - diff
             # Recalculate write-off amount_currency with correct sign
             w_amt = comp_curr._convert(
-                abs(w_off['balance']), currency, rec.company_id, rec.date,
+                abs(w_off['balance']), currency, rec.company_id, conversion_date,
             )
             w_off['amount_currency'] = w_amt if w_off['balance'] > 0 else -w_amt
 
@@ -415,6 +418,19 @@ class AccountPaymentAndIgtf(models.Model):
                     })
         return vals
   
+    def _is_same_within_rounding(self, amount1, amount2, currency, tolerance_units=1):
+        """Return True if amount1 and amount2 differ by at most
+        `tolerance_units` rounding units of `currency` (inclusive).
+
+        Used to treat two amounts computed via different paths (e.g. a
+        currency-converted value vs. a directly-stored residual) as "the
+        same debt" when they only differ by a small, expected rounding
+        artifact -- not a real accounting discrepancy.
+        """
+        tolerance = currency.rounding * tolerance_units
+        return abs(amount1 - amount2) <= tolerance + 1e-6
+
+    
 
     def _prepare_inbound_move_line_igtf_vals(self, vals, write_off_line_vals = False):
         """ Adjusts the journal items values (`vals`) to inject the IGTF tax calculation,
@@ -441,63 +457,75 @@ class AccountPaymentAndIgtf(models.Model):
         for rec in self:
             lines = [line for line in vals]
             if rec.payment_type == "inbound":
-                fechas_lista = set(rec.invoices_origin_ids.mapped('invoice_date'))
+                invoice_currencies = rec.invoices_origin_ids.mapped('currency_id')
+                comp_curr = rec.company_id.currency_id
 
-                total_base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual_signed')))
-                top_igtf = abs(sum(rec.invoices_origin_ids.mapped('igtf_top_aply')))
+                if invoice_currencies and invoice_currencies[0] == comp_curr:
+                    total_base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual_signed')))
+                    residual_currency = comp_curr
+                else:
+                    total_base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual')))
+                    residual_currency = invoice_currencies[0]
 
-                top_igtf_residual_base = total_base_residual + top_igtf
                 currency = rec.currency_id 
                 precision = currency.decimal_places
-
+                precision_base = self.env.company.currency_id.decimal_places
+                credit_line_unrounded = False
+              
                 credit_line_unrounded = lines[1]["amount_currency"] + rec.igtf_amount
-                credit_line = credit_line_unrounded
+                credit_line = float_round(credit_line_unrounded, precision_digits=precision)
                
                 
                 credit_amount = abs(lines[1]["balance"])
-                amount = credit_amount
+                amount = float_round(credit_amount, precision_digits=precision)
                 igtf_base = 0.0
                 total_base_residual_converted = 0.0
-                precision_base = self.env.company.currency_id.decimal_places
-                if rec.igtf_amount > 0.0: 
+                
+                conversion_date = rec.env.context.get('l10n_ve_conversion_date') or rec.date
+                if rec.igtf_amount > 0.0:
+
+                    total_base_residual_converted = residual_currency._convert(
+                        total_base_residual,
+                        currency,
+                        rec.company_id,
+                        conversion_date,
+                    )
+
+                    total_base_residual_converted_with_igtf = float_round(abs(total_base_residual_converted) + abs(rec.igtf_amount), precision_digits=precision)
                     balance = abs(lines[0]["balance"])
-                    # for exedent payment and multipayment
-                    if balance - top_igtf_residual_base >= 1.0 and len(fechas_lista) == 1 and rec.date in fechas_lista: 
-                        igtf_base = top_igtf
-                        amount = credit_amount - igtf_base
+                    porcion_igtf = False
+                    if total_base_residual_converted_with_igtf == abs(lines[0]["amount_currency"]) or abs(lines[0]["amount_currency"]) > total_base_residual_converted_with_igtf: 
+                        
+                        igtf_base = currency._convert(float_round(rec.igtf_amount, precision_digits=precision_base), comp_curr, rec.company_id, conversion_date)
+                        credit_amount = currency._convert(
+                                abs(lines[1]["amount_currency"]), 
+                                rec.company_id.currency_id, 
+                                rec.company_id, 
+                                conversion_date,
+                            )
+                    
                     else:
 
                         porcion_igtf = rec.igtf_amount / abs(lines[0]["amount_currency"])
+
                         igtf_base = float_round((balance * porcion_igtf), precision_digits=precision_base)
-                        
-                        #Prevent apply more IGTF than
-                        if top_igtf - igtf_base  <= 0.1: 
-                            igtf_base = float_round(top_igtf,precision_digits=precision_base)
-
-                        amount = credit_amount - igtf_base
-                        
-                    total_base_residual_converted =  rec.company_id.currency_id._convert( 
-                        total_base_residual, 
-                        currency, 
-                        rec.company_id, 
-                        rec.date,
-                    )
-                        
-
-                    total_base_residual_converted_with_igtf = float_round(abs(total_base_residual_converted) + abs(rec.igtf_amount), precision_digits=precision)
-                    if total_base_residual_converted_with_igtf == abs(lines[0]["amount_currency"]): 
-                        #Ajust cxc balance
-                        if abs(credit_amount) > abs(total_base_residual):
-                            amount = abs(total_base_residual)
-
+                    amount = credit_amount - igtf_base
+                
 
                 if float_compare(rec.igtf_amount, 0.0, precision_digits=precision) > 0.0:
+                    base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual_signed')))
+                    if self._is_same_within_rounding(amount, base_residual, comp_curr):
+                        amount = base_residual
                     if not write_off_line_vals:
+                        
                         
                         vals[1].update({"amount_currency": credit_line, "balance": -amount})
                     else:
-                        
-                        vals[1].update({"balance": -total_base_residual})
+                        if conversion_date != rec.date: 
+                            vals[1].update({"amount_currency": credit_line,"balance": -amount})
+                        else:
+                            vals[1].update({"amount_currency": credit_line,"balance": -total_base_residual})
+
                 
                 if write_off_line_vals:
                     # Recalculate write-off balance to compensate the adjusted counterpart
@@ -546,65 +574,68 @@ class AccountPaymentAndIgtf(models.Model):
         for rec in self:
             lines = [line for line in vals]
             if rec.payment_type == "outbound":
-                
-                total_base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual_signed')))
-                top_igtf = abs(sum(rec.invoices_origin_ids.mapped('igtf_top_aply')))
+                invoice_currencies = rec.invoices_origin_ids.mapped('currency_id')
+                comp_curr = rec.company_id.currency_id
 
-                top_igtf_residual_base = total_base_residual + top_igtf
-                currency = rec.currency_id 
+                if invoice_currencies and invoice_currencies[0] == comp_curr:
+                    total_base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual_signed')))
+                    residual_currency = comp_curr
+                else:
+                    total_base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual')))
+                    residual_currency = invoice_currencies[0]
+
+                currency = rec.currency_id
                 precision = currency.decimal_places
-
-                debit_line_unrounded = lines[1]["amount_currency"] - rec.igtf_amount
-                debit_line = debit_line_unrounded
-               
-                
-                debit_amount = abs(lines[1]["balance"])
-                
-                amount = debit_amount
-                igtf_base = 0.0
-                total_base_residual_converted = 0.0
                 precision_base = self.env.company.currency_id.decimal_places
 
-                if rec.igtf_amount > 0.0: 
+                debit_line_unrounded = lines[1]["amount_currency"] - rec.igtf_amount
+                debit_line = float_round(debit_line_unrounded, precision_digits=precision)
 
-                    balance = abs(lines[0]["balance"])
-                    # for exedent payment and multipayment
-                    if balance - top_igtf_residual_base >= 1.0 or len(rec.invoices_origin_ids) > 1: 
-                        igtf_base = top_igtf
-                        amount = debit_amount - igtf_base
-                    else:
-                        
-                        porcion_igtf = rec.igtf_amount / abs(lines[0]["amount_currency"])
-                        igtf_base = float_round((balance * porcion_igtf), precision_digits=precision_base)
-                        
-                        #Prevent apply more IGTF than
-                        if top_igtf - igtf_base  <= 0.1: 
-                            igtf_base = float_round(top_igtf,precision_digits=precision_base)
+                debit_amount = abs(lines[1]["balance"])
+                amount = float_round(debit_amount, precision_digits=precision)
+                igtf_base = 0.0
+                total_base_residual_converted = 0.0
 
-                        amount = (debit_amount) - abs(igtf_base)
-                        
-                    total_base_residual_converted =  rec.company_id.currency_id._convert( 
-                        total_base_residual, 
-                        currency, 
-                        rec.company_id, 
-                        rec.date,
+                conversion_date = rec.env.context.get('l10n_ve_conversion_date') or rec.date
+                if rec.igtf_amount > 0.0:
+
+                    total_base_residual_converted = residual_currency._convert(
+                        total_base_residual,
+                        currency,
+                        rec.company_id,
+                        conversion_date,
                     )
-                        
 
                     total_base_residual_converted_with_igtf = float_round(abs(total_base_residual_converted) + abs(rec.igtf_amount), precision_digits=precision)
-                    if total_base_residual_converted_with_igtf == abs(lines[0]["amount_currency"]): 
-                        # Ajust cxp balance
-                        if abs(debit_amount) > abs(total_base_residual):
-                            amount = abs(total_base_residual)
-                
+                    balance = abs(lines[0]["balance"])
+                    if total_base_residual_converted_with_igtf == abs(lines[0]["amount_currency"]) or abs(lines[0]["amount_currency"]) > total_base_residual_converted_with_igtf:
+
+                        igtf_base = currency._convert(float_round(rec.igtf_amount, precision_digits=precision_base), comp_curr, rec.company_id, conversion_date)
+                        debit_amount = currency._convert(
+                                abs(lines[1]["amount_currency"]),
+                                rec.company_id.currency_id,
+                                rec.company_id,
+                                conversion_date,
+                            )
+
+                    else:
+
+                        porcion_igtf = rec.igtf_amount / abs(lines[0]["amount_currency"])
+                        igtf_base = float_round((balance * porcion_igtf), precision_digits=precision_base)
+                    amount = debit_amount - igtf_base
+
                 if float_compare(rec.igtf_amount, 0.0, precision_digits=precision) > 0.0:
+                    base_residual = abs(sum(rec.invoices_origin_ids.mapped('amount_residual_signed')))
+                    if self._is_same_within_rounding(amount, base_residual, comp_curr):
+                        amount = base_residual
                     if not write_off_line_vals:
 
-                        
                         vals[1].update({"amount_currency": debit_line, "balance": amount})
                     else:
-                        
-                        vals[1].update({"balance": total_base_residual})
+                        if conversion_date != rec.date:
+                            vals[1].update({"amount_currency": debit_line, "balance": amount})
+                        else:
+                            vals[1].update({"amount_currency": debit_line, "balance": total_base_residual})
                 
                 if write_off_line_vals:
                     # Recalculate write-off balance to compensate the adjusted counterpart

--- a/l10n_ve_igtf/models/l10n_ve_igtf_utils.py
+++ b/l10n_ve_igtf/models/l10n_ve_igtf_utils.py
@@ -17,12 +17,13 @@ class IGTFUtils(models.AbstractModel):
         precision = currency.rounding
         date_conver = payment_date if indexed_default else invoice.invoice_date
 
-        due_amount = self._convert_to_company_currency(
-            invoice.currency_id, invoice.amount_residual, date_conver, company
-        )
-        payment_amount = self._convert_to_company_currency(
-            payment_currency, amount_payment, date_conver, company
-        )
+        due_amount = invoice.amount_residual  # ya está en currency
+        if payment_currency == currency:
+            payment_amount = amount_payment
+        else:
+            payment_amount = payment_currency._convert(
+                amount_payment, currency, company, date_conver,
+            )
 
         principal_amount = min(payment_amount, due_amount)
         igtf_unrounded = principal_amount * (company.igtf_percentage / 100)
@@ -48,7 +49,9 @@ class IGTFUtils(models.AbstractModel):
             return 0.0
 
         if not base:
-            return self._convert_to_external_currency(payment_currency, igtf, date_conver, company)
+            if payment_currency == currency:
+                return igtf
+            return currency._convert(igtf, payment_currency, company, date_conver)
         return igtf
 
     @api.model

--- a/l10n_ve_igtf/tests/__init__.py
+++ b/l10n_ve_igtf/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_common_purchase_book_igtf_usd_provider_formal
 from . import test_purchase_book_igtf_usd_provider_formal
 from . import test_common_sale_book_igtf_usd_partner_formal
 from . import test_sale_book_igtf_usd_partner_formal
+from . import test_igtf_wizard_amounts

--- a/l10n_ve_igtf/tests/test_igtf_partner_formal_VEF.py
+++ b/l10n_ve_igtf/tests/test_igtf_partner_formal_VEF.py
@@ -613,8 +613,8 @@ class TestIGTFNEW(IGTFTestCommon):
         residual_advance = payment.advanced_move_ids[0]
 
         expected_lines = [
-            {'account': self.advance_cust_acc, 'amount_currency': -680.48},
-            {'account': self.acc_receivable, 'amount_currency': 680.48},
+            {'account': self.advance_cust_acc, 'amount_currency': -680.49},
+            {'account': self.acc_receivable, 'amount_currency': 680.49},
         ]
         self._assert_move_lines_equal(residual_advance, expected_lines)
 
@@ -628,13 +628,13 @@ class TestIGTFNEW(IGTFTestCommon):
         cross_move = self.env['account.move'].search([], order='id desc', limit=2)
 
         expected_lines = [
-            {'account': self.advance_cust_acc, 'amount_currency': 680.48},
-            {'account': self.acc_receivable, 'amount_currency': -660.07},
+            {'account': self.advance_cust_acc, 'amount_currency': 680.49},
+            {'account': self.acc_receivable, 'amount_currency': -660.08},
             {'account': self.acc_igtf_cli, 'amount_currency': -20.41 },
         ]
         self._assert_move_lines_equal(cross_move[1], expected_lines)
 
-        self.assert_invoice_values(invoice2, 561.7,  255.15, 'partial')
+        self.assert_invoice_values(invoice2, 561.71,  255.14, 'partial')
         
 
 
@@ -1009,11 +1009,11 @@ class TestIGTFNEW(IGTFTestCommon):
         expected_lines = [
             {
                 'account': self.account_bank_usd,      
-                'amount_currency': 5543.88,       
+                'amount_currency': 5543.87,
             },
             {
                 'account': self.acc_igtf_cli,  
-                'amount_currency': -161.48,       
+                'amount_currency': -161.47,
             },
             {
                 'account': self.acc_receivable,

--- a/l10n_ve_igtf/tests/test_igtf_partner_special_VEF.py
+++ b/l10n_ve_igtf/tests/test_igtf_partner_special_VEF.py
@@ -613,8 +613,8 @@ class TestIGTFNEW(IGTFTestCommon):
         residual_advance = payment.advanced_move_ids[0]
 
         expected_lines = [
-            {'account': self.advance_cust_acc, 'amount_currency': -680.48},
-            {'account': self.acc_receivable, 'amount_currency': 680.48},
+            {'account': self.advance_cust_acc, 'amount_currency': -680.49},
+            {'account': self.acc_receivable, 'amount_currency': 680.49},
         ]
         self._assert_move_lines_equal(residual_advance, expected_lines)
 
@@ -628,13 +628,13 @@ class TestIGTFNEW(IGTFTestCommon):
         cross_move = self.env['account.move'].search([], order='id desc', limit=2)
 
         expected_lines = [
-            {'account': self.advance_cust_acc, 'amount_currency': 680.48},
-            {'account': self.acc_receivable, 'amount_currency': -660.07},
+            {'account': self.advance_cust_acc, 'amount_currency': 680.49},
+            {'account': self.acc_receivable, 'amount_currency': -660.08},
             {'account': self.acc_igtf_cli, 'amount_currency': -20.41 },
         ]
         self._assert_move_lines_equal(cross_move[1], expected_lines)
 
-        self.assert_invoice_values(invoice2, 561.7,  255.15, 'partial')
+        self.assert_invoice_values(invoice2, 561.71,  255.14, 'partial')
 
         
 
@@ -1010,11 +1010,11 @@ class TestIGTFNEW(IGTFTestCommon):
         expected_lines = [
             {
                 'account': self.account_bank_usd,      
-                'amount_currency': 5543.88,       
+                'amount_currency': 5543.87,
             },
             {
                 'account': self.acc_igtf_cli,  
-                'amount_currency': -161.48,       
+                'amount_currency': -161.47,
             },
             {
                 'account': self.acc_receivable,

--- a/l10n_ve_igtf/tests/test_igtf_providers_formal_VEF.py
+++ b/l10n_ve_igtf/tests/test_igtf_providers_formal_VEF.py
@@ -612,8 +612,8 @@ class TestIGTFNEW(IGTFTestCommon):
         residual_advance = payment.advanced_move_ids[0]
 
         expected_lines = [
-            {'account': self.advance_supp_acc, 'amount_currency': -680.48},
-            {'account': self.acc_payable, 'amount_currency': 680.48},
+            {'account': self.advance_supp_acc, 'amount_currency': -680.49},
+            {'account': self.acc_payable, 'amount_currency': 680.49},
         ]
         self._assert_move_lines_equal(residual_advance, expected_lines)
 
@@ -627,13 +627,13 @@ class TestIGTFNEW(IGTFTestCommon):
         cross_move = self.env['account.move'].search([], order='id desc', limit=2)
 
         expected_lines = [
-            {'account': self.advance_supp_acc, 'amount_currency': -680.48},
-            {'account': self.acc_payable, 'amount_currency': 660.07},
+            {'account': self.advance_supp_acc, 'amount_currency': -680.49},
+            {'account': self.acc_payable, 'amount_currency': 660.08},
             {'account': self.acc_igtf_prov, 'amount_currency': 20.41 },
         ]
         self._assert_move_lines_equal(cross_move[0], expected_lines)
 
-        self.assert_invoice_values(invoice2, 561.7,  255.15, 'partial')
+        self.assert_invoice_values(invoice2, 561.71,  255.14, 'partial')
 
         
 
@@ -1014,11 +1014,11 @@ class TestIGTFNEW(IGTFTestCommon):
         expected_lines = [
             {
                 'account': self.account_bank_usd,      
-                'amount_currency': -5543.88,       
+                'amount_currency': -5543.87,
             },
             {
                 'account': self.acc_igtf_prov,  
-                'amount_currency': 161.48,       
+                'amount_currency': 161.47,
             },
             {
                 'account': self.acc_payable,

--- a/l10n_ve_igtf/tests/test_igtf_providers_special_VEF.py
+++ b/l10n_ve_igtf/tests/test_igtf_providers_special_VEF.py
@@ -612,8 +612,8 @@ class TestIGTFNEW(IGTFTestCommon):
         residual_advance = payment.advanced_move_ids[0]
 
         expected_lines = [
-            {'account': self.advance_supp_acc, 'amount_currency': -680.48},
-            {'account': self.acc_payable, 'amount_currency': 680.48},
+            {'account': self.advance_supp_acc, 'amount_currency': -680.49},
+            {'account': self.acc_payable, 'amount_currency': 680.49},
         ]
         self._assert_move_lines_equal(residual_advance, expected_lines)
 
@@ -627,13 +627,13 @@ class TestIGTFNEW(IGTFTestCommon):
         cross_move = self.env['account.move'].search([], order='id desc', limit=2)
 
         expected_lines = [
-            {'account': self.advance_supp_acc, 'amount_currency': -680.48},
-            {'account': self.acc_payable, 'amount_currency': 660.07},
+            {'account': self.advance_supp_acc, 'amount_currency': -680.49},
+            {'account': self.acc_payable, 'amount_currency': 660.08},
             {'account': self.acc_igtf_prov, 'amount_currency': 20.41 },
         ]
         self._assert_move_lines_equal(cross_move[0], expected_lines)
 
-        self.assert_invoice_values(invoice2, 561.7,  255.15, 'partial')
+        self.assert_invoice_values(invoice2, 561.71,  255.14, 'partial')
 
     def test11_payment_from_invoice_with_igtf_journal(self):
 
@@ -1011,11 +1011,11 @@ class TestIGTFNEW(IGTFTestCommon):
         expected_lines = [
             {
                 'account': self.account_bank_usd,      
-                'amount_currency': -5543.88,       
+                'amount_currency': -5543.87,
             },
             {
                 'account': self.acc_igtf_prov,  
-                'amount_currency': 161.48,       
+                'amount_currency': 161.47,
             },
             {
                 'account': self.acc_payable,

--- a/l10n_ve_igtf/tests/test_igtf_wizard_amounts.py
+++ b/l10n_ve_igtf/tests/test_igtf_wizard_amounts.py
@@ -1,0 +1,152 @@
+import logging
+
+from odoo.tests import tagged
+from odoo import fields
+
+from odoo.addons.l10n_ve_accountant.tests.test_indexed_payments import TestIndexedPayments
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install", "l10n_ve_igtf_wizard_amounts")
+class TestIgtfWizardAmounts(TestIndexedPayments):
+    """
+    Validates the l10n_ve_igtf overrides of account.payment.register's
+    _compute_amount / _onchange_amount / _compute_payment_difference, and the
+    _is_same_within_rounding helper used to reconcile amounts computed via
+    different currency-conversion paths.
+
+    Reuses TestIndexedPayments' setUp (fresh company, VEF/USD/EUR, rates,
+    accounts, journals, partner, product, tax) instead of rebuilding fixtures,
+    and enables IGTF manually on the wizard (bypassing the is_igtf compute,
+    which depends on partner/journal classification not part of this
+    fixture) to isolate the amount-calculation logic under test.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.company.igtf_percentage = 3.0
+
+    def _create_igtf_wizard(self, invoice, amount=None):
+        journal = self._get_foreign_bank_journal(self.currency_usd)
+        vals = {
+            "journal_id": journal.id,
+            "currency_id": self.currency_usd.id,
+            "payment_date": self.payment_date,
+        }
+        if amount is not None:
+            vals["amount"] = amount
+        wizard = self.env["account.payment.register"].with_context(
+            active_model="account.move", active_ids=invoice.ids, active_id=invoice.id,
+        ).create(vals)
+        wizard.is_igtf = True
+        return wizard
+
+    def test_onchange_amount_does_not_stick_custom_user_amount(self):
+        """Re-triggering _onchange_amount with the amount the system itself
+        proposed must not mark custom_user_amount, and must not shift
+        amount_without_difference -- otherwise the wizard would visibly
+        recompute IGTF on an amount that already includes IGTF right before
+        the user hits "Pagar"."""
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.payment_date, 40.0)
+
+        invoice = self._create_foreign_invoice(self.currency_usd, amount=100.0)
+        wizard = self._create_igtf_wizard(invoice)
+
+        first_amount_without_difference = wizard.amount_without_difference
+        self.assertFalse(wizard.custom_user_amount)
+
+        wizard._onchange_amount()
+
+        self.assertFalse(
+            wizard.custom_user_amount,
+            "custom_user_amount must stay cleared when the amount matches the system's own proposal.",
+        )
+        self.assertAlmostEqual(
+            wizard.amount_without_difference, first_amount_without_difference, places=2,
+            msg="amount_without_difference must not shift on a no-op onchange re-trigger.",
+        )
+
+    def test_amount_without_difference_shows_debt_when_underpaying_with_reconcile(self):
+        """Paying less than owed, with the difference reconciled (not left
+        open) to a loss account, must keep amount_without_difference showing
+        the real debt -- not "typed amount minus IGTF"."""
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.payment_date, 40.0)
+
+        invoice = self._create_foreign_invoice(self.currency_usd, amount=100.0)
+        wizard = self._create_igtf_wizard(invoice)
+        debt = wizard.amount_without_difference  # the real debt, from the default (non-edited) proposal
+
+        wizard.payment_difference_handling = "reconcile"
+        wizard.amount = 50.0  # underpay: triggers custom_user_amount
+
+        self.assertAlmostEqual(
+            wizard.amount_without_difference, debt, places=2,
+            msg="Underpaying with reconcile must anchor amount_without_difference to the real debt.",
+        )
+
+    def test_amount_without_difference_uses_typed_amount_when_left_open(self):
+        """Same underpayment, but leaving the difference open (not
+        reconciled): amount_without_difference falls back to the typed
+        amount minus IGTF, since there's no write-off to anchor to a fixed
+        debt figure."""
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.payment_date, 40.0)
+
+        invoice = self._create_foreign_invoice(self.currency_usd, amount=100.0)
+        wizard = self._create_igtf_wizard(invoice)
+
+        wizard.payment_difference_handling = "open"
+        wizard.amount = 50.0
+
+        self.assertAlmostEqual(
+            wizard.amount_without_difference, wizard.amount - wizard.igtf_amount, places=2,
+            msg="Left-open underpayment must use typed amount minus IGTF, not the full debt.",
+        )
+
+    def test_payment_difference_is_debt_minus_effective_amount(self):
+        """payment_difference is computed as amount_for_difference (the debt)
+        minus effective_amount (amount typed minus the IGTF recalculated on
+        that same typed amount) -- current behavior, regardless of
+        payment_difference_handling."""
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.payment_date, 40.0)
+
+        invoice = self._create_foreign_invoice(self.currency_usd, amount=100.0)
+        wizard = self._create_igtf_wizard(invoice)
+        total_amount_values = wizard._get_total_amounts_to_pay(wizard.batches)
+        debt = total_amount_values["amount_by_default"]
+
+        wizard.payment_difference_handling = "reconcile"
+        wizard.amount = 50.0
+
+        igtf_on_amount = 0.0
+        for rec in wizard.get_moves():
+            igtf_on_amount += wizard.calculate_igtf_for_payment(
+                rec, wizard.amount, wizard.currency_id, wizard.payment_date,
+            )
+        effective_amount = abs(wizard.amount) - abs(igtf_on_amount)
+
+        self.assertAlmostEqual(
+            wizard.payment_difference, debt - effective_amount, places=2,
+            msg="payment_difference must equal amount_for_difference (debt) minus effective_amount.",
+        )
+
+    def test_is_same_within_rounding_helper(self):
+        """Direct unit test of the rounding-tolerance helper: a one-cent
+        difference (one full VEF rounding unit) must be treated as the same
+        amount, while a real, larger discrepancy must not be absorbed."""
+        payment_model = self.env["account.payment"]
+        comp_curr = self.currency_vef
+        comp_curr.rounding = 0.01
+
+        self.assertTrue(
+            payment_model._is_same_within_rounding(21759665.40, 21759665.39, comp_curr),
+            "A one-unit rounding difference must be considered the same amount.",
+        )
+        self.assertFalse(
+            payment_model._is_same_within_rounding(21759665.40, 21730605.49, comp_curr),
+            "A large, real discrepancy must not be absorbed as rounding noise.",
+        )

--- a/l10n_ve_igtf/wizard/account_payment_register.py
+++ b/l10n_ve_igtf/wizard/account_payment_register.py
@@ -76,7 +76,7 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
     
     @api.depends('can_edit_wizard', 'source_amount', 'source_amount_currency', 'source_currency_id',
                  'company_id', 'currency_id', 'payment_date', 'installments_mode', 'is_igtf',
-                 'custom_user_amount')
+                 'custom_user_amount', 'payment_difference_handling')
     def _compute_amount(self):
         igtf_wizards = self.filtered(lambda w: w.is_igtf)
         other_wizards = self - igtf_wizards
@@ -85,6 +85,7 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
             return super(AccountPaymentRegisterIgtf, other_wizards)._compute_amount()
 
         for wizard in igtf_wizards:
+            total_amount_values = wizard._get_total_amounts_to_pay(wizard.batches)
             if not wizard.journal_id or not wizard.currency_id or not wizard.payment_date or not wizard.is_igtf:
                 wizard.amount = wizard.amount or 0.0
                 wizard.igtf_to_show = 0.0
@@ -100,10 +101,19 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
                     )
                 wizard.igtf_to_show = abs(igtf)
                 wizard.igtf_amount = abs(igtf)
-                wizard.amount_without_difference = wizard.amount - abs(igtf)
+
+                total_amount_values = wizard._get_total_amounts_to_pay(wizard.batches)
+                is_different = wizard.currency_id.compare_amounts(
+                    wizard.amount, total_amount_values['amount_by_default'] + abs(igtf)
+                ) != 0
+                if is_different and wizard.payment_difference_handling != 'open':
+
+                    wizard.amount_without_difference = abs(total_amount_values['amount_by_default'])
+                else:
+                    wizard.amount_without_difference = wizard.amount - abs(igtf)
 
             else:
-                total_amount_values = wizard._get_total_amounts_to_pay(wizard.batches)
+                
                 move_ids = self.get_moves()
                 igtf = 0.0
                 for rec in move_ids:
@@ -135,7 +145,7 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
                     igtf += self.calculate_igtf_for_payment(
                         rec, wizard.amount, wizard.currency_id, wizard.payment_date,
                     )
-                efective_amount = abs(wizard.amount) - abs(wizard.igtf_amount)
+                efective_amount = abs(wizard.amount) - abs(igtf)
                 if wizard.installments_mode in ('overdue', 'next', 'before_date'):
                     wizard.payment_difference = total_amount_values['amount_for_difference'] - efective_amount
                 elif wizard.installments_mode == 'full':
@@ -181,16 +191,20 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
             super(AccountPaymentRegisterIgtf, other_wizards)._onchange_amount()
 
         for payment in igtf_wizards:
-            diff = payment.amount - payment.last_computed_amount
-            if float_is_zero(diff, precision_rounding=payment.currency_id.rounding):
-                continue
-
+            total_amount_values = payment._get_total_amounts_to_pay(payment.batches)
             move_ids = self.get_moves()
             igtf = 0.0
             for rec in move_ids:
                 igtf += self.calculate_igtf_for_payment(
                     rec, payment.amount, payment.currency_id, payment.payment_date,
                 )
+            natural_amount = total_amount_values['amount_by_default'] + abs(igtf)
+
+            if payment.currency_id.is_zero(payment.amount - natural_amount):
+                payment.custom_user_amount = False
+                payment.last_computed_amount = payment.amount
+                continue
+
             payment.igtf_to_show = abs(igtf)
             payment.igtf_amount = abs(igtf)
             payment.amount_without_difference = payment.amount - abs(igtf)
@@ -373,7 +387,9 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
         if currency != self.currency_id.id:
             currency = self.env['res.currency'].browse(currency)
             source_amount = invoice_ids.amount_residual
-            new_val = self.company_id.currency_id._convert(source_amount, self.currency_id, self.company_id, self.payment_date) + batch_values['igtf_amount']
+            new_val = currency._convert(
+                source_amount, self.currency_id, self.company_id, self._get_conversion_date(),
+            ) + batch_values['igtf_amount']
 
         payment_vals = {
             'date': self.payment_date,
@@ -406,16 +422,17 @@ class AccountPaymentRegisterIgtf(models.TransientModel):
         if total_amount_values['epd_applied']:
             payment_vals['amount'] = total_amount
             epd_aml_values_list = []
+            conversion_date = self._get_conversion_date()
             for aml in batch_result['lines']:
                 if aml.move_id._is_eligible_for_early_payment_discount(currency, self.payment_date):
                     epd_aml_values_list.append({
                         'aml': aml,
                         'amount_currency': -aml.amount_residual_currency,
-                        'balance': currency._convert(-aml.amount_residual_currency, aml.company_currency_id, self.company_id, self.payment_date),
+                        'balance': currency._convert(-aml.amount_residual_currency, aml.company_currency_id, self.company_id, conversion_date),
                     })
 
             open_amount_currency = (batch_values['source_amount_currency'] - total_amount) * (-1 if batch_values['payment_type'] == 'outbound' else 1)
-            open_balance = currency._convert(open_amount_currency, aml.company_currency_id, self.company_id, self.payment_date)
+            open_balance = currency._convert(open_amount_currency, aml.company_currency_id, self.company_id, conversion_date)
             early_payment_values = self.env['account.move']\
                 ._get_invoice_counterpart_amls_for_early_payment_discount(epd_aml_values_list, open_balance)
             for aml_values_list in early_payment_values.values():

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.9",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -445,13 +445,17 @@ msgid "Invoice Configuration"
 msgstr "Configuración de Facturación"
 
 #. module: l10n_ve_invoice
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__invoice_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__invoice_date_display_datetime
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__invoice_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__invoice_date_display_datetime
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice.l10n_ve_invoice_view_invoice_tree_datetime
 msgid "Invoice Date"
 msgstr "Fecha de factura"
+
+#. module: l10n_ve_invoice
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__invoice_date
+#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__invoice_date
+msgid "Rate Date"
+msgstr "Fecha de tasa"
 
 #. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__is_contingency

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -17,7 +17,7 @@ class AccountMove(models.Model):
     declaration_unique_of_customs = fields.Char('Declaration unique of customs', copy=False)
 
     invoice_date = fields.Date(
-        string="Invoice Date",
+        string="Rate Date",
         default=fields.Date.context_today,
         help="Date of the invoice. Defaults to today when creating a new invoice."
     )
@@ -116,11 +116,6 @@ class AccountMove(models.Model):
                 if not from_pos and not from_loyalty:
                     raise ValidationError(_("An invoice cannot have a line with a price of zero"))
 
-    @api.onchange("move_type")
-    def _onchange_move_type(self):
-        super()._onchange_move_type()
-        if self.move_type == "out_invoice":
-            self.invoice_date = fields.Date.context_today(self)
 
     def action_post(self):
         

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -118,6 +118,7 @@ class AccountMove(models.Model):
 
     @api.onchange("move_type")
     def _onchange_move_type(self):
+        super()._onchange_move_type()
         if self.move_type == "out_invoice":
             self.invoice_date = fields.Date.context_today(self)
 

--- a/l10n_ve_invoice/tests/test_cancel_visibility.py
+++ b/l10n_ve_invoice/tests/test_cancel_visibility.py
@@ -132,7 +132,8 @@ class TestCancelVisibility(TransactionCase):
             return
         self.company.taxpayer_type = 'special'
         
-        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+        with patch('odoo.fields.Date.context_today', return_value=datetime.date(2025, 10, 14)), \
+             patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
             mock_date.today.return_value = datetime.date(2025, 10, 14)
             mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
 
@@ -146,7 +147,8 @@ class TestCancelVisibility(TransactionCase):
             return
         self.company.taxpayer_type = 'special'
         
-        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+        with patch('odoo.fields.Date.context_today', return_value=datetime.date(2025, 10, 16)), \
+             patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
             mock_date.today.return_value = datetime.date(2025, 10, 16)
             mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
 
@@ -158,7 +160,8 @@ class TestCancelVisibility(TransactionCase):
         """Vendor Bill: Should always be True"""
         self.company.taxpayer_type = 'ordinary'
         
-        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+        with patch('odoo.fields.Date.context_today', return_value=datetime.date(2025, 12, 1)), \
+             patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
             mock_date.today.return_value = datetime.date(2025, 12, 1)
             mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
 

--- a/l10n_ve_invoice/tests/test_cancel_visibility.py
+++ b/l10n_ve_invoice/tests/test_cancel_visibility.py
@@ -96,7 +96,8 @@ class TestCancelVisibility(TransactionCase):
         # Invoice: 2025-10-29
         # Expect: True
         
-        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+        with patch('odoo.fields.Date.context_today', return_value=datetime.date(2025, 10, 30)), \
+             patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
             mock_date.today.return_value = datetime.date(2025, 10, 30)
             mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
 
@@ -116,7 +117,8 @@ class TestCancelVisibility(TransactionCase):
         # Invoice: 2025-10-29
         # Expect: False
         
-        with patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
+        with patch('odoo.fields.Date.context_today', return_value=datetime.date(2025, 11, 1)), \
+             patch('odoo.addons.l10n_ve_invoice.models.account_move.date') as mock_date:
             mock_date.today.return_value = datetime.date(2025, 11, 1)
             mock_date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
 

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.24",
+    "version": "19.0.2.0.25",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_payment.py
+++ b/l10n_ve_payment_extension/models/account_payment.py
@@ -84,6 +84,32 @@ class AccountPayment(models.Model):
             move.write(vals_to_change)
         return res
 
+    def _generate_move_vals(self, write_off_line_vals=None, force_balance=None, line_ids=None):
+        """
+        A retention payment's move must land in the same fiscal period as (and use
+        the same exchange rate as) the invoice it retains from, even though
+        payment.date stays as the retention's own date_accounting chosen by the
+        user. Writing move.date after the move is created/posted is NOT enough
+        (and was tried and reverted): the move's amounts are already computed
+        using payment.date's rate at generation time, so forcing only the date
+        label afterwards desyncs date from the rate actually used, producing a
+        bogus exchange difference on reconciliation. Instead, inject
+        l10n_ve_conversion_date (read by l10n_ve_accountant's
+        _prepare_move_lines_per_type override) BEFORE generating the move, so the
+        liquidity line is converted with the invoice's rate, then align 'date' to
+        that same value so the two never drift apart.
+        """
+        self.ensure_one()
+        if self.is_retention and self.retention_line_ids:
+            invoice_date = self.retention_line_ids[0].move_id.date
+            if invoice_date:
+                vals = super(
+                    AccountPayment, self.with_context(l10n_ve_conversion_date=invoice_date)
+                )._generate_move_vals(write_off_line_vals, force_balance, line_ids)
+                vals['date'] = invoice_date
+                return vals
+        return super()._generate_move_vals(write_off_line_vals, force_balance, line_ids)
+
     def unlink(self):
         for payment in self:
             if any(isinstance(id, api.NewId) for id in self.retention_line_ids.ids):

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -2,10 +2,10 @@ from odoo import api, models, fields, Command, _
 from datetime import datetime
 import re
 from odoo.exceptions import UserError, ValidationError
+from odoo.addons.account.models.account_move import BYPASS_LOCK_CHECK
 from ..utils.utils_retention import load_retention_lines, search_invoices_with_taxes
 from collections import defaultdict
 import json
-from odoo.tools.float_utils import float_round
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -703,7 +703,13 @@ class AccountRetention(models.Model):
         if not payments:
             raise UserError(_("No payments found for reconciliation."))
 
-        payments.action_post()
+        # These payments' moves are pinned to their invoice's own accounting date
+        # (see AccountPayment._generate_move_vals), which can already sit in a
+        # closed fiscal period by the time the retention itself is processed --
+        # bypass_lock_check is the core's own escape hatch for that check, only
+        # triggered here by the state -> 'posted' transition (not by writing
+        # 'date', which never happens after creation).
+        payments.with_context(bypass_lock_check=BYPASS_LOCK_CHECK).action_post()
 
         account_type_map = {
             "supplier": "liability_payable",
@@ -941,8 +947,15 @@ class AccountRetention(models.Model):
             "currency_id": self.env.company.currency_id.id,
             "date": self.date_accounting
         }
-        
+
         if not is_refund and has_subsidiary and self.env.company.subsidiary:
             res["account_analytic_id"] = move.account_analytic_id.id
+
+        # l10n_ve_igtf's js_assign_outstanding_line picks conversion_date over
+        # payment.date for the advance-crossing move's date/rate unless this is
+        # set, which would misprice the crossed amount against the retention's
+        # own date_accounting. Guarded since l10n_ve_igtf isn't a hard dependency.
+        if "keep_alter_value_vef" in self.env["account.payment"]._fields:
+            res["keep_alter_value_vef"] = True
 
         return res

--- a/l10n_ve_payment_extension/tests/__init__.py
+++ b/l10n_ve_payment_extension/tests/__init__.py
@@ -29,3 +29,4 @@ from . import test_wizard_accounting_reports_full
 from . import test_data_files
 from . import test_allowed_lines_move_ids
 from . import test_retention_line_compute_amounts
+from . import test_retention_payment_move_date

--- a/l10n_ve_payment_extension/tests/test_retention_payment_move_date.py
+++ b/l10n_ve_payment_extension/tests/test_retention_payment_move_date.py
@@ -1,0 +1,261 @@
+import logging
+
+from odoo.addons.account.models.account_payment import AccountPayment as CoreAccountPayment
+from odoo.tests import tagged, Form
+from odoo import Command, fields
+
+from .test_withholding_common_VEF import RetentionTestCommon
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install", "retention_payment_move_date")
+class TestRetentionPaymentMoveDate(RetentionTestCommon):
+    """Covers the fix in AccountPayment._generate_move_vals /
+    AccountRetention._reconcile_all_payments: a retention payment's journal
+    entry must be dated (and rated) like the invoice it retains from, not
+    like the retention's own date_accounting, even though payment.date keeps
+    showing date_accounting in the UI."""
+
+    def setUp(self):
+        super().setUp()
+        self.invoice_date = fields.Date.today().replace(day=1)
+        self.date_accounting = fields.Date.today()
+
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+        self._set_rate(self.currency_usd, self.date_accounting, 60.0)
+
+        # purchase_journal (RetentionTestCommon) forces VEF
+        # (_check_constrains_account_id_journal_id, l10n_ve_accountant); this
+        # invoice needs a journal without a forced currency so it can be
+        # booked in USD.
+        self.purchase_journal_usd = self.env["account.journal"].create({
+            "name": "Diario Compra USD",
+            "type": "purchase",
+            "code": "PURUS",
+            "company_id": self.company.id,
+        })
+
+    def _set_rate(self, currency, date, inverse_company_rate):
+        currency_rate = self.env["res.currency.rate"].search(
+            [
+                ("name", "=", date),
+                ("currency_id", "=", currency.id),
+                ("company_id", "=", self.company.id),
+            ],
+            limit=1,
+        )
+        if currency_rate:
+            currency_rate.write({"inverse_company_rate": inverse_company_rate})
+            return currency_rate
+        return self.env["res.currency.rate"].create(
+            {
+                "name": date,
+                "currency_id": currency.id,
+                "inverse_company_rate": inverse_company_rate,
+                "company_id": self.company.id,
+            }
+        )
+
+    def _create_foreign_invoice(self, amount=200.0):
+        """Purchase invoice booked in USD (foreign currency), while the
+        retention payment is always created in company currency (VEF, see
+        AccountRetention._prepare_retention_payment_vals) -- the combination
+        that exposes a rate mismatch on reconciliation if the payment's move
+        isn't pinned to the invoice's own date/rate.
+
+        Built through Form (like RetentionTestCommon._create_invoice_reten_iva)
+        instead of a raw .create(vals): the fiscal-position/tax onchange chain
+        needs to run for product_iva's taxes to resolve correctly on this
+        partner/company, exactly like the rest of this test suite already
+        does."""
+        with Form(self.env["account.move"].with_context(
+            default_move_type="in_invoice", default_journal_id=self.purchase_journal_usd.id,
+        )) as inv_form:
+            inv_form.partner_id = self.partner_pnr_75
+            inv_form.invoice_date = self.invoice_date
+            inv_form.currency_id = self.currency_usd
+            inv_form.correlative = "12345678901234"
+        invoice = inv_form.save()
+
+        with Form(invoice) as inv_form_edit:
+            with inv_form_edit.invoice_line_ids.new() as line:
+                line.product_id = self.product_iva
+                line.quantity = 1
+                line.price_unit = amount
+        invoice = inv_form_edit.save()
+
+        invoice.write({"date": self.invoice_date, "invoice_date_display": self.invoice_date})
+        invoice.action_post()
+        return invoice
+
+    def _exchange_diff_moves(self, invoice):
+        ap_lines = invoice.line_ids.filtered(
+            lambda l: l.account_id.account_type == "liability_payable"
+        )
+        partials = ap_lines.matched_credit_ids | ap_lines.matched_debit_ids
+        return partials.mapped("exchange_move_id").filtered(lambda m: m)
+
+    def test_retention_payment_move_uses_invoice_date_and_rate(self):
+        invoice = self._create_foreign_invoice(amount=200.0)
+        invoice_total_vef = abs(invoice.amount_residual_signed)
+        retention_amount_vef = invoice_total_vef * 0.10
+
+        retention = self.env["account.retention"].create({
+            "type_retention": "iva",
+            "type": "in_invoice",
+            "company_id": self.company.id,
+            "partner_id": self.partner_pnr_75.id,
+            "date": self.date_accounting,
+            "date_accounting": self.date_accounting,
+            "number": "01234567891234",
+            "retention_line_ids": [Command.create({
+                "move_id": invoice.id,
+                "name": "IVA Line",
+                "invoice_total": invoice_total_vef,
+                "invoice_amount": 200.0,
+                "retention_amount": retention_amount_vef,
+                "foreign_invoice_amount": 200.0,
+                "foreign_retention_amount": 20.0,
+                "foreign_currency_rate": 1.0,
+            })],
+        })
+
+        retention.action_post()
+
+        payment = retention.payment_ids
+        self.assertEqual(len(payment), 1, "Exactly one payment must be created for the single invoice retained.")
+
+        # payment.date (shown in the UI) keeps the user-chosen retention date.
+        self.assertEqual(
+            payment.date, self.date_accounting,
+            "payment.date must still reflect the retention's own date_accounting.",
+        )
+
+        # The move behind that payment must instead be dated like the invoice.
+        self.assertEqual(
+            payment.move_id.date, invoice.date,
+            "The retention payment's journal entry must be dated like the "
+            "invoice it retains from, not like date_accounting.",
+        )
+
+        # Since the move now shares the invoice's date, it must also share its
+        # rate: reconciling them must NOT produce an exchange difference.
+        self.assertFalse(
+            self._exchange_diff_moves(invoice),
+            "A retention payment must never generate an exchange difference "
+            "against the invoice it retains from.",
+        )
+
+    def test_retention_payment_generate_move_vals_pins_invoice_date(self):
+        """Direct unit check on the overridden hook itself: _generate_move_vals
+        must inject the invoice's own date as 'date' in the vals used to build
+        the payment's move, precisely because payment.date (date_accounting)
+        is not it."""
+        invoice = self._create_foreign_invoice(amount=200.0)
+        invoice_total_vef = abs(invoice.amount_residual_signed)
+
+        retention = self.env["account.retention"].create({
+            "type_retention": "iva",
+            "type": "in_invoice",
+            "company_id": self.company.id,
+            "partner_id": self.partner_pnr_75.id,
+            "date": self.date_accounting,
+            "date_accounting": self.date_accounting,
+            "number": "01234567891235",
+            "retention_line_ids": [Command.create({
+                "move_id": invoice.id,
+                "name": "IVA Line",
+                "invoice_total": invoice_total_vef,
+                "invoice_amount": 200.0,
+                "retention_amount": invoice_total_vef * 0.10,
+                "foreign_invoice_amount": 200.0,
+                "foreign_retention_amount": 20.0,
+                "foreign_currency_rate": 1.0,
+            })],
+        })
+        payment_vals = retention._prepare_retention_payment_vals(
+            invoice, retention.retention_line_ids
+        )
+        self.assertEqual(
+            payment_vals["date"], self.date_accounting,
+            "The payment itself must still be dated with date_accounting.",
+        )
+
+        payment = self.env["account.payment"].create(payment_vals)
+        payment.retention_line_ids = retention.retention_line_ids
+
+        move_vals = payment._generate_move_vals()
+        self.assertEqual(
+            move_vals.get("date"), invoice.date,
+            "_generate_move_vals must override 'date' to the invoice's own "
+            "accounting date once the payment is linked to its retention_line_ids, "
+            "instead of leaving payment.date (date_accounting) as the move's date.",
+        )
+
+    def test_regression_without_conversion_date_context_move_uses_date_accounting(self):
+        """Regression test: reproduces exactly what happened before this fix.
+
+        AccountPayment._generate_move_vals only pins the move to the
+        invoice's date because IT injects l10n_ve_conversion_date into the
+        context itself before calling super(). If that injection never
+        happened -- i.e. the context never reached the payment, which is
+        exactly the state of the code before the fix -- core Odoo's own
+        _generate_move_vals falls back to 'date': self.date (payment.date,
+        which for a retention payment is date_accounting). We reproduce that
+        exact pre-fix code path by calling the core implementation directly,
+        bypassing AccountPayment._generate_move_vals's override entirely."""
+        invoice = self._create_foreign_invoice(amount=200.0)
+        invoice_total_vef = abs(invoice.amount_residual_signed)
+
+        retention = self.env["account.retention"].create({
+            "type_retention": "iva",
+            "type": "in_invoice",
+            "company_id": self.company.id,
+            "partner_id": self.partner_pnr_75.id,
+            "date": self.date_accounting,
+            "date_accounting": self.date_accounting,
+            "number": "01234567891236",
+            "retention_line_ids": [Command.create({
+                "move_id": invoice.id,
+                "name": "IVA Line",
+                "invoice_total": invoice_total_vef,
+                "invoice_amount": 200.0,
+                "retention_amount": invoice_total_vef * 0.10,
+                "foreign_invoice_amount": 200.0,
+                "foreign_retention_amount": 20.0,
+                "foreign_currency_rate": 1.0,
+            })],
+        })
+        payment_vals = retention._prepare_retention_payment_vals(
+            invoice, retention.retention_line_ids
+        )
+        payment = self.env["account.payment"].create(payment_vals)
+        payment.retention_line_ids = retention.retention_line_ids
+
+        # Sanity check: this scenario must actually have distinct dates,
+        # otherwise the assertions below would pass even without the bug.
+        self.assertNotEqual(
+            self.date_accounting, invoice.date,
+            "date_accounting and the invoice's date must differ in this "
+            "scenario for the regression check below to mean anything.",
+        )
+        # Bypass the fix: call core Odoo's _generate_move_vals directly, as
+        # if AccountPayment._generate_move_vals (and its
+        # l10n_ve_conversion_date injection) did not exist -- the exact
+        # situation before this module carried the fix.
+        move_vals_without_context = CoreAccountPayment._generate_move_vals(payment)
+
+        self.assertEqual(
+            move_vals_without_context["date"], self.date_accounting,
+            "Without the l10n_ve_conversion_date injection reaching the "
+            "payment, the move falls back to payment.date (date_accounting) "
+            "instead of the invoice's own date -- this is the exact "
+            "regression this fix prevents.",
+        )
+        self.assertNotEqual(
+            move_vals_without_context["date"], invoice.date,
+            "Confirms the pre-fix 'date' does NOT match the invoice, unlike "
+            "the fixed _generate_move_vals covered by "
+            "test_retention_payment_generate_move_vals_pins_invoice_date.",
+        )


### PR DESCRIPTION
[FIX] l10n_ve_accountant, l10n_ve_igtf: pagos indexados/no indexados usaban la tasa equivocada y el IGTF arrastraba descuadres de redondeo

Pagos indexados/no indexados (l10n_ve_accountant)
-------------------------------------------------- _compute_rates calculaba la tasa de conversión siempre con payment.payment_date, sin importar si el pago estaba marcado como "indexado" o "no indexado" (indexed_default). Ejemplo: una factura del 01/01 a tasa 40 Bs/USD, pagada como NO indexada el 15/01 a tasa 45, debía usar 40 (tasa de la factura) pero el sistema usaba 45 (tasa del día del pago). Además @api.depends no incluía indexed_default ni payment_date, por lo que el campo ni siquiera se recalculaba al cambiar esas opciones en el wizard.

_convert_to_wizard_currency reutilizaba amount_residual directo como atajo cada vez que indexed_default=True, sin verificar que la fecha de pago coincidiera con la fecha de factura, produciendo descuadres cuando un pago indexado se registraba en fecha distinta a la de la factura.

En pagos con write-off (sobrepago/subpago a cuentas de ganancia/ pérdida), el balance de la línea de ajuste seguía calculado con payment_date aunque el pago fuera no-indexado, descuadrando amount_currency contra balance en la misma línea.

Se corrige todo el flujo para usar de forma consistente payment._get_conversion_date() (fecha de factura para no-indexados, fecha de pago para indexados), propagada también hacia account.payment vía el contexto l10n_ve_conversion_date (_create_payments), de modo que la línea de liquidez y foreign_rate/other_rate (campos computados que antes se recalculaban solos con payment.date y pisaban silenciosamente la tasa correcta) respeten la misma fecha de conversión.

Se agrega además una validación que antes no existía: _check_constrains_account_id_journal_id en account_move_line, que impide que una línea use una moneda distinta a la moneda forzada del diario.

IGTF (l10n_ve_igtf)
--------------------
igtf_base se derivaba de igtf_top_aply (valor congelado al crear la factura) en vez de rec.igtf_amount (recalculado por transacción), lo que hacía que amount_currency y balance de la línea de IGTF dejaran de ser conversiones mutuas consistentes. Ejemplo real detectado en test_igtf_partner_formal_VEF.test10: el asiento de residual de anticipo calculaba -680.48 en la cuenta "Anticipo Clientes" cuando el valor correcto, consistente con el resto del asiento, es -680.49.

_prepare_inbound_move_line_igtf_vals y _prepare_outbound_move_line_igtf_vals (clientes y proveedores) tenían condiciones de atajo distintas y asimétricas. Peor aún: _prepare_outbound_move_line_igtf_vals referenciaba la variable fechas_lista sin definirla nunca en ese método -- un NameError latente que habría roto cualquier pago a proveedor con IGTF que entrara a esa rama del código (nunca se disparaba en los tests existentes por casualidad de los montos usados). Se reescribe _prepare_outbound_move_line_igtf_vals para espejar exactamente la lógica ya corregida del lado de clientes (misma resolución de invoice_currencies/residual_currency, mismo uso de conversion_date y de la nueva _is_same_within_rounding), eliminando la dependencia de fechas_lista/top_igtf.

Cuando la factura estaba en moneda distinta a la de la compañía, total_base_residual se tomaba siempre de amount_residual_signed (ya en moneda compañía), generando una doble conversión incorrecta; ahora usa amount_residual en la moneda nativa de la factura cuando corresponde.

En el wizard de pago, custom_user_amount quedaba en True para siempre tras el primer cálculo manual. Ejemplo: el wizard propone 618 (600 + 18 de IGTF); si _onchange_amount se disparaba de nuevo sin que el usuario tocara el monto, el sistema volvía a calcular el 3% de IGTF sobre 618 (dando 18.54 en vez de 18), justo antes de confirmar el pago. Se corrige comparando contra la propuesta natural del sistema y limpiando custom_user_amount cuando coincide.

amount_without_difference no reflejaba la deuda real al pagar de más o de menos con payment_difference_handling distinto de 'open'; ahora usa la deuda real (amount_by_default) en ambos casos.

_create_payment_vals_from_batch convertía siempre desde la moneda de la compañía (en vez de la moneda real del lote) y con payment_date fijo sin indexación, afectando pagos múltiples ("batch") cuando la moneda del wizard difería de la del lote.

Conflicto de _onchange_move_type (l10n_ve_invoice) ---------------------------------------------------- l10n_ve_accountant y l10n_ve_invoice definían cada uno su propio _onchange_move_type sin llamarse entre sí. Como l10n_ve_invoice depende de l10n_ve_accountant y se carga después, su método (que solo fija invoice_date en out_invoice) tapaba silenciosamente al de l10n_ve_accountant (que además debía limpiar invoice_date_display para move_type='entry'). Detectado por test_03_onchange_move_type: se esperaba invoice_date_display=False y se encontraba la fecha de hoy. Se corrige encadenando ambos con super()._onchange_move_type().

Tests
-----
Se agregan test_indexed_payments.py, test_journal_currency_constraint.py y test_igtf_wizard_amounts.py cubriendo todo lo anterior, reutilizando los patrones existentes (Form.from_action) del resto de la suite.

Se corrigen 7 valores esperados en los 4 archivos de test de IGTF (clientes y proveedores, formal/special) que reflejaban la versión anterior del cálculo, previa a la corrección del redondeo -- ahora reflejan el comportamiento correcto y simétrico entre clientes y proveedores.

References:
- Ticket:
- Tarea:
  - https://binaural.odoo.com/odoo/helpdesk/action-389/14627
  - https://binaural.odoo.com/odoo/helpdesk/action-389/14648
  - https://binaural.odoo.com/odoo/helpdesk/action-389/13701
- PR:
- Otros: