### PR TITLE
[FIX] l10n_ve_stock: etiqueta de bulto usa display_name solo en salidas

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "19.0.1.0.7",
+    "version": "19.0.1.0.8",
     "depends": [
         "stock",
         "product",

--- a/l10n_ve_stock/report/packaging_picking_template.xml
+++ b/l10n_ve_stock/report/packaging_picking_template.xml
@@ -22,7 +22,7 @@
             </div>
             <div class="row border border-dark rounded mt-2 p-2">
                 <div class="col-12 text-center" style="height:2.5rem !important">
-                    <p t-out="picking.partner_id.name[:80]" class="h5" />
+                    <p t-if="picking.picking_type_id and picking.picking_type_id.code in ['outgoing']" t-out="picking.partner_id.display_name[:80]" class="h5" />
                 </div>
             </div>
             <div class="row font-weight-bold border-right border-left">


### PR DESCRIPTION
## Summary
- La etiqueta de bulto (`packaging_picking_item`) mostraba `partner_id.name` para cualquier tipo de picking.
- Ahora solo se muestra en pickings de salida (`picking_type_id.code == 'outgoing'`), usando `partner_id.display_name` para reflejar el nombre comercial completo del contacto. En el resto de tipos de picking la etiqueta queda vacía.

## Test plan
- [ ] Imprimir la etiqueta de bultos (Packaging tags) de un picking de salida y verificar que se muestre el display_name del contacto.
- [ ] Imprimir la etiqueta de un picking que no sea de salida (interno/entrada) y verificar que ese párrafo quede vacío.

🤖 Generated with [Claude Code](https://claude.com/claude-code)