### PR TITLE
[FIX] l10n_ve_invoice: tests de columnas del reporte contable rompian…

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.9",
+    "version": "19.0.1.0.10",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/tests/test_accounting_reports.py
+++ b/l10n_ve_invoice/tests/test_accounting_reports.py
@@ -9,6 +9,13 @@ from odoo.tests import TransactionCase, tagged
 
 @tagged("post_install", "-at_install", "l10n_ve_invoice")
 class TestAccountingReports(TransactionCase):
+    def _payment_extension_installed(self):
+        return bool(
+            self.env["ir.module.module"].sudo().search(
+                [("name", "=", "l10n_ve_payment_extension"), ("state", "=", "installed")]
+            )
+        )
+
     def setUp(self):
         super().setUp()
         self.company = self.env.ref("base.main_company")
@@ -935,8 +942,9 @@ class TestAccountingReports(TransactionCase):
         wizard = self._create_wizard("sale", date_from=today, date_to=today)
         moves = wizard.search_moves()
         fields_list = wizard._resume_sale_book_fields(moves)
-        self.assertEqual(len(fields_list), 7)
-        self.assertEqual(fields_list[-1]["total"], True)
+        expected = 7 + (1 if self._payment_extension_installed() else 0)
+        self.assertEqual(len(fields_list), expected)
+        self.assertTrue(any(f.get("total") for f in fields_list))
 
     def test_resume_purchase_book_fields(self):
         today = fields.Date.today()
@@ -947,5 +955,6 @@ class TestAccountingReports(TransactionCase):
         wizard = self._create_wizard("purchase", date_from=today, date_to=today)
         moves = wizard.search_moves()
         fields_list = wizard._resume_purchase_book_fields(moves)
-        self.assertEqual(len(fields_list), 9)
-        self.assertEqual(fields_list[-1]["total"], True)
+        expected = 9 + (1 if self._payment_extension_installed() else 0)
+        self.assertEqual(len(fields_list), expected)
+        self.assertTrue(any(f.get("total") for f in fields_list))

--- a/l10n_ve_invoice/tests/test_accounting_reports.py
+++ b/l10n_ve_invoice/tests/test_accounting_reports.py
@@ -277,11 +277,16 @@ class TestAccountingReports(TransactionCase):
         self.assertTrue(wizard.show_field_currency_system)
 
     def test_default_currency_system_non_vef(self):
-        self.company.write({
+        company = self.env["res.company"].create({
+            "name": "Non VEF Test Company",
+            "currency_id": self.currency_vef.id,
+            "foreign_currency_id": self.currency_usd.id,
+        })
+        company.write({
             "currency_id": self.currency_usd.id,
             "foreign_currency_id": self.currency_vef.id,
         })
-        wizard = self._create_wizard("sale")
+        wizard = self._create_wizard("sale", company_id=company.id)
         self.assertTrue(wizard)
 
     # ============================================================
@@ -942,8 +947,18 @@ class TestAccountingReports(TransactionCase):
         wizard = self._create_wizard("sale", date_from=today, date_to=today)
         moves = wizard.search_moves()
         fields_list = wizard._resume_sale_book_fields(moves)
-        expected = 7 + (1 if self._payment_extension_installed() else 0)
-        self.assertEqual(len(fields_list), expected)
+        expected_names = [
+            "Ventas Internas no Gravadas",
+            "Ventas de Exportación",
+            "Ventas Internas Gravadas sólo por Alícuota General",
+            "Ventas Internas Gravadas por Alícuota Reducida",
+            "Ventas Internas Gravadas por Alícuota General más Adicional",
+            "Ajustes a los Débitos Fiscales de Periodos Anteriores",
+            "Total Ventas y Débitos Fiscales del Periodo",
+        ]
+        if self._payment_extension_installed():
+            expected_names.append("Total Retenciones")
+        self.assertEqual([f.get("name") for f in fields_list], expected_names)
         self.assertTrue(any(f.get("total") for f in fields_list))
 
     def test_resume_purchase_book_fields(self):
@@ -955,6 +970,18 @@ class TestAccountingReports(TransactionCase):
         wizard = self._create_wizard("purchase", date_from=today, date_to=today)
         moves = wizard.search_moves()
         fields_list = wizard._resume_purchase_book_fields(moves)
-        expected = 9 + (1 if self._payment_extension_installed() else 0)
-        self.assertEqual(len(fields_list), expected)
+        expected_names = [
+            "Compras Internas no Gravadas",
+            "Importaciones Gravadas por Alícuota Reducida",
+            "Importaciones Gravadas por Alícuota General",
+            "Importaciones Gravadas por Alícuota General más Adicional",
+            "Compras Internas Gravadas sólo por Alícuota General",
+            "Compras Internas Gravadas por Alícuota General más Adicional",
+            "Compras Internas Gravadas por Alícuota Reducida",
+            "Ajustes a los Créditos Fiscales de Periodos Anteriores",
+            "Total Compras y Créditos Fiscales del Periodo",
+        ]
+        if self._payment_extension_installed():
+            expected_names.append("Total Retenciones")
+        self.assertEqual([f.get("name") for f in fields_list], expected_names)
         self.assertTrue(any(f.get("total") for f in fields_list))


### PR DESCRIPTION
… con l10n_ve_payment_extension instalado

Los tests de _resume_sale_book_fields y _resume_purchase_book_fields asumian un conteo exacto de columnas, sin contemplar que l10n_ve_payment_extension hereda esos metodos y agrega una columna de retenciones. Ahora el conteo esperado se ajusta segun si ese modulo esta instalado.