### PR TITLE
[FIX] l10n_ve_payment_extension: invoice_amount se resetea a 0 en líneas nuevas de retención

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "17.0.0.0.35",
+    "version": "17.0.0.0.36",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_retention_line.py
+++ b/l10n_ve_payment_extension/models/account_retention_line.py
@@ -296,6 +296,12 @@ class AccountRetentionLine(models.Model):
         # untouched one to 0 on recompute. _origin preserves the persisted value.
         base_currency_is_vef = self.env.company.currency_id == self.env.ref("base.VEF")
         for line in self:
+            if not line._origin:
+                # Brand-new (unsaved) line: there is no persisted value to
+                # restore, so keep whatever the user/onchange just set instead
+                # of collapsing it to 0. Same guard already applied to
+                # retention_amount/foreign_retention_amount in _compute_retention_amount.
+                continue
             origin_invoice_amount = line._origin.invoice_amount
             origin_foreign_invoice_amount = line._origin.foreign_invoice_amount
             if not base_currency_is_vef:


### PR DESCRIPTION
## Resumen

`account.retention.line.invoice_amount` / `foreign_invoice_amount` están declarados `store=True, readonly=False` pero son campos calculados con un `@api.depends` **autorreferencial** (dependen de sí mismos). Al crear una retención de ISLR/Municipal directamente desde el menú de retenciones (no generada desde una factura ya contabilizada) y editar manualmente "Base Imponible", el compute relee `line._origin.invoice_amount` — que para una línea nueva/no persistida es 0 — y sobreescribe el valor recién tecleado con 0.

## Causa raíz

Mismo patrón ya identificado y corregido en este archivo (commit `ad2137549`) para `retention_amount`/`foreign_retention_amount`, pero nunca replicado para `invoice_amount`/`foreign_invoice_amount`.

## Fix

Guard `if not line._origin: continue` en `_compute_amounts`: si la línea no está persistida, se respeta el valor que dejó el onchange en vez de recalcularlo desde un origen inexistente.

## Por qué no se usó la propuesta alternativa (Victor Colmenarez, comentario en el ticket)

Se evaluó quitar `compute=` de ambos campos y reemplazarlo por dos `@api.onchange` de sincronización. Se descartó porque los `@api.onchange` no se ejecutan en `create()`/`write()` fuera del cliente web — cualquier creación server-side que solo asigne uno de los dos campos dejaría de sincronizar el otro. El guard sobre `_origin` mantiene el campo como `compute+store` (se sincroniza siempre, sea o no desde UI) y reutiliza el mismo patrón ya validado en el archivo.

## Validación

Probado end-to-end en instancia local 17.0 (`homo-v17`): factura de proveedor nueva con tasa de cambio válida → retención de IVA para proveedor → aprobación, sin el error "You can not create a retention with 0 amount." Confirmado también que el valor tecleado manualmente en Base Imponible ya no se resetea a 0 en líneas ISLR/Municipal creadas desde el menú de retenciones.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk.ticket/14836

🤖 Generated with [Claude Code](https://claude.com/claude-code)