### PR TITLE
[FIX] l10n_ve_invoice, l10n_ve_sale: permitir imprimir y enviar cotizaciones en borrador (ti 14822)

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.10",
+    "version": "19.0.1.0.11",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -776,13 +776,3 @@ msgid ""
 msgstr ""
 "Ninguno de los documentos seleccionados está publicado.\n"
 "Solo los documentos publicados se pueden imprimir."
-
-#. module: l10n_ve_invoice
-#. odoo-python
-#: code:addons/l10n_ve_invoice/models/ir_actions_report.py:0
-msgid ""
-"None of the selected sale orders are confirmed.\n"
-"Only non-draft orders can be printed."
-msgstr ""
-"Ninguna de las órdenes de venta seleccionadas está confirmada.\n"
-"Solo las órdenes no borrador se pueden imprimir."

--- a/l10n_ve_invoice/models/ir_actions_report.py
+++ b/l10n_ve_invoice/models/ir_actions_report.py
@@ -16,15 +16,6 @@ class IrActionsReport(models.Model):
                     "Only posted documents can be printed."
                 ))
             res_ids = valid.ids
-        if report and res_ids and report.model == 'sale.order':
-            docs = self.env['sale.order'].browse(res_ids)
-            valid = docs.filtered(lambda d: d.state != 'draft')
-            if not valid:
-                raise UserError(_(
-                    "None of the selected sale orders are confirmed.\n"
-                    "Only non-draft orders can be printed."
-                ))
-            res_ids = valid.ids
         return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
 
     def _render_qweb_html(self, report_ref, docids, data=None):
@@ -41,15 +32,6 @@ class IrActionsReport(models.Model):
                 raise UserError(_(
                     "None of the selected documents are posted.\n"
                     "Only posted documents can be printed."
-                ))
-            return super()._render_qweb_html(report_ref, valid.ids, data=data)
-        if model == 'sale.order' and ids:
-            docs = self.env[model].browse(ids)
-            valid = docs.filtered(lambda d: d.state != 'draft')
-            if not valid:
-                raise UserError(_(
-                    "None of the selected sale orders are confirmed.\n"
-                    "Only non-draft orders can be printed."
                 ))
             return super()._render_qweb_html(report_ref, valid.ids, data=data)
         return super()._render_qweb_html(report_ref, docids, data=data)

--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "19.0.1.0.5",
+    "version": "19.0.1.0.6",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/tests/__init__.py
+++ b/l10n_ve_sale/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_sale_order_vat
 from . import test_action_confirm
 from . import test_create_invoices_note_lines
 #from . import test_sale_order_invoice_status
+from . import test_report_quotation_print

