### PR TITLE
[FIX] l10n_ve_stock_purchase: resolver producto por Código Alterno en línea de compra

### DIFF
--- a/l10n_ve_stock_purchase/__init__.py
+++ b/l10n_ve_stock_purchase/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ve_stock_purchase/__manifest__.py
+++ b/l10n_ve_stock_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Inventario/Compras",
-    "version": "1.1",
+    "version": "19.0.1.2.0",
     "license": "LGPL-3",
     "summary": "Módulo para gestionar inventario/compras en Venezuela",
     "description": """
@@ -11,9 +11,11 @@
     "category": "Purchase",
     "depends": [
         "purchase_stock",
+        "l10n_ve_stock",
     ],
     "data": [
         "security/ir.model.access.csv",
+        "views/purchase_order_views.xml",
     ],
     "application": True,
     "images": ["static/description/icon.png"],

--- a/l10n_ve_stock_purchase/i18n/es_VE.po
+++ b/l10n_ve_stock_purchase/i18n/es_VE.po
@@ -1,0 +1,30 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ve_stock_purchase
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-28 00:00+0000\n"
+"PO-Revision-Date: 2026-08-28 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ve_stock_purchase
+#: model:ir.model.fields,field_description:l10n_ve_stock_purchase.field_purchase_order_line__alternate_code
+msgid "Alternate Code"
+msgstr "Código Alterno"
+
+#. module: l10n_ve_stock_purchase
+#: model:ir.model.fields,help:l10n_ve_stock_purchase.field_purchase_order_line__alternate_code
+msgid ""
+"Alternate code of the product, taken from the product form. Shown here "
+"for reference only; edit it on the product itself."
+msgstr ""
+"Código alterno del producto, tomado de la ficha del producto. Se muestra "
+"aquí solo como referencia; edítelo en el producto."

--- a/l10n_ve_stock_purchase/models/__init__.py
+++ b/l10n_ve_stock_purchase/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_product
+from . import purchase_order_line

--- a/l10n_ve_stock_purchase/models/product_product.py
+++ b/l10n_ve_stock_purchase/models/product_product.py
@@ -1,0 +1,28 @@
+from odoo import api, models
+from odoo.fields import Domain
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.model
+    def name_search(self, name="", domain=None, operator="ilike", limit=100):
+        results = super().name_search(name, domain, operator, limit)
+        if not name or operator in Domain.NEGATIVE_OPERATORS:
+            return results
+        remaining_limit = None
+        if limit:
+            remaining_limit = limit - len(results)
+            if remaining_limit <= 0:
+                return results
+        alternate_domain = Domain(domain or Domain.TRUE) & Domain(
+            "alternate_code", operator, name
+        )
+        if results:
+            alternate_domain &= Domain("id", "not in", [res[0] for res in results])
+        products = self.search_fetch(
+            alternate_domain, ["display_name"], limit=remaining_limit
+        )
+        return results + [
+            (product.id, product.display_name) for product in products.sudo()
+        ]

--- a/l10n_ve_stock_purchase/models/purchase_order_line.py
+++ b/l10n_ve_stock_purchase/models/purchase_order_line.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    alternate_code = fields.Char(
+        related="product_id.alternate_code",
+        string="Alternate Code",
+        help=(
+            "Alternate code of the product, taken from the product form. "
+            "Shown here for reference only; edit it on the product itself."
+        ),
+    )

--- a/l10n_ve_stock_purchase/views/purchase_order_views.xml
+++ b/l10n_ve_stock_purchase/views/purchase_order_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="purchase_order_form_alternate_code" model="ir.ui.view">
+        <field name="name">purchase.order.form.alternate.code</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_id']" position="after">
+                <field name="alternate_code" optional="show" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/README.md
+++ b/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/README.md
@@ -1,0 +1,3 @@
+# l10n-ve-stock-purchase-alternate-code-search
+
+Resuelve producto por alternate_code al agregar linea en Compras (ticket 14833)

--- a/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/design.md
+++ b/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/design.md
@@ -1,0 +1,36 @@
+## Context
+
+`product.product` already overrides `name_search` in Odoo core (prioritizes exact `default_code`, then `barcode`, then partial matches) and overrides `_search_display_name`. In Odoo 19 the many2one autocomplete in the web client calls `web_name_search` (`addons/web/models/models.py`), which delegates to `self.name_search(name, domain, operator, limit)` — so extending `name_search` on `product.product` covers the purchase order line dropdown (and any other many2one using the same path) without touching the view widget or a separate `_search_display_name` override. See proposal.md for the motivating bug.
+
+Note the Odoo 19 signature change from earlier versions: the second positional argument is `domain` (not `args`). An override copied from a 17.0/18.0 base with `args=None` breaks the `super()` call.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `alternate_code` a first-class match key in `product.product.name_search`, without discarding or reordering what `super()` already returns.
+- Surface the resolved code back on the purchase order line as a read-only reference, so buyers can visually confirm which code matched.
+
+**Non-Goals:**
+- Not changing `product.template.alternate_code` itself (already defined in `l10n_ve_stock`) or its constraints/uniqueness.
+- Not touching `_search_display_name` or the core `name_search` relevance order for `default_code`/`barcode`/`name` — only appending.
+- Not extending this behavior to sales order lines or other many2one pickers in this change; scope is purchase order lines only, per the ticket.
+
+## Decisions
+
+- **Extend `name_search`, don't replace it.** Alternatives considered: overriding `_search_display_name` instead (rejected — that path is for computing display names, not full-text candidate search, and duplicating the core `name_search` logic there would be more invasive and easier to desync from core updates); overriding at the view/widget level with a custom `search_default` domain (rejected — doesn't cover other callers of `name_search`, e.g. API/XML-RPC clients).
+- **Append `alternate_code` matches after `super()`'s results, excluding ids already returned.** This preserves the existing relevance order (exact `default_code` first) and avoids showing the same product twice when it matches on both criteria.
+- **Respect the caller's `domain` and remaining `limit`.** The alternate-code search reuses the caller's `domain` (AND-ed with the `alternate_code` condition) and only asks for `limit - len(results)` additional records, so callers that pass a restrictive domain or a small limit still get correct, bounded results.
+- **No-op on negative operators (`not ilike`, `not in`, etc.).** `Domain.NEGATIVE_OPERATORS` is used as the guard; negating a "code contains X" condition across two fields via simple concatenation would not produce a correct "does not match" set, so those cases fall through to `super()`'s behavior unchanged.
+- **`purchase.order.line.alternate_code` as `related`, not stored/computed.** It is a pure read-only mirror of `product_id.alternate_code` for display purposes; there is no independent value to store or business logic to compute, so `related=` is the simplest, always-in-sync choice.
+- **New view field is `optional="show"`, `readonly="1"`.** Visible by default but a user can hide it from the optional-columns picker; read-only because the source of truth is the product form, not the purchase line.
+- **`l10n_ve_stock_purchase` gains `l10n_ve_stock` as a dependency, not `l10n_ve_stock`(the product module) itself absorbing purchase view logic.** `alternate_code` is defined in `l10n_ve_stock` on `product.template`, but that module intentionally does not depend on `purchase` — it is inventory-scoped. `l10n_ve_stock_purchase` is the existing inventory/purchase bridge module, so it is the correct place for a `purchase.order.line` view inheritance and a `product.product` override that only matters in a purchasing context.
+
+## Risks / Trade-offs
+
+- [Extra DB query per `name_search` call when the caller's typed text does not already match via `super()`] → Bounded by `remaining_limit` and short-circuited entirely (`return results` before querying) whenever `super()` already fills the requested `limit`, or when the search term is empty, or on negative operators.
+- [Duplicate products if `search_fetch` returns an id also present in `results`] → Explicitly excluded via `Domain("id", "not in", [...])` before calling `search_fetch`.
+- [`sudo()` on the alternate-code matches bypasses per-record read rules for products matched only by this new path] → Accepted: this mirrors how `product.product` is generally readable for purchasing purposes across the codebase, and `sudo()` here only affects the name/id pair used for display, not read access to the underlying product record elsewhere.
+
+## Migration Plan
+
+No data migration. Adding the `alternate_code` related field and the view triggers a standard module update (`-u l10n_ve_stock_purchase`) picking up the new field/view/dependency. Rollback is a plain module downgrade/revert since no stored data or ACL changes are introduced. Once this ships, the temporary staging module `maxcam_purchase_alternate_code` must be uninstalled to avoid two "Código Alterno" columns on the same view.

--- a/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/proposal.md
+++ b/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Helpdesk ticket 14833: typing a product's `alternate_code` (Código Alterno) into a purchase order line does not resolve the product, because `product.product`'s core `name_search` only matches `default_code`, `name`, and `barcode`. A hotfix module (`maxcam_purchase_alternate_code`) already proves the fix works on a client staging environment, but it lives unversioned there and is lost on every rebuild. This change ports that verified fix into the shared product (`l10n_ve_stock_purchase`, repo `odoo-venezuela`) so it survives rebuilds and reaches every client, not just the one that reported it.
+
+## What Changes
+
+- Extend `product.product.name_search` to also match `alternate_code` (partial, case-insensitive), appended after the core `super()` results so the existing relevance order (`default_code` exact, then `barcode`, then partials) is preserved, with no duplicate ids and no behavior change for negative-operator domains.
+- Add a read-only related field `purchase.order.line.alternate_code` (mirrors `product_id.alternate_code`, not stored).
+- Add an optional, translated "Código Alterno" column to the purchase order line list view, positioned after "Product".
+- Add `l10n_ve_stock` as a manifest dependency (source of `product.template.alternate_code`) and register the new view in `data`.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `l10n_ve_stock_purchase`: adds requirements for resolving products by `alternate_code` in `name_search` and for displaying that code as an optional column on purchase order lines. The module's dependency surface also grows from `purchase_stock`-only to include `l10n_ve_stock`.
+
+## Impact
+
+- **Module**: `l10n_ve_stock_purchase` (repo `odoo-venezuela`, base branch `19.0`).
+- **New files**: `models/__init__.py`, `models/product_product.py`, `models/purchase_order_line.py`, `views/purchase_order_views.xml`, `i18n/es_VE.po`.
+- **Manifest**: `depends` gains `l10n_ve_stock`; `data` gains `views/purchase_order_views.xml`; version bumped `1.1` → `19.0.1.2.0` (repo's `19.0.x.y.z` scheme; the previous `1.1` did not follow it).
+- **No security/ACL changes** beyond the module's existing `security/ir.model.access.csv` (untouched).
+- **Source ticket**: Helpdesk 14833. Once this ships, the temporary `maxcam_purchase_alternate_code` hotfix module on the client's staging environment must be uninstalled/removed to avoid a duplicate column.

--- a/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/specs/l10n_ve_stock_purchase/spec.md
+++ b/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/specs/l10n_ve_stock_purchase/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Búsqueda de producto por Código Alterno al agregar línea de compra
+El sistema DEBE (MUST) resolver un producto por su `alternate_code` (Código Alterno) cuando se escribe texto en el selector de producto de una línea de orden de compra, además de los criterios ya soportados por el núcleo (`default_code`, `barcode`, nombre). Los resultados obtenidos por `alternate_code` DEBEN agregarse después de los que devuelve el comportamiento estándar, sin duplicar productos ya incluidos, respetando el `domain` y el `limit` recibidos, y sin aplicarse cuando el operador de búsqueda es negativo.
+
+#### Scenario: Coincidencia exacta por Código Alterno
+- **WHEN** un usuario escribe el Código Alterno completo de un producto (por ejemplo `RPCL4-1001`) en el selector de producto de una línea de orden de compra
+- **THEN** el desplegable muestra el producto cuyo `alternate_code` coincide
+
+#### Scenario: Coincidencia parcial por Código Alterno
+- **WHEN** un usuario escribe una parte del Código Alterno de un producto (por ejemplo `RPCL4-18`)
+- **THEN** el desplegable muestra los productos cuyo `alternate_code` contiene ese texto
+
+#### Scenario: Sin regresión en la búsqueda estándar
+- **WHEN** un usuario escribe la Referencia Interna (`default_code`) o el nombre de un producto en la línea de compra
+- **THEN** el producto sigue resolviendo igual que antes de este cambio, y en el mismo orden de relevancia
+
+#### Scenario: Producto que coincide por dos criterios no se duplica
+- **WHEN** el texto escrito coincide simultáneamente con el `default_code`/nombre/`barcode` de un producto y también con su `alternate_code`
+- **THEN** ese producto aparece una sola vez en el desplegable
+
+#### Scenario: Sin coincidencias
+- **WHEN** el texto escrito no coincide con ningún `default_code`, nombre, `barcode` ni `alternate_code`
+- **THEN** el desplegable no muestra productos
+
+#### Scenario: Operador de búsqueda negativo
+- **WHEN** la búsqueda de producto se ejecuta con un operador negativo (por ejemplo `not ilike`)
+- **THEN** el comportamiento es exactamente el del núcleo, sin considerar `alternate_code`
+
+### Requirement: Columna Código Alterno en la línea de orden de compra
+El sistema DEBE (MUST) mostrar el Código Alterno del producto seleccionado como columna de solo lectura en la lista de líneas de la orden de compra, disponible como columna opcional y traducida a `es_VE`.
+
+#### Scenario: Columna visible por defecto
+- **WHEN** un usuario abre una orden de compra con líneas
+- **THEN** la columna "Código Alterno" se muestra junto a la columna de producto, con el valor de `product_id.alternate_code`, y no es editable desde la línea
+
+#### Scenario: Columna ocultable
+- **WHEN** un usuario abre el selector de columnas opcionales de la lista de líneas de compra
+- **THEN** puede ocultar la columna "Código Alterno" sin afectar el dato almacenado en el producto

--- a/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/tasks.md
+++ b/openspec/changes/l10n-ve-stock-purchase-alternate-code-search/tasks.md
@@ -1,0 +1,19 @@
+## 1. Port the fix from the client staging hotfix
+
+- [x] 1.1 Add `models/product_product.py` extending `product.product.name_search` to also match `alternate_code`, appended after `super()`, respecting `domain`/`limit`, excluding duplicate ids, and no-op on negative operators. Verified by reading the ticket 14833 section 5 code and porting it unchanged.
+- [x] 1.2 Add `models/purchase_order_line.py` with a read-only `alternate_code` related field (`product_id.alternate_code`). Verified by `python3 -c "import ast; ast.parse(...)"` on the file.
+- [x] 1.3 Add `models/__init__.py` and the package-level `__init__.py` importing `models`. Verified by `python3 -c "import ast; ast.parse(...)"` on both files.
+- [x] 1.4 Add `views/purchase_order_views.xml` inheriting `purchase.purchase_order_form`, inserting an optional read-only `alternate_code` column after `product_id` in the order line list. Verified by `python3 -c "import xml.etree.ElementTree as ET; ET.parse(...)"`.
+
+## 2. Manifest and translations
+
+- [x] 2.1 Add `l10n_ve_stock` to `depends` (source of `product.template.alternate_code`) and add `views/purchase_order_views.xml` to `data` in `__manifest__.py`. Verified by `python3 -c "eval(open('__manifest__.py').read())"`.
+- [x] 2.2 Bump the manifest `version` from the non-conforming `1.1` to `19.0.1.2.0`, matching the repo's `19.0.x.y.z` scheme. Verified by reading the updated manifest.
+- [x] 2.3 Add `i18n/es_VE.po` translating the new field's `field_description` ("Alternate Code" → "Código Alterno") and `help` string. Verified with `msgfmt --check -o /dev/null i18n/es_VE.po`.
+
+## 3. Verification
+
+- [ ] 3.1 Update the module in a real Odoo 19 environment (`odoo -u l10n_ve_stock_purchase -d <db> --stop-after-init` or `./odoo update -d <db> -m l10n_ve_stock_purchase`) and confirm it installs/updates without errors.
+- [ ] 3.2 In Purchase > Quotations > New, type a product's `alternate_code` (full and partial) in a line and confirm it resolves the expected product; confirm `default_code` and name search still work unchanged; confirm a non-matching text returns no results.
+- [ ] 3.3 Confirm the "Código Alterno" column appears on the purchase order line list with the correct value, is read-only, and can be hidden from the optional columns picker.
+- [ ] 3.4 Once deployed, uninstall/remove the temporary `maxcam_purchase_alternate_code` hotfix module from the client's staging environment to avoid a duplicate column (tracked in ticket 14833, not part of this PR).


### PR DESCRIPTION
## Resumen

Extiende la búsqueda de producto en líneas de Compras para que también
resuelva por **Código Alterno** (`alternate_code`), no solo por
Referencia Interna / nombre / código de barras.

- Extiende `name_search` de `product.product` (módulo
  `l10n_ve_stock_purchase`) para que también resuelva por
  `alternate_code`, **agregando** los resultados después de los que ya
  devuelve `super()` (mismo orden de relevancia: `default_code` exacto,
  luego `barcode`, luego parciales), sin duplicar ids, respetando
  `domain`/`limit`, y sin efecto sobre operadores negativos
  (`Domain.NEGATIVE_OPERATORS`).
- Agrega el campo `related` de solo lectura `alternate_code` en
  `purchase.order.line`.
- Agrega una columna opcional y de solo lectura "Código Alterno" en la
  lista de líneas de la orden de compra, después de la columna de
  producto.
- Manifest: agrega `l10n_ve_stock` a `depends` (ahí vive
  `product.template.alternate_code`), agrega
  `views/purchase_order_views.xml` a `data`, sube la versión de `1.1`
  (no seguía el esquema del repo) a `19.0.1.2.0`.
- `i18n/es_VE.po`: traduce el `field_description` y el `help` del nuevo
  campo.
- Documentado con OpenSpec en
  `openspec/changes/l10n-ve-stock-purchase-alternate-code-search/`
  (proposal, design, specs delta sobre `l10n_ve_stock_purchase`, tasks),
  validado con `openspec validate --strict`.

## Test plan

- [x] Sintaxis Python validada con `ast.parse` en los 4 archivos `.py`
      nuevos/modificados.
- [x] Sintaxis XML validada con `xml.etree.ElementTree.parse` en
      `views/purchase_order_views.xml`.
- [x] `__manifest__.py` evaluado (`eval`) para confirmar estructura
      válida.
- [x] `i18n/es_VE.po` validado con `msgfmt --check`.
- [x] `openspec validate l10n-ve-stock-purchase-alternate-code-search
      --strict` → válido.
- [ ] Actualizar el módulo en un entorno Odoo 19 real
      (`-u l10n_ve_stock_purchase`) y probar en Compras > Cotizaciones >
      Nueva: buscar por Código Alterno completo y parcial, confirmar que
      Referencia Interna y nombre siguen funcionando sin regresión, y que
      la columna nueva se ve en la línea.
- Sin tests unitarios en este PR.