### PR TITLE
Error en cálculo de saldo pendiente ($ USD) al procesar comprobantes de retención de IVA a tasa variable.

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.24",
+    "version": "19.0.2.0.25",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_payment.py
+++ b/l10n_ve_payment_extension/models/account_payment.py
@@ -84,6 +84,32 @@ class AccountPayment(models.Model):
             move.write(vals_to_change)
         return res
 
+    def _generate_move_vals(self, write_off_line_vals=None, force_balance=None, line_ids=None):
+        """
+        A retention payment's move must land in the same fiscal period as (and use
+        the same exchange rate as) the invoice it retains from, even though
+        payment.date stays as the retention's own date_accounting chosen by the
+        user. Writing move.date after the move is created/posted is NOT enough
+        (and was tried and reverted): the move's amounts are already computed
+        using payment.date's rate at generation time, so forcing only the date
+        label afterwards desyncs date from the rate actually used, producing a
+        bogus exchange difference on reconciliation. Instead, inject
+        l10n_ve_conversion_date (read by l10n_ve_accountant's
+        _prepare_move_lines_per_type override) BEFORE generating the move, so the
+        liquidity line is converted with the invoice's rate, then align 'date' to
+        that same value so the two never drift apart.
+        """
+        self.ensure_one()
+        if self.is_retention and self.retention_line_ids:
+            invoice_date = self.retention_line_ids[0].move_id.date
+            if invoice_date:
+                vals = super(
+                    AccountPayment, self.with_context(l10n_ve_conversion_date=invoice_date)
+                )._generate_move_vals(write_off_line_vals, force_balance, line_ids)
+                vals['date'] = invoice_date
+                return vals
+        return super()._generate_move_vals(write_off_line_vals, force_balance, line_ids)
+
     def unlink(self):
         for payment in self:
             if any(isinstance(id, api.NewId) for id in self.retention_line_ids.ids):

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -2,10 +2,10 @@ from odoo import api, models, fields, Command, _
 from datetime import datetime
 import re
 from odoo.exceptions import UserError, ValidationError
+from odoo.addons.account.models.account_move import BYPASS_LOCK_CHECK
 from ..utils.utils_retention import load_retention_lines, search_invoices_with_taxes
 from collections import defaultdict
 import json
-from odoo.tools.float_utils import float_round
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -703,7 +703,13 @@ class AccountRetention(models.Model):
         if not payments:
             raise UserError(_("No payments found for reconciliation."))
 
-        payments.action_post()
+        # These payments' moves are pinned to their invoice's own accounting date
+        # (see AccountPayment._generate_move_vals), which can already sit in a
+        # closed fiscal period by the time the retention itself is processed --
+        # bypass_lock_check is the core's own escape hatch for that check, only
+        # triggered here by the state -> 'posted' transition (not by writing
+        # 'date', which never happens after creation).
+        payments.with_context(bypass_lock_check=BYPASS_LOCK_CHECK).action_post()
 
         account_type_map = {
             "supplier": "liability_payable",
@@ -941,8 +947,15 @@ class AccountRetention(models.Model):
             "currency_id": self.env.company.currency_id.id,
             "date": self.date_accounting
         }
-        
+
         if not is_refund and has_subsidiary and self.env.company.subsidiary:
             res["account_analytic_id"] = move.account_analytic_id.id
+
+        # l10n_ve_igtf's js_assign_outstanding_line picks conversion_date over
+        # payment.date for the advance-crossing move's date/rate unless this is
+        # set, which would misprice the crossed amount against the retention's
+        # own date_accounting. Guarded since l10n_ve_igtf isn't a hard dependency.
+        if "keep_alter_value_vef" in self.env["account.payment"]._fields:
+            res["keep_alter_value_vef"] = True
 
         return res


### PR DESCRIPTION
[FIX] l10n_ve_payment_extension: asiento de pago de retenciones desalineado de la fecha/tasa de la factura

