### PR TITLE
[FIX] l10n_ve_pos: mostrar descuento sobre base imponible

### DIFF
--- a/l10n_ve_pos/openspec/changes/pos-discount-net-display/proposal.md
+++ b/l10n_ve_pos/openspec/changes/pos-discount-net-display/proposal.md
@@ -1,0 +1,57 @@
+# Proposal: Mostrar el descuento del PoS sobre la base imponible (sin IVA)
+
+## Intent
+
+En cajas configuradas con **impuestos incluidos** (`pos.config.iface_tax_included == "total"`)
+el core de Odoo 19 pinta cada línea de la orden con IVA, incluida la línea de
+descuento generada por `pos_discount`. Como esa línea se crea sobre la **base
+imponible** con su impuesto asociado (el motor de impuestos reduce base e IVA
+por separado), el cajero ve el descuento **más su IVA** (p. ej. `1,08` en lugar
+de `1,00` con IVA al 8%), que no coincide con el monto que imprime la máquina
+fiscal (que muestra la reducción de base).
+
+Este cambio hace que **solo la línea de descuento** se muestre por su monto
+sobre la base imponible (sin IVA), tanto en moneda local como en divisa, en
+carrito y recibo, sin alterar el dato subyacente ni el resto del carrito.
+
+## Scope
+
+### In Scope
+- `static/src/overrides/models/pos_order_line.js`: getters `displayPrice` y
+  `displayPriceUnit` para la línea de descuento devuelven el neto sin IVA;
+  nuevo `get_foreign_display_price()` (sin IVA para la línea de descuento).
+- `static/src/overrides/components/orderline/orderline.xml`: el monto en divisa
+  por línea usa `get_foreign_display_price()` en vez de
+  `get_foreign_price_with_tax()`.
+- Detección de la línea de descuento vía `pos.config.discount_product_id`.
+
+### Out of Scope
+- El **cálculo** del descuento (ya es sobre la base imponible, sin cambios).
+- El dato de la línea de descuento: conserva `price_unit` e impuesto para que
+  base y total se computen correctamente.
+- El ticket de la máquina fiscal (`l10n_ve_pos_mf`) y su driver.
+- Cambiar `iface_tax_included` a nivel de configuración.
+
+## Approach
+
+El precio mostrado de cada línea sale de un único getter del core
+(`PosOrderAccounting.displayPrice`), que devuelve `priceIncl` cuando la caja está
+en `"total"`. Se intercepta ese getter **solo para la línea de descuento** para
+devolver `priceExcl` (base). El carrito y el recibo comparten el componente
+`Orderline`, así que el override cubre ambas superficies. El monto en divisa por
+línea (plantilla `orderline.xml`) se alinea con un método de modelo dedicado.
+
+## Affected Areas
+
+| Área | Impacto |
+|------|---------|
+| `l10n_ve_pos` modelo `pos.order.line` (JS) | `displayPrice`/`displayPriceUnit` de la línea de descuento devuelven el neto; `get_foreign_display_price` nuevo |
+| `l10n_ve_pos` plantilla `Orderline` (XML) | el monto en divisa por línea usa `get_foreign_display_price` |
+
+## Trade-off conocido
+
+Con productos mostrados con IVA y el descuento mostrado sin IVA, las líneas del
+recibo del PoS no suman a simple vista por el IVA del descuento (p. ej.
+`10,80 − 1,00 ≠ 9,72`; faltan `0,08`). El total es correcto y el ticket fiscal de
+la máquina cuadra en su formato base+IVA. Decisión aceptada por el negocio:
+mostrar el descuento "real" sobre base imponible.

