### PR TITLE
[FIX] #14522: l10n_ve_stock_account

### DIFF
--- a/l10n_ve_stock_account/__manifest__.py
+++ b/l10n_ve_stock_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock Account",
-    "version": "19.0.2.0.4",
+    "version": "19.0.2.0.5",
     "depends": [
         "l10n_ve_stock",
         "l10n_ve_invoice",

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -2,7 +2,7 @@ from odoo.exceptions import UserError
 import logging
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 from odoo.tools.safe_eval import safe_eval
 from datetime import date, datetime, timedelta

--- a/l10n_ve_stock_account/models/stock_picking.py
+++ b/l10n_ve_stock_account/models/stock_picking.py
@@ -1334,7 +1334,7 @@ class StockPicking(models.Model):
     def get_foreign_currency_is_vef(self):
         return self.env.company.foreign_currency_id == self.env.ref("base.VEF")
 
-    @api.depends('is_consignment', 'is_dispatch_guide', 'transfer_reason_id')
+    @api.depends('is_consignment', 'is_dispatch_guide', 'transfer_reason_id', 'location_dest_id')
     def _compute_partner_required(self):
         consignment_reason = self.env.ref('l10n_ve_stock_account.transfer_reason_consignment', raise_if_not_found=False)
         for picking in self.filtered(lambda p: p.transfer_reason_id):
@@ -1342,6 +1342,8 @@ class StockPicking(models.Model):
                 picking.transfer_reason_id.id == consignment_reason.id
                 and picking.is_dispatch_guide
                 and picking.is_consignment
+                and picking.location_dest_id
+                and picking.location_dest_id.partner_id
             )
             picking._assign_partner_from_location()
 
@@ -1364,7 +1366,8 @@ class StockPicking(models.Model):
         for picking in self:
             if picking.partner_required:
                 partner = picking.location_dest_id.partner_id
-                picking.partner_id = partner.id if partner else False
+                if partner:
+                    picking.partner_id = partner.id
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_ve_stock_account/tests/test_stock_picking.py
+++ b/l10n_ve_stock_account/tests/test_stock_picking.py
@@ -593,6 +593,7 @@ class TestStockPickingCoverage(TransactionCase):
 
     def test_compute_partner_required(self):
         picking = self._create_internal_picking(reason=self.reason_consignment)
+        picking.location_dest_id.partner_id = self.partner
         picking.is_dispatch_guide = True
         picking.is_consignment = True
         picking._compute_partner_required()

--- a/l10n_ve_stock_account/views/stock_picking_views.xml
+++ b/l10n_ve_stock_account/views/stock_picking_views.xml
@@ -27,7 +27,7 @@
             </xpath>
             <xpath expr="//form//group//group//field[@name='partner_id']" position="attributes">
                 <attribute name="required">partner_required or is_dispatch_guide</attribute> 
-                <attribute name="readonly">order_is_consignment or partner_required or is_donation</attribute>
+                <attribute name="readonly">state == 'done' or order_is_consignment or partner_required or is_donation</attribute>
             </xpath>
             <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="before">
                 <field name="is_return" invisible="1"/>


### PR DESCRIPTION
Problema: Al seleccionar el motivo "Consignación" en un traslado interno, el campo contacto se bloqueaba (readonly) y se marcaba como obligatorio (required) simultáneamente, impidiendo guardar el traslado si la ubicación destino no tenía un cliente asignado. Esto ocurría porque `partner_required` se activaba únicamente por la razón de traslado, sin verificar si la ubicación destino disponía de un partner.

Solución: Se modifica `_compute_partner_required` para que solo active `partner_required = True` cuando la ubicación destino (`location_dest_id`) tenga un cliente (`partner_id`) asignado. Se agrega `location_dest_id` a las dependencias del compute y se ajusta `_assign_partner_from_location` para no limpiar el campo contacto cuando la ubicación no tiene partner, permitiendo que el usuario lo seleccione manualmente. Se actualizan los tests correspondientes para reflejar la nueva condición.

Ticket (link): https://binaural.odoo.com/odoo/my-tickets/14522