--- a/l10n_ve_sale/tests/test_report_quotation_print.py
+++ b/l10n_ve_sale/tests/test_report_quotation_print.py
@@ -1,0 +1,106 @@
+from unittest.mock import patch
+
+from odoo import Command, fields
+from odoo.addons.base.models.ir_actions_report import IrActionsReport
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "l10n_ve_sale")
+class TestReportQuotationPrint(TransactionCase):
+    """Una cotización en borrador debe poder imprimirse y enviarse por correo.
+
+    El diálogo de envío de Odoo 19 renderiza el PDF del reporte al abrirse, así
+    que cualquier restricción de impresión sobre sale.order inutiliza el botón
+    "Enviar" de una cotización (ticket 14822).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.report_saleorder = 'sale.report_saleorder'
+        self.report_invoice = 'account.account_invoices'
+
+        # Sin moneda de la compañía y moneda alterna configuradas, el cómputo de
+        # tax_totals de l10n_ve_accountant redondea contra un res.currency vacío.
+        self.company = self.env.company
+        self.ves = self.env.ref('base.VEF')
+        self.usd = self.env.ref('base.USD')
+        self.company.currency_id = self.ves
+        self.company.foreign_currency_id = self.usd
+        self.env['res.currency.rate'].create({
+            'currency_id': self.usd.id,
+            'company_id': self.company.id,
+            'name': fields.Date.today(),
+            'rate': 1.0 / 380.0,
+        })
+
+        self.account_receivable = self.env['account.account'].create({
+            'name': 'Receivable', 'code': '1111111',
+            'account_type': 'asset_receivable', 'reconcile': True,
+        })
+        self.account_revenue = self.env['account.account'].create({
+            'name': 'Revenue', 'code': '4444444',
+            'account_type': 'income',
+        })
+        self.journal_sale = self.env['account.journal'].create({
+            'name': 'Sale Journal', 'type': 'sale',
+            'code': 'SALE1',
+            'default_account_id': self.account_revenue.id,
+        })
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'property_account_receivable_id': self.account_receivable.id,
+        })
+        self.product = self.env['product.product'].create({
+            'name': 'Service Product',
+            'type': 'service',
+            'list_price': 100.0,
+            'property_account_income_id': self.account_revenue.id,
+        })
+        self.order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': self.product.id,
+                'product_uom_qty': 1,
+                'price_unit': 100.0,
+            })],
+        })
+
+    def test_01_render_html_draft_quotation(self):
+        """El HTML del reporte de una cotización en borrador se genera."""
+        self.assertEqual(self.order.state, 'draft')
+        html, report_type = self.env['ir.actions.report']._render_qweb_html(
+            self.report_saleorder, self.order.ids
+        )
+        self.assertEqual(report_type, 'html')
+        self.assertIn(self.order.name, html.decode())
+
+    def test_02_render_pdf_streams_draft_quotation(self):
+        """El PDF de una cotización en borrador no se bloquea."""
+        self.assertEqual(self.order.state, 'draft')
+        with patch.object(
+            IrActionsReport, '_render_qweb_pdf_prepare_streams', return_value={}
+        ):
+            self.env['ir.actions.report']._render_qweb_pdf_prepare_streams(
+                self.report_saleorder, {}, res_ids=self.order.ids
+            )
+
+    def test_03_draft_invoice_still_blocked(self):
+        """No se regresa el ticket 14012: la factura en borrador sigue bloqueada."""
+        invoice = self.env['account.move'].with_context(check_move_validity=False).create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+            'journal_id': self.journal_sale.id,
+            'invoice_date': fields.Date.today(),
+            'date': fields.Date.today(),
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product.id,
+                'quantity': 1,
+                'price_unit': 100.0,
+            })],
+        })
+        self.assertEqual(invoice.state, 'draft')
+        with self.assertRaises(UserError):
+            self.env['ir.actions.report']._render_qweb_pdf_prepare_streams(
+                self.report_invoice, {}, res_ids=invoice.ids
+            )

--- a/openspec/specs/l10n_ve_invoice/spec.md
+++ b/openspec/specs/l10n_ve_invoice/spec.md
@@ -112,14 +112,19 @@ Cuando la compañía activa `block_invoice_display_date_upper_than_date`, el sis
 - **WHEN** se guarda una factura de proveedor con fecha de documento posterior a la fecha contable y el bloqueo activo
 - **THEN** se lanza un error "The invoice date cannot be greater than the accounting date."
 
-### Requirement: Solo documentos confirmados se imprimen
+### Requirement: Solo documentos contables confirmados se imprimen
 
-`ir.actions.report` DEBE (MUST) filtrar las impresiones (PDF y HTML) de `account.move` a documentos en estado `posted` y las de `sale.order` a órdenes no borrador, lanzando un error cuando ningún documento seleccionado cumple la condición.
+`ir.actions.report` DEBE (MUST) filtrar las impresiones (PDF y HTML) de `account.move` a documentos en estado `posted`, lanzando un error cuando ningún documento seleccionado cumple la condición. La restricción NO DEBE (MUST NOT) aplicarse a otros modelos: en particular `sale.order`, cuyas cotizaciones se imprimen y se envían por correo estando en borrador.
 
 #### Scenario: Imprimir factura en borrador
 
 - **WHEN** se solicita el PDF de una factura no publicada
 - **THEN** se lanza un error indicando que solo se imprimen documentos publicados
+
+#### Scenario: Imprimir o enviar una cotización en borrador
+
+- **WHEN** se solicita el reporte de una orden de venta en estado `draft` (por el botón Imprimir o por el adjunto que genera el diálogo de envío de correo)
+- **THEN** el reporte se genera normalmente, sin restricción alguna
 
 ### Requirement: Registro de la fecha-hora de emisión
 


### PR DESCRIPTION
## Problema

Ticket **[14822](https://binaural.odoo.com/odoo/helpdesk/action-389/14822)** (Sumiflex, V19): al pulsar **Enviar** en una cotización en borrador, Odoo muestra:

> **Operación no válida**
> Ninguna de las órdenes de venta seleccionadas está confirmada.
> Solo las órdenes no borrador se pueden imprimir.

El botón queda inutilizable: no se puede enviar ninguna cotización por correo.

## Causa raíz

`l10n_ve_invoice/models/ir_actions_report.py` bloqueaba el render de **cualquier** reporte cuyo `model` fuera `sale.order` cuando todas las órdenes estaban en `draft`, tanto en `_render_qweb_pdf_prepare_streams` como en `_render_qweb_html`.

En Odoo 19 el diálogo de envío **genera el PDF al abrirse**, no al enviar:

```
sale_order.action_quotation_send()                sale/models/sale_order.py:1068
 └─ dialog mail.compose.message
    └─ MailComposer._compute_attachment_ids       mail/wizard/mail_compose_message.py:261
       └─ MailTemplate._generate_template_attachments  mail/models/mail_template.py:332
          └─ ir.actions.report._render_qweb_pdf(...)   mail/models/mail_template.py:369
             └─ _render_qweb_pdf_prepare_streams / _render_qweb_html   ← override l10n_ve
```

No hay `try/except` en ninguna capa de esa cadena, así que el `UserError` impide que el diálogo llegue a abrirse.

La restricción sobre `sale.order` la introdujo el commit `beb7886a9` para el ticket **[14012](https://binaural.odoo.com/odoo/helpdesk/action-389/14012)**, que pedía únicamente bloquear la impresión de la **forma libre de documentos fiscales** (Factura, Nota de Débito, Nota de Crédito) en borrador. Las órdenes de venta nunca estuvieron en ese alcance, y Odoo estándar imprime cotizaciones en borrador **por diseño**: el reporte se llama "Quotation / Order" y conmuta el título entre *Quotation #* y *Order #* según `doc.state in ('draft','sent')` (`sale/report/ir_actions_report.xml:4-13`, `sale/report/ir_actions_report_templates.xml:39-45`).

## Cambios

- `l10n_ve_invoice/models/ir_actions_report.py`: se eliminan las dos ramas `sale.order`. **El bloqueo de `account.move` queda intacto.**
- `l10n_ve_invoice/i18n/es_VE.po`: se elimina el bloque de traducción huérfano.
- `l10n_ve_sale/tests/test_report_quotation_print.py` (nuevo): test de regresión. Va en `l10n_ve_sale` porque `l10n_ve_invoice` **no depende de `sale`**, mientras que `l10n_ve_sale` depende de ambos.
  - `test_01_render_html_draft_quotation`: el HTML de la cotización en borrador se genera.
  - `test_02_render_pdf_streams_draft_quotation`: el PDF de la cotización en borrador no se bloquea.
  - `test_03_draft_invoice_still_blocked`: la factura en borrador **sigue** lanzando `UserError` (no se regresa el 14012).
- `openspec/specs/l10n_ve_invoice/spec.md`: se actualiza el requirement para que hable solo de `account.move`.
- Bump: `l10n_ve_invoice` 19.0.1.0.10 → 19.0.1.0.11 · `l10n_ve_sale` 19.0.1.0.5 → 19.0.1.0.6.

También quedan arreglados de paso el envío masivo de cotizaciones (acción de servidor `sale.model_sale_order_send_mail`) y el botón *Vista previa*.

## Cómo probar

1. Ventas → Órdenes → Cotizaciones → abrir una cotización en estado *Cotización* (borrador).
2. **Enviar** → debe abrirse el diálogo de correo con el PDF adjunto, sin el error "Operación no válida".
3. Enviar → el estado pasa a *Cotización enviada*.
4. **Imprimir** sobre una cotización en borrador → PDF con encabezado *Cotización #*.
5. **No regresión 14012:** una factura de cliente en borrador debe seguir lanzando "Ninguno de los documentos seleccionados está publicado" al imprimir.

```
./scripts/odoo-test <instancia> -t /l10n_ve_sale -i l10n_ve_sale
./scripts/odoo-test <instancia> -t /l10n_ve_invoice -i l10n_ve_invoice
```

## Observación fuera de alcance

El bloqueo de `account.move` también es más amplio de lo que pidió el 14012: aplica a **todos** los reportes de `account.move`, no solo a la forma libre. No se toca en este PR.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/14822
- Otros: https://binaural.odoo.com/odoo/helpdesk/action-389/14012 (origen de la restricción)
