### PR TITLE
10n_ve_accountant: corregir inversión de monto alterno en retenciones

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -41,7 +41,7 @@ Cambios en UI / Modelos impactados
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.62",
+    "version": "17.0.0.0.63",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -304,8 +304,8 @@ class AccountMoveLine(models.Model):
                 and self.move_id.payment_id.is_retention:
             retention_amount = self.move_id.payment_id.retention_foreign_amount
             if self.credit:
-                return retention_amount
-            return -retention_amount
+                return -retention_amount
+            return retention_amount
 
         if not self.move_id.is_invoice(include_receipts=True):
             return self._get_non_invoice_foreign_value()

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.34",
+    "version": "17.0.0.0.35",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/tests/test_retention_credit_note.py
+++ b/l10n_ve_payment_extension/tests/test_retention_credit_note.py
@@ -239,6 +239,44 @@ class TestRetentionCreditNote(TransactionCase):
                     line.payment_concept_id = self.payment_concept
         return retention_form_edit.save()
 
+    def _assert_foreign_debit_credit_matches_debit_credit(self, payment):
+        """
+        Regression for the retention branch of `AccountMoveLine._get_foreign_value`
+        (l10n_ve_accountant): a debit line must land its foreign amount on
+        `foreign_debit` and a credit line on `foreign_credit`, mirroring plain
+        debit/credit -- not the other way around.
+        """
+        self.assertGreater(
+            payment.retention_foreign_amount,
+            0.0,
+            "retention_foreign_amount must be computed for a retention payment.",
+        )
+        for line in payment.move_id.line_ids.filtered(lambda l: l.debit or l.credit):
+            if line.debit:
+                self.assertAlmostEqual(
+                    line.foreign_debit,
+                    payment.retention_foreign_amount,
+                    places=2,
+                    msg="A debit line must carry the foreign amount on foreign_debit.",
+                )
+                self.assertEqual(
+                    line.foreign_credit,
+                    0.0,
+                    "A debit line must not carry any amount on foreign_credit.",
+                )
+            else:
+                self.assertAlmostEqual(
+                    line.foreign_credit,
+                    payment.retention_foreign_amount,
+                    places=2,
+                    msg="A credit line must carry the foreign amount on foreign_credit.",
+                )
+                self.assertEqual(
+                    line.foreign_debit,
+                    0.0,
+                    "A credit line must not carry any amount on foreign_debit.",
+                )
+
     def test_islr_payment_type_direction_supplier_invoice_and_credit_note(self):
         """
         Regla original rota: `payment_type` se inicializaba una sola vez antes
@@ -273,6 +311,9 @@ class TestRetentionCreditNote(TransactionCase):
             "Supplier retention over a credit note must create an inbound payment "
             "(opposite direction to the invoice).",
         )
+
+        self._assert_foreign_debit_credit_matches_debit_credit(invoice_line.payment_id)
+        self._assert_foreign_debit_credit_matches_debit_credit(refund_line.payment_id)
 
     def test_islr_payment_type_direction_customer_invoice_and_credit_note(self):
         invoice = self._create_move(
@@ -339,6 +380,9 @@ class TestRetentionCreditNote(TransactionCase):
             "Customer retention over a credit note must create an outbound payment "
             "(opposite direction to the invoice).",
         )
+
+        self._assert_foreign_debit_credit_matches_debit_credit(invoice_line.payment_id)
+        self._assert_foreign_debit_credit_matches_debit_credit(refund_line.payment_id)
 
     def test_iva_customer_retention_loads_credit_note_despite_negative_residual(self):
         """


### PR DESCRIPTION
[FIX] l10n_ve_accountant: corregir inversión de monto alterno en retenciones

TI-14766: en AccountMoveLine._get_foreign_value, la rama de retención asignaba el monto alterno (Bs) al revés entre Débito y Crédito -- la línea de crédito recibía el valor positivo (foreign_debit) y la de débito el negativo (foreign_credit), contrario a la convención del resto del método (positivo -> Débito, negativo -> Crédito).

Se agregan validaciones en los tests existentes de retención de proveedor y de cliente (l10n_ve_payment_extension) que confirman el signo correcto de foreign_debit/foreign_credit contra debit/credit.

https://binaural.odoo.com/odoo/helpdesk.ticket/14766