--- a/l10n_ve_pos/openspec/changes/pos-discount-net-display/specs/pos-discount-net-display/spec.md
+++ b/l10n_ve_pos/openspec/changes/pos-discount-net-display/specs/pos-discount-net-display/spec.md
@@ -1,0 +1,75 @@
+# Visualización del descuento del PoS sobre la base imponible
+
+## Purpose
+
+Definir cómo `l10n_ve_pos` muestra la línea de descuento por su monto sobre la
+base imponible (sin IVA) sin alterar el cálculo ni el dato de la línea.
+
+## Requirements
+
+### Requirement: La línea de descuento se muestra sin IVA en moneda local
+
+Cuando la caja está en impuestos incluidos (`iface_tax_included == "total"`), la
+línea cuyo producto es `pos.config.discount_product_id` DEBE mostrarse por su
+monto sobre la base imponible (`priceExcl`), no por el monto con IVA
+(`priceIncl`). El resto de las líneas conserva su comportamiento.
+
+#### Scenario: Descuento con IVA al 8% en caja con impuestos incluidos
+
+- GIVEN una caja con `iface_tax_included = "total"` y un producto de base `10,00` con IVA `8%`
+- WHEN se aplica un descuento del `10%` (línea de descuento base `-1,00`, IVA `-0,08`)
+- THEN el carrito y el recibo muestran la línea de descuento como `-1,00` (no `-1,08`)
+- AND las demás líneas siguen mostrándose con IVA
+
+#### Scenario: El dato subyacente no cambia
+
+- GIVEN la línea de descuento mostrada como `-1,00`
+- WHEN se calculan base, IVA y total de la orden
+- THEN la base se reduce en `1,00`, el IVA en `0,08` y el total en `1,08`
+- AND el `price_unit` y el impuesto de la línea de descuento no se modifican
+
+### Requirement: La línea de descuento se muestra sin IVA en divisa
+
+El monto en divisa mostrado para la línea de descuento DEBE ser el equivalente
+sin IVA (`get_foreign_price_without_tax`), aunque la caja esté en impuestos
+incluidos, para ser consistente con el monto en moneda local. El resto de las
+líneas conserva el monto en divisa con IVA (`get_foreign_price_with_tax`).
+
+#### Scenario: Display en divisa del descuento
+
+- GIVEN una orden con moneda extranjera y caja en `iface_tax_included = "total"`
+- WHEN se muestra la línea de descuento
+- THEN su monto en divisa es la conversión del neto sin IVA, no del monto con IVA
+
+### Requirement: La referencia del descuento por línea es la base imponible
+
+Cuando una línea de producto tiene un descuento propio (`discount > 0`) y la caja
+está en impuestos incluidos, el texto de referencia del descuento
+("X% discount off on Y", `displayPriceNoDiscount`) DEBE mostrar el precio
+pre-descuento sobre la **base imponible** (`priceExclNoDiscount`), no el precio
+con IVA (`priceInclNoDiscount`). Es un getter de display (no entra en cálculos).
+
+#### Scenario: Descuento de línea 10% sobre producto con IVA 31%
+
+- GIVEN un producto de base `10.000` con IVA `31%` (con IVA = `13.100`) en caja `iface_tax_included = "total"`
+- WHEN se aplica `10%` de descuento a la línea
+- THEN la referencia muestra "10% off on 10.000" (base), no "10% off on 13.100"
+- AND el total de la orden no cambia (sigue calculándose con el dato real de la línea)
+
+#### Scenario: Línea sin descuento no cambia su referencia
+
+- GIVEN una línea sin descuento
+- WHEN se muestra
+- THEN `displayPriceNoDiscount` conserva el comportamiento del core
+
+### Requirement: Solo aplica a la línea de descuento
+
+El override NO DEBE alterar la visualización de líneas de producto normales ni
+la de cajas configuradas sin impuestos incluidos (`"subtotal"`), donde el core ya
+muestra los montos sin IVA.
+
+#### Scenario: Línea de producto normal intacta
+
+- GIVEN una línea de producto normal en caja con impuestos incluidos
+- WHEN se muestra
+- THEN su precio se muestra con IVA como antes del cambio

--- a/l10n_ve_pos/static/src/overrides/components/orderline/orderline.xml
+++ b/l10n_ve_pos/static/src/overrides/components/orderline/orderline.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="l10n_ve_pos.Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('product-price')]" position="after">
-                / <t t-out="env.utils.formatForeignCurrency(line.get_foreign_price_with_tax())"/>
+                / <t t-out="env.utils.formatForeignCurrency(line.get_foreign_display_price())"/>
         </xpath>
 
         <xpath expr="//div[hasclass('product-name')]" position="inside">

