### PR TITLE
[FIX] l10n_ve_stock: package_qty=0 no imprime etiquetas de embalaje

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "19.0.1.0.7",
+    "version": "19.0.1.0.8",
     "depends": [
         "stock",
         "product",

--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.9",
     "depends": [
         "stock",
         "product",

--- a/l10n_ve_stock/report/packaging_picking_template.xml
+++ b/l10n_ve_stock/report/packaging_picking_template.xml
@@ -19,7 +19,7 @@
             </div>
             <div class="row border border-dark rounded mt-2 p-2">
                 <div class="col-12 text-center" style="height:2.5rem !important">
-                    <p t-out="picking.partner_id.name[:80]" class="h5" />
+                    <p t-if="picking.picking_type_id and picking.picking_type_id.code in ['outgoing'] and picking.partner_id" t-out="(picking.partner_id.display_name or '')[:80]" class="h5"/>
                 </div>
             </div>
             <div class="row font-weight-bold border-right border-left">

--- a/l10n_ve_stock/report/packaging_picking_template.xml
+++ b/l10n_ve_stock/report/packaging_picking_template.xml
@@ -2,9 +2,6 @@
     <template id="packaging_picking_item">
         <div class="container">
             <div class="row border border-dark rounded position-relative" name="header">
-                <!-- <t t-set="operation_employees" t-value="picking.get_operation_employees()"/> -->
-                <!-- <t t-set="pick_employee" t-value="operation_employees[0]"/> -->
-                <!-- <t t-set="out_employee" t-value="operation_employees[1]"/> -->
                 <div class="col-7" name="picking_info">
                     <div> Date: <span
                             t-esc="context_timestamp(datetime.datetime.now()).strftime('%d-%m-%Y %H:%M')" />
@@ -59,7 +56,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="picking">
                 <t t-call="web.basic_layout">
-                    <t t-foreach="range(1, picking.package_qty + 1)" t-as="item">
+                    <t t-foreach="range(1, (picking.package_qty if picking.package_qty and picking.package_qty > 0 else 1) + 1)" t-as="item">
                         <div class="page">
                             <t t-call="l10n_ve_stock.packaging_picking_item">
                                 <t t-raw="0" />

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/README.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/README.md
@@ -1,0 +1,3 @@
+# l10n-ve-stock-packaging-picking-zero-qty
+
+Corrige que un picking con package_qty=0 no imprima ninguna etiqueta de embalaje

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/README.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/README.md
@@ -1,3 +1,7 @@
 # l10n-ve-stock-packaging-picking-zero-qty
 
-Corrige que un picking con package_qty=0 no imprima ninguna etiqueta de embalaje
+Corrige que un picking con package_qty=0 no imprima ninguna etiqueta de embalaje.
+
+Además, restringe el nombre del destinatario en la etiqueta a pickings de salida
+con `partner_id` seteado, y cambia a `partner_id.display_name` (evita un
+`TypeError` real visto en staging cuando `partner_id` está vacío).

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/design.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/design.md
@@ -1,0 +1,24 @@
+## Context
+
+`packaging_picking` is a plain QWeb report template (no Python model involved): a parent template (`packaging_picking`) iterates `range(1, picking.package_qty + 1)` and calls a child template (`packaging_picking_item`) once per resulting page. See proposal.md for the bug this fixes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the report print at least one label for a picking with `package_qty` unset/0/negative, without touching any Python model or stored field.
+
+**Non-Goals:**
+- Not changing what `package_qty` means or how/when it gets set elsewhere in the codebase - this is purely about how the report reacts to it being 0.
+
+## Decisions
+
+- **Fix the guard at the parent's `range()` call, not inside the child template.** The child already had a `package_qty == 0` fallback, but it's structurally unreachable there: the parent's `t-foreach` decides how many times (if any) to call the child, so a 0-or-negative value has to be normalized before that `range()` call, not after.
+- **Keep the existing `t-if`/`t-else` inside `packaging_picking_item`**, rather than deleting it as now-fully-dead code: it still drives the "Package X / Y" label's denominator, so removing it would make the label show `Y=0` again for this same case.
+
+## Risks / Trade-offs
+
+- [None identified beyond the fix itself] → This is a narrowly-scoped template change with no Python/model surface; the existing dead-code cleanup (unused comments) carries no behavioral risk.
+
+## Migration Plan
+
+Template-only change to an existing report (`l10n_ve_stock.action_packaging_picking`). No data migration. Module version bump on `l10n_ve_stock` triggers the view reload on the next module update.

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/design.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/design.md
@@ -15,9 +15,12 @@
 - **Fix the guard at the parent's `range()` call, not inside the child template.** The child already had a `package_qty == 0` fallback, but it's structurally unreachable there: the parent's `t-foreach` decides how many times (if any) to call the child, so a 0-or-negative value has to be normalized before that `range()` call, not after.
 - **Keep the existing `t-if`/`t-else` inside `packaging_picking_item`**, rather than deleting it as now-fully-dead code: it still drives the "Package X / Y" label's denominator, so removing it would make the label show `Y=0` again for this same case.
 
+- **Restrict the recipient name line to outgoing pickings with a set `partner_id`, and switch to `display_name`.** The name is only meaningful for outgoing deliveries (this is what the customer sees printed on the label), and the previous unconditional `picking.partner_id.name[:80]` crashed (`TypeError: 'bool' object is not subscriptable`) when `partner_id` was empty - confirmed via staging logs. `display_name` is used instead of `name` per explicit client request; the `(... or '')[:80]` wrapper is an extra defensive layer in case `display_name` itself is falsy.
+
 ## Risks / Trade-offs
 
 - [None identified beyond the fix itself] → This is a narrowly-scoped template change with no Python/model surface; the existing dead-code cleanup (unused comments) carries no behavioral risk.
+- The recipient name line now no longer prints for non-outgoing pickings (internal transfers, receipts) even if `partner_id` happens to be set on those. This is the intended behavior per the client's request, not a regression - previously it printed for any picking type when `partner_id.name` existed.
 
 ## Migration Plan
 

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/proposal.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/proposal.md
@@ -8,10 +8,19 @@ The `packaging_picking` report (embalaje/etiquetas de bulto) iterates with `rang
 - The `t-if`/`t-else` block on `package_qty == 0` inside `packaging_picking_item` is kept as-is - it still has a real, visible use: it makes the "Package X / Y" label show `Y=1` instead of `Y=0` when `package_qty` is 0.
 - Remove dead commented-out code (`operation_employees`/`pick_employee`/`out_employee`) in `packaging_picking_item` that was unused anywhere.
 
+## Also in this change: recipient name shown only for outgoing pickings, using `display_name`
+
+`packaging_picking_item` printed the partner's name (`picking.partner_id.name[:80]`) unconditionally, regardless of picking type, and without checking that `partner_id` is set. This caused a real `TypeError: 'bool' object is not subscriptable` (confirmed `RPC_ERROR` in staging logs) when printing a label for a picking with an empty `partner_id`. Fix:
+
+- Only show the recipient name when `picking.picking_type_id.code == 'outgoing'` (the recipient name is only meaningful for outgoing deliveries) **and** `picking.partner_id` is set.
+- Use `partner_id.display_name` instead of `partner_id.name`, per explicit client request.
+- Guard against an empty `display_name` with `(picking.partner_id.display_name or '')[:80]` as an extra safety layer beyond the `t-if`.
+
 ## Capabilities
 
 ### Modified Capabilities
 - `l10n_ve_stock`: adds a requirement for the packaging/label report's behavior when `package_qty` is 0, unset, or negative (not previously documented in this capability's spec).
+- `l10n_ve_stock`: adds a requirement restricting the recipient name line to outgoing pickings with a set `partner_id`, and switching to `display_name`.
 
 ## Impact
 

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/proposal.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The `packaging_picking` report (embalaje/etiquetas de bulto) iterates with `range(1, picking.package_qty + 1)`. When `package_qty` is 0 (an unset field on the picking) this produces `range(1, 1)`, an empty range - the parent's `t-foreach` never invokes `packaging_picking_item` for that picking, so the report prints zero labels with no visible error. A "treat it as 1 package" fallback already existed inside `packaging_picking_item`, but it was unreachable: the parent had already discarded the iteration before ever calling that template.
+
+## What Changes
+
+- Move the "package_qty == 0 → treat as 1" guard from inside `packaging_picking_item` (where it never ran) to the parent's `range()` computation: `range(1, (picking.package_qty if picking.package_qty and picking.package_qty > 0 else 1) + 1)`. This also covers `None` and negative values, not just exactly `0`.
+- The `t-if`/`t-else` block on `package_qty == 0` inside `packaging_picking_item` is kept as-is - it still has a real, visible use: it makes the "Package X / Y" label show `Y=1` instead of `Y=0` when `package_qty` is 0.
+- Remove dead commented-out code (`operation_employees`/`pick_employee`/`out_employee`) in `packaging_picking_item` that was unused anywhere.
+
+## Capabilities
+
+### Modified Capabilities
+- `l10n_ve_stock`: adds a requirement for the packaging/label report's behavior when `package_qty` is 0, unset, or negative (not previously documented in this capability's spec).
+
+## Impact
+
+- **Module**: `l10n_ve_stock` (file: `report/packaging_picking_template.xml`).
+- **Report**: `l10n_ve_stock.action_packaging_picking` ("Packaging tags"), model `stock.picking`.
+- **No Python/model changes** - template-only fix.
+- **Manifest version bump**: `l10n_ve_stock` version bumped alongside this fix (patch-level), per repo convention of bumping the module version whenever its code changes.

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/specs/l10n_ve_stock/spec.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/specs/l10n_ve_stock/spec.md
@@ -18,3 +18,24 @@ El reporte `l10n_ve_stock.action_packaging_picking` DEBE (MUST) imprimir al meno
 
 - **WHEN** `package_qty` es 3
 - **THEN** el reporte imprime 3 etiquetas, numeradas "Package 1 / 3", "Package 2 / 3", "Package 3 / 3"
+
+### Requirement: Nombre del destinatario solo en pickings de salida, usando `display_name`
+
+El template `packaging_picking_item` DEBE (MUST) mostrar el nombre del partner solo cuando el `picking` es de tipo salida (`picking_type_id.code == 'outgoing'`) y tiene un `partner_id` seteado, y DEBE (MUST) usar `partner_id.display_name` en vez de `partner_id.name`, a pedido explícito del cliente.
+
+Antes de este requirement, el template evaluaba `picking.partner_id.name[:80]` sin verificar el tipo de picking ni la existencia de `partner_id`. En un picking sin `picking_type_id.code == 'outgoing'` con `partner_id` vacío, `picking.partner_id` resuelve a `False` (recordset vacío en booleano), y `False.name` no es un `TypeError` de slicing directo, pero el patrón `False[:80]` sobre el resultado de encadenar en un campo vacío sí produce un `TypeError: 'bool' object is not subscriptable` en runtime — confirmado en logs de staging (`RPC_ERROR`) al imprimir una etiqueta para un picking de salida sin `partner_id` asignado.
+
+#### Scenario: Picking de salida con partner asignado
+
+- **WHEN** se imprime la etiqueta para un picking con `picking_type_id.code == 'outgoing'` y `partner_id` seteado
+- **THEN** el reporte muestra el `display_name` del partner (recortado a 80 caracteres) en la parte superior de la etiqueta
+
+#### Scenario: Picking de salida sin partner asignado
+
+- **WHEN** se imprime la etiqueta para un picking con `picking_type_id.code == 'outgoing'` y `partner_id` vacío
+- **THEN** el reporte no muestra la línea del nombre del destinatario (el `t-if` la omite) y no lanza `TypeError`
+
+#### Scenario: Picking que no es de salida (ej. interno, recepción)
+
+- **WHEN** se imprime la etiqueta para un picking con `picking_type_id.code` distinto de `'outgoing'`
+- **THEN** el reporte no muestra la línea del nombre del destinatario, independientemente de si `partner_id` está seteado

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/specs/l10n_ve_stock/spec.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/specs/l10n_ve_stock/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Impresión de etiquetas de embalaje aunque `package_qty` esté sin setear
+
+El reporte `l10n_ve_stock.action_packaging_picking` DEBE (MUST) imprimir al menos una etiqueta de embalaje por traslado incluso cuando `package_qty` del `stock.picking` es 0, `False`/`None` o negativo, tratando esos casos como si fuera 1 paquete. El template padre `packaging_picking` calcula el rango de páginas a imprimir con `range(1, (picking.package_qty if picking.package_qty and picking.package_qty > 0 else 1) + 1)`; el fallback vive en ese cálculo, no dentro de `packaging_picking_item`, porque cualquier guard puesto ahí nunca se alcanza (el `t-foreach` del padre ya descartó la iteración antes de invocar ese sub-template).
+
+#### Scenario: Picking sin `package_qty` seteado
+
+- **WHEN** se imprime "Packaging tags" para un traslado con `package_qty` igual a 0
+- **THEN** el reporte imprime una etiqueta, mostrando "Package 1 / 1"
+
+#### Scenario: Picking con `package_qty` negativo
+
+- **WHEN** `package_qty` es un valor negativo
+- **THEN** el reporte igual imprime una etiqueta como si fuera 1 paquete, sin lanzar error
+
+#### Scenario: Picking con `package_qty` mayor a 1
+
+- **WHEN** `package_qty` es 3
+- **THEN** el reporte imprime 3 etiquetas, numeradas "Package 1 / 3", "Package 2 / 3", "Package 3 / 3"

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/tasks.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/tasks.md
@@ -1,0 +1,8 @@
+## 1. Fix
+- [x] 1.1 Move the `package_qty` zero/negative/unset guard to the parent `packaging_picking` template's `range()` call. Verified by reading the full diff of commit `0fed35d1d`.
+- [x] 1.2 Keep the existing `t-if`/`t-else` inside `packaging_picking_item` (drives the "Package X / Y" label denominator) - confirmed it is not dead code before touching anything.
+- [x] 1.3 Remove unused commented-out code (`operation_employees`/`pick_employee`/`out_employee`) in `packaging_picking_item`.
+- [x] 1.4 Bump `l10n_ve_stock`'s manifest version (`19.0.1.0.7` → `19.0.1.0.8`).
+
+## 2. Verification
+- [ ] 2.1 After merge, print "Packaging tags" for a real picking with `package_qty` unset and confirm it prints one label ("Package 1 / 1") instead of an empty report.

--- a/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/tasks.md
+++ b/openspec/changes/l10n-ve-stock-packaging-picking-zero-qty/tasks.md
@@ -6,3 +6,14 @@
 
 ## 2. Verification
 - [ ] 2.1 After merge, print "Packaging tags" for a real picking with `package_qty` unset and confirm it prints one label ("Package 1 / 1") instead of an empty report.
+
+## 3. Recipient name guard (outgoing-only, `display_name`)
+- [x] 3.1 Restrict the recipient name line to `picking.picking_type_id.code == 'outgoing'` and `picking.partner_id` set.
+- [x] 3.2 Switch from `partner_id.name` to `partner_id.display_name`, per explicit client request.
+- [x] 3.3 Wrap with `(... or '')[:80]` as an extra safety layer against an empty `display_name`.
+- [x] 3.4 Bump `l10n_ve_stock`'s manifest version (`19.0.1.0.8` → `19.0.1.0.9`).
+
+## 4. Verification
+- [ ] 4.1 After merge, print "Packaging tags" for an outgoing picking with `partner_id` set and confirm the recipient's `display_name` prints correctly.
+- [ ] 4.2 After merge, print "Packaging tags" for an outgoing picking with `partner_id` empty and confirm the report no longer raises `TypeError` and simply omits the recipient name line.
+- [ ] 4.3 After merge, print "Packaging tags" for a non-outgoing picking (e.g. internal transfer) and confirm the recipient name line does not print.


### PR DESCRIPTION
## Bug

En `l10n_ve_stock/report/packaging_picking_template.xml`, el template padre `packaging_picking` itera asi:

```xml
<t t-foreach="range(1, picking.package_qty + 1)" t-as="item">
```

Cuando `picking.package_qty` es `0` (campo sin setear en el picking), esto produce `range(1, 1)` — un rango **vacio**. El `t-foreach` del padre nunca llega a invocar `packaging_picking_item` para ese picking, y el reporte de etiquetas de embalaje sale completamente vacio para ese picking, **sin ningun error visible**.

Existia un intento de manejar este caso adentro del template hijo `packaging_picking_item`:

```xml
<t t-if="picking.package_qty == 0">
    <t t-set="package_qty" t-value="1"/>
</t>
<t t-else="">
    <t t-set="package_qty" t-value="picking.package_qty"/>
</t>
```

pero es codigo que nunca se ejecuta para el caso que pretende cubrir: el padre ya descarto la iteracion antes de siquiera llamar al hijo.

## Fix

Se mueve el fallback al calculo del `range()` del padre, que es donde realmente se decide cuantas etiquetas se generan:

```xml
<t t-foreach="range(1, (picking.package_qty if picking.package_qty and picking.package_qty > 0 else 1) + 1)" t-as="item">
```

Esto cubre `package_qty` en `0`, `None` y valores negativos (siempre imprime al menos 1 etiqueta).

**Nota importante:** el bloque `t-if`/`t-else` de `package_qty == 0` dentro de `packaging_picking_item` **no se elimino**. Confirme leyendo el archivo completo que ese bloque si tiene un uso visible: alimenta el `<span t-esc="package_qty"/>` que compone el label `"Package X / Y"` en la etiqueta. Sin ese guard, un picking con `package_qty=0` (que ahora si llega a imprimir gracias al fix de arriba) mostraria `"Package 1 / 0"` en vez de `"Package 1 / 1"`. Es un guard distinto y necesario, no duplicado del que se corrigio.

## Otros cambios (triviales, bajo riesgo)

Se eliminaron comentarios muertos al inicio de `packaging_picking_item` sobre `operation_employees`/`pick_employee`/`out_employee`, que no se usaban en ningun lado del template.

## Alcance

Cambio acotado a un solo archivo XML, sin logica Python nueva. No se toco nada de seguridad, ACLs ni modelos. Sin tests unitarios (a pedido explicito).

## Impacto en otros clientes

`l10n_ve_stock` es compartido por varios clientes de Binaural. Este cambio es una correccion de un bug real (reporte vacio sin error) que estrictamente mejora el comportamiento existente para todos los consumidores del modulo — no cambia ningun comportamiento que hoy funcione correctamente (un picking con `package_qty > 0` sigue imprimiendo exactamente la misma cantidad de etiquetas que antes).