### PR TITLE
[FIX] l10n_ve_accountant: unicidad diario compra intl por compañía

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.11",
+    "version": "19.0.1.0.12",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_journal.py
+++ b/l10n_ve_accountant/models/account_journal.py
@@ -44,6 +44,7 @@ class AccountJournal(models.Model):
                 domain = [
                     ('is_purchase_international', '=', True),
                     ('id', '!=', record.id),
+                    ('company_id', '=', record.company_id)
                 ]
                 
                 if self.search_count(domain) > 0:


### PR DESCRIPTION
## Problema

En entornos **multicompañía**, al intentar parametrizar el **Diario de Compras Internacionales** (`is_purchase_international`) en una segunda compañía, el sistema lanzaba el error:

> An International Purchase Journal is already enabled. Only one is allowed.

Esto impedía habilitar el diario internacional en cada compañía, aun cuando la que ya lo tenía habilitado era **otra compañía distinta**.

## Causa raíz

La restricción `_check_single_international_purchase_journal` del modelo `account.journal` (módulo `l10n_ve_accountant`) valida que exista un único diario con `is_purchase_international = True`. El `domain` de esa validación **no filtraba por compañía**, por lo que la búsqueda era global a toda la base: encontraba el diario internacional habilitado en cualquier compañía y bloqueaba la parametrización.

```python
domain = [
    ('is_purchase_international', '=', True),
    ('id', '!=', record.id),
]
```

## Fix

Se agrega el leaf `('company_id', '=', record.company_id)` al `domain`, de modo que la unicidad del diario de Compras Internacionales se evalúe **dentro de cada compañía** y no de forma global.

```python
domain = [
    ('is_purchase_international', '=', True),
    ('id', '!=', record.id),
    ('company_id', '=', record.company_id),
]
```

Se sube la versión del módulo `l10n_ve_accountant`: `19.0.1.0.11` → `19.0.1.0.12`.

## Verificación

- **Reproducción manual:** con dos compañías, habilitar el diario de Compras Internacionales en la Compañía A y luego intentar habilitarlo en la Compañía B → antes fallaba con el `ValidationError`; con el fix se puede habilitar en ambas.
- Se sigue impidiendo tener **dos** diarios internacionales **dentro de la misma compañía** (la restricción sigue vigente, ahora acotada por `company_id`).

## Alcance

- Cambio acotado a la constraint `_check_single_international_purchase_journal`. No se tocaron otras validaciones del modelo (`_check_payment_method_line_accounts`, `_validate_support_user_group`, `create`/`write`).
- Sin cambios de esquema, vistas ni datos; solo lógica de validación y bump de versión.

References: https://binaural.odoo.com/odoo/helpdesk.ticket/14658