Las retenciones son siempre indexadas por definición: el monto retenido se calcula sobre la factura, así que su asiento debe salir siempre a la fecha (y tasa) contable de esa factura, sin importar qué fecha eligió el usuario al confirmar la retención (date_accounting). Hasta ahora eso no se cumplía: el account.payment se crea con date = date_accounting, y esa MISMA fecha terminaba siendo también la del asiento (account.move) del pago -- el core arma el asiento con 'date': self.date en _generate_move_vals, sin distinguir "fecha del pago" de "fecha que debe usar el asiento". Si la retención se procesa días o semanas después de la factura, el asiento del pago cae en una fecha/tasa distinta a la de la factura que retiene, y al conciliar (que usa
max(debit_aml.date, credit_aml.date) para fijar la fecha de la diferencia de cambio) esto genera una diferencia de cambio ficticia que la retención nunca debería producir.

Ejemplo real detectado: una retención sobre una factura en USD, pagada en VEF, mostró "325,52 Bs. Diferencia de cambio" y otra línea de "1,67 Bs. Diferencia de cambio" que no debían existir.

Ejemplo ilustrativo del mecanismo: factura del 01/06 a tasa 40 Bs/USD; la retención sobre esa factura se confirma el 20/06 a tasa 45 Bs/USD (date_accounting = 20/06, elegida por el usuario). Antes del fix, el asiento del pago de retención salía fechado 20/06 y convertido a 45 Bs/USD -- una tasa que la factura nunca usó -- por lo que al conciliar contra la factura (fechada y tasada al 01/06) Odoo detectaba una "diferencia de cambio" y generaba una línea adicional para cuadrarla. Con el fix, el asiento sale fechado 01/06 y convertido a 40 Bs/USD (la tasa real de la factura); payment.date sigue mostrando 20/06 en la UI, pero no se genera ninguna diferencia de cambio porque ambos asientos (factura y retención) usan la misma tasa.

Primer intento (revertido): forzar move.write({'date': invoice_date}) DESPUÉS de creado/posteado el asiento. Esto solo cambia la etiqueta de fecha, pero los montos de la línea de liquidez ya se habían calculado con la tasa de payment.date -- desalinea fecha real vs. tasa realmente usada y termina generando la MISMA diferencia de cambio que se quería evitar.

Fix definitivo: se sobreescribe _generate_move_vals para, cuando el pago es de retención, inyectar el contexto l10n_ve_conversion_date con la fecha contable de la factura asociada ANTES de generar el asiento (mismo mecanismo que l10n_ve_accountant ya usa para distinguir pagos indexados/no indexados), de modo que la línea de liquidez se convierta con la tasa de esa fecha, y luego se alinea 'date' al mismo valor -- fecha y tasa nunca quedan desincronizadas. payment.date (visible en la UI) no se toca, sigue siendo el date_accounting elegido por el usuario. Como cada pago de retención ya está ligado a una única factura (se crean por factura, no por retención completa, en
_create_payments_from_retention_lines), no hay ambigüedad aunque una retención cubra varias facturas de fechas distintas.

Como el asiento nace ya con la fecha de la factura, postearlo puede chocar con el bloqueo de período fiscal si esa fecha ya está cerrada para cuando se procesa la retención. Se envuelve el payments.action_post() de _reconcile_all_payments con bypass_lock_check (mismo mecanismo ya usado en este módulo para el ticket 14574 original de tasa de cambio), sin necesidad de tocar el chequeo de campos de solo lectura en asiento posteado (skip_readonly_check), porque ya no se escribe 'date' después de posteado.

Se agrega además keep_alter_value_vef=True al crear el pago de retención: sin este flag, l10n_ve_igtf.js_assign_outstanding_line usa conversion_date en vez de payment.date para el asiento de cruce contra un anticipo, produciendo un monto cruzado incorrecto. Guardado detrás de un chequeo de existencia del campo (self.env["account.payment"]._fields) ya que l10n_ve_igtf no es dependencia dura de l10n_ve_payment_extension.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/14574
- Tarea:
- PR:
- Otros: