### PR TITLE
[FIX] l10n_ve_sale: _create_invoices re-entraba al while con solo la línea de nota restante

### DIFF
--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -443,10 +443,25 @@ class SaleOrder(models.Model):
         """
         invoices = self.env["account.move"]
         for order in self:
-            invoiceable_lines = order._get_invoiceable_lines(final)
-            while len(invoiceable_lines) != 0:
+            # Las líneas de sección/nota cuentan SIEMPRE como "invoiceable" para
+            # el core (sale/models/sale_order.py, _get_invoiceable_lines incluye
+            # display_type sin condición de cantidad), así que no sirven para
+            # decidir si queda algo por facturar: con una nota en la orden el
+            # while re-entraba después del último lote y el core reventaba con
+            # "No items are available to invoice".
+            invoiceable_lines = order._get_invoiceable_lines(final).filtered(
+                lambda line: not line.display_type
+            )
+            while invoiceable_lines:
                 invoices |= super()._create_invoices(grouped, final, date)
-                invoiceable_lines = order._get_invoiceable_lines(final)
+                remaining = order._get_invoiceable_lines(final).filtered(
+                    lambda line: not line.display_type
+                )
+                if remaining == invoiceable_lines:
+                    # Si el lote no consumió ninguna línea, cortar en vez de
+                    # iterar infinito (misma protección que el caso de notas).
+                    break
+                invoiceable_lines = remaining
 
         return invoices
 

--- a/l10n_ve_sale/tests/__init__.py
+++ b/l10n_ve_sale/tests/__init__.py
@@ -2,4 +2,5 @@ from . import test_pricelist
 from . import test_sale_order_rate
 from . import test_sale_order_vat
 from . import test_action_confirm
+from . import test_create_invoices_note_lines
 #from . import test_sale_order_invoice_status

--- a/l10n_ve_sale/tests/test_create_invoices_note_lines.py
+++ b/l10n_ve_sale/tests/test_create_invoices_note_lines.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+from odoo.fields import Command
+
+
+@tagged('post_install', '-at_install')
+class TestCreateInvoicesNoteLines(TransactionCase):
+    """Regresión del loop de `_create_invoices`: las líneas de nota cuentan
+    siempre como "invoiceable" para el core, así que el while que reparte la
+    facturación por lotes (max_product_invoice) re-entraba después del último
+    lote con solo la nota restante y el core reventaba con "No items are
+    available to invoice"."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.customer = cls.env['res.partner'].create({'name': 'Cliente Nota l10n_ve'})
+        cls.product_a = cls.env['product.product'].create({
+            'name': 'Producto A Nota',
+            'type': 'consu',
+            'invoice_policy': 'order',
+            'list_price': 100.0,
+        })
+        cls.product_b = cls.env['product.product'].create({
+            'name': 'Producto B Nota',
+            'type': 'consu',
+            'invoice_policy': 'order',
+            'list_price': 50.0,
+        })
+
+    def _create_order(self, products):
+        lines = [
+            Command.create({'product_id': product.id, 'product_uom_qty': 1})
+            for product in products
+        ]
+        lines.append(Command.create({'display_type': 'line_note', 'name': 'Nota de entrega'}))
+        order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': lines,
+        })
+        order.action_confirm()
+        return order
+
+    def test_01_create_invoices_with_note_line(self):
+        """Una orden con línea de nota debe facturarse en un solo pase, sin
+        que el loop re-entre por la nota y reviente."""
+        order = self._create_order([self.product_a])
+
+        invoices = order._create_invoices()
+
+        self.assertEqual(len(invoices), 1)
+        self.assertFalse(
+            order._get_invoiceable_lines().filtered(lambda line: not line.display_type),
+            "No deberían quedar líneas de producto por facturar",
+        )
+
+    def test_02_create_invoices_multi_batch_with_note_line(self):
+        """El caso para el que existe el while: con max_product_invoice bajo
+        la orden se factura en varios lotes, y la nota tampoco debe hacer que
+        el loop siga después del último lote."""
+        self.env.company.max_product_invoice = 1
+        order = self._create_order([self.product_a, self.product_b])
+
+        invoices = order._create_invoices()
+
+        self.assertEqual(len(invoices), 2, "Dos productos con límite 1 son dos facturas")
+        self.assertFalse(
+            order._get_invoiceable_lines().filtered(lambda line: not line.display_type),
+            "No deberían quedar líneas de producto por facturar",
+        )


### PR DESCRIPTION
## Bug

`_create_invoices` (l10n_ve_sale/models/sale_order.py) reparte la facturación por lotes con:

```python
invoiceable_lines = order._get_invoiceable_lines(final)
while len(invoiceable_lines) != 0:
    invoices |= super()._create_invoices(grouped, final, date)
    invoiceable_lines = order._get_invoiceable_lines(final)
```

Las líneas de sección/nota cuentan **siempre** como "invoiceable" para `_get_invoiceable_lines` del core (`sale/models/sale_order.py` las incluye sin condición de cantidad). En una orden con línea de nota, después del último lote la lista queda `[nota]` → `len != 0` → el while re-entra → el core revienta con **"No items are available to invoice"**.

Afecta a cualquier orden v19 con línea de nota. La App móvil agrega una siempre (`manage_note_app` de binaural_mobile), así que todo el flujo de facturación desde órdenes de la App estaba roto. Detectado por el CI de binaural-dev/integra-addons#2539 (`TestSaleOrder.test_14_create_invoices_assigns_invoice_user_from_order`).

## Fix

- La condición del loop filtra `display_type` (solo líneas reales de producto deciden si queda algo por facturar).
- Guard de no-progreso: si un lote no consume líneas, se corta en vez de iterar infinito.

## Tests

`test_create_invoices_note_lines.py`:
- orden con producto + nota → 1 factura, sin excepción;
- `max_product_invoice = 1` con 2 productos + nota → 2 facturas (el multi-lote para el que existe el while sigue funcionando).

Verificado local en review19: `2 post-tests in 0.65s`, 0 fallos.

Ref tarea: https://binaural.odoo.com/odoo/all-tasks/79284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vuwk2L42NE5WeUVApfrvDS