--- a/l10n_ve_pos/static/src/overrides/models/pos_order_line.js
+++ b/l10n_ve_pos/static/src/overrides/models/pos_order_line.js
@@ -29,6 +29,63 @@ import { parseFloat as parseFloatLocale } from "@web/views/fields/parsers";
 // -----------------------------------------------------------------------------
 
 patch(PosOrderline.prototype, {
+    // -------------------------------------------------------------------------
+    // Descuento mostrado sobre la BASE IMPONIBLE (sin IVA).
+    //
+    // El descuento (global o de línea) YA se calcula sobre la base imponible:
+    // la línea de descuento se crea con `price_unit` = base descontada y su
+    // impuesto asociado, de modo que el motor reduce base e IVA por separado
+    // (la base baja `%`, el IVA recalcula sobre la base menor). Eso es lo que
+    // espera la máquina fiscal.
+    //
+    // Sin embargo, con la caja configurada en "impuestos incluidos"
+    // (`iface_tax_included === "total"`), el core pinta CADA línea con IVA,
+    // incluida la de descuento → el cajero ve el descuento + su IVA
+    // (p. ej. 1,08 en vez de 1,00). Aquí forzamos que SOLO la línea de
+    // descuento se muestre por su monto sin IVA (la base real descontada),
+    // dejando intacto el resto del carrito y el dato subyacente de la línea
+    // (sigue con su IVA, así base y total se calculan bien).
+    // -------------------------------------------------------------------------
+
+    get _isVeDiscountLine() {
+        const discountProductId = this.config?.discount_product_id?.id;
+        return !!discountProductId && this.product_id?.id === discountProductId;
+    },
+
+    get displayPrice() {
+        if (this._isVeDiscountLine) {
+            return this.currency.round(this.priceExcl);
+        }
+        return super.displayPrice;
+    },
+
+    get displayPriceUnit() {
+        if (this._isVeDiscountLine) {
+            return this.currency.round(this.displayPriceUnitExcl);
+        }
+        return super.displayPriceUnit;
+    },
+
+    // Referencia del descuento POR LÍNEA ("X% discount off on Y"): debe
+    // mostrarse sobre la BASE IMPONIBLE (sin IVA), aunque la caja esté en
+    // impuestos incluidos. Ej.: producto base 10.000 + IVA 31% = 13.100 con
+    // 10% de descuento → "10% off on 10.000" (no sobre 13.100). Solo afecta
+    // esa referencia visual (getter de display; no entra en cálculos) y solo
+    // cuando la línea tiene descuento.
+    get displayPriceNoDiscount() {
+        const hasDiscount = Number(this.discount || 0) > 0;
+        if (!hasDiscount) {
+            return super.displayPriceNoDiscount;
+        }
+        if (!this.combo_line_ids.length) {
+            return this.priceExclNoDiscount;
+        }
+        return this.combo_line_ids.reduce(
+            (total, cl) => total + cl.priceExclNoDiscount,
+            0
+        );
+    },
+
     _is_order_in_foreign_currency() {
       const foreignCurrency = this.get_foreign_currency?.();
       const orderCurrencyId = this.order_id?.currency?.id ?? this.order_id?.currency;
@@ -169,6 +226,16 @@ patch(PosOrderline.prototype, {
 
     get_foreign_price_with_tax() {
       return this._conv(this.priceIncl);
+    },
+
+    // Monto en divisa mostrado por línea. La línea de descuento se muestra
+    // sin IVA (base real descontada), igual que en moneda local; el resto
+    // conserva el comportamiento previo (con IVA). Ver displayPrice arriba.
+    get_foreign_display_price() {
+      if (this._isVeDiscountLine) {
+        return this.get_foreign_price_without_tax();
+      }
+      return this.get_foreign_price_with_tax();
     },
 
     get_foreign_total_tax() {


### PR DESCRIPTION
## Problema

En cajas con impuestos incluidos (`iface_tax_included = "total"`), el PdV mostraba el descuento con el IVA sumado, sin coincidir con la base imponible que aplica la máquina fiscal:

- La línea de descuento **global** salía como base + IVA (p. ej. `1,08` en vez de `1,00`, con IVA 8%).
- La referencia del descuento **por línea** ("X% discount off on Y") salía sobre el precio con IVA (p. ej. `13.100` en vez de `10.000`, con IVA 31%).

## Causa raíz

El cálculo del descuento ya es correcto (siempre sobre la base imponible), pero el core de Odoo 19 pinta cada línea según `iface_tax_included`: en modo `"total"`, los getters `displayPrice` y `displayPriceNoDiscount` devuelven el importe **con IVA**, incluida la línea de descuento y la referencia del descuento por línea.

## Fix

Ajuste **solo de visualización** en `l10n_ve_pos` (no se toca el dato de las líneas; base, IVA y total se calculan igual):

- `displayPrice` / `displayPriceUnit` de la línea de descuento devuelven el neto sin IVA (`priceExcl`).
- `get_foreign_display_price()` aplica el mismo criterio al monto en divisa (la plantilla `orderline.xml` pasa a usarlo).
- `displayPriceNoDiscount` devuelve la base (`priceExclNoDiscount`) como referencia del descuento por línea (solo cuando la línea tiene descuento).
- **No** se toca `displayPriceUnitNoDiscount` porque entra en un cálculo del core (`pos_order.js`).

## Verificación

- Probado en `pos2`, caja *Binaural C.A*:
  - Descuento global con IVA 8% → la línea de descuento muestra `1,00` (base), no `1,08`.
  - Descuento de línea 10% sobre producto con IVA 31% → la referencia sale sobre `10.000` (base), no `13.100`.
- Productos exentos / sin impuesto: `base == total`, sin cambio visible (correcto).

## Alcance

- Cambio **solo de display**; el total de la orden y el cálculo de impuestos no cambian.
- Correcto con productos con y sin IVA, y con precio con o sin impuesto incluido.
- No se modifica el ticket de la máquina fiscal ni su driver.
- Trade-off conocido y aceptado: en modo impuestos incluidos, con productos gravados, la línea de producto muestra su precio con IVA mientras el descuento se muestra sobre base; en exentos no hay asimetría.
- Documentado en `l10n_ve_pos/openspec/changes/pos-discount-net-display/`.

References: https://binaural.odoo.com/odoo/action-341/78328
