### PR TITLE
validar productos y monto de Notas de Crédito contra su factura origen

### DIFF
--- a/l10n_ve_donation/__manifest__.py
+++ b/l10n_ve_donation/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Venezuela - Donaciones",
-    "version": "19.0.2.0.2",
+    "version": "19.0.2.0.3",
     "category": "Accounting/Accounting",
     "summary": "Venezuela - Donaciones",
     "author": "",

--- a/l10n_ve_donation/models/account_move.py
+++ b/l10n_ve_donation/models/account_move.py
@@ -96,9 +96,16 @@ class AccountMove(models.Model):
                     "is_donation": True,
                     "invoice_line_ids": invoice_line_vals,
                 }
+                # `l10n_ve_skip_refund_origin_validation` -- este NC nunca
+                # repite el producto de la factura original (usa el
+                # producto de donación dedicado, ver
+                # `product_line_donation()`), así que no debe pasar por
+                # la validación de `l10n_ve_invoice` que exige que los
+                # productos de la NC ya estén en la factura de origen.
                 reverse_move = self.env['account.move'].with_context(
                     check_move_validity=False,
                     skip_invoice_sync=True,
+                    l10n_ve_skip_refund_origin_validation=True,
                 ).create(move_vals)
                 reverse_moves += reverse_move
             return reverse_moves

--- a/l10n_ve_donation/openspec/changes/l10n-ve-donation-skip-refund-origin-validation/proposal.md
+++ b/l10n_ve_donation/openspec/changes/l10n-ve-donation-skip-refund-origin-validation/proposal.md
@@ -1,0 +1,24 @@
+# Fix: Coordinar la NC de donación con la nueva validación de origen de `l10n_ve_invoice`
+
+## Why
+
+Ticket Helpdesk #13965. `l10n_ve_invoice` incorpora un `@api.constrains` en
+`account.move` que bloquea cualquier producto de una Nota de Crédito
+(`out_refund`) ausente en la factura que revierte
+(`reversed_entry_id`). `l10n_ve_donation._reverse_moves()`
+(`models/account_move.py`) crea justamente ese tipo de NC, pero con un
+producto de donación dedicado (`is_donation_product=True`), nunca el
+producto de la factura original. Sin coordinación, revertir una factura de
+donación se rompería con `ValidationError`.
+
+## What Changes
+
+- `_reverse_moves()` pasa ahora `l10n_ve_skip_refund_origin_validation=True`
+  al `create()` de la Nota de Crédito de donación, el mismo mecanismo de
+  bypass que ya usaba `l10n_ve_exchange_difference` de forma anticipada.
+- Bump de manifest `19.0.2.0.2` -> `19.0.2.0.3`.
+
+## Non-goals
+
+- No cambia ninguna regla de negocio de donaciones, solo evita una
+  regresión introducida por un módulo hermano.

--- a/l10n_ve_donation/openspec/changes/l10n-ve-donation-skip-refund-origin-validation/tasks.md
+++ b/l10n_ve_donation/openspec/changes/l10n-ve-donation-skip-refund-origin-validation/tasks.md
@@ -1,0 +1,12 @@
+## 1. Bypass de la validación de origen
+
+- [x] 1.1 Agregar `l10n_ve_skip_refund_origin_validation=True` al `with_context()` del `create()` de la Nota de Crédito en `_reverse_moves()` (`models/account_move.py`). Verificado leyendo el diff.
+- [x] 1.2 Bump de manifest `19.0.2.0.2` -> `19.0.2.0.3`.
+
+## 2. Tests
+
+- [x] 2.1 Crear `tests/` (el módulo no tenía) con `test_donation_credit_note_regression.py`: confirma que la reversión automática crea la NC con el producto de donación (corrección), y que la misma NC sin el bypass es rechazada por `l10n_ve_invoice` (reproduce la regresión).
+
+## 3. Verificación manual
+
+- [ ] 3.1 Revertir una factura marcada como donación en un ambiente Odoo 19 con `l10n_ve_invoice` actualizado y confirmar que la Nota de Crédito se crea sin `ValidationError`.

--- a/l10n_ve_donation/openspec/config.yaml
+++ b/l10n_ve_donation/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/l10n_ve_donation/tests/__init__.py
+++ b/l10n_ve_donation/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_donation_credit_note_regression

--- a/l10n_ve_donation/tests/test_donation_credit_note_regression.py
+++ b/l10n_ve_donation/tests/test_donation_credit_note_regression.py
@@ -1,0 +1,112 @@
+from odoo import Command, fields
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "l10n_ve_donation")
+class TestDonationCreditNoteRegression(TransactionCase):
+    """Ticket #13965: `l10n_ve_invoice` added a constrains that blocks a
+    credit note (out_refund) from using a product absent on the invoice it
+    reverses. `l10n_ve_donation._reverse_moves()` builds exactly that kind
+    of credit note, but always with a dedicated donation product, never the
+    product of the original invoice -- so without the
+    `l10n_ve_skip_refund_origin_validation` bypass this reversal would
+    always raise a ValidationError. This is the regression Manuel Guerrero's
+    review (16 ago 2026) flagged as missing.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+
+        cls.expense_account = cls.env["account.account"].search(
+            [("account_type", "=", "expense"), ("company_ids", "in", cls.company.ids)],
+            limit=1,
+        ) or cls.env["account.account"].create({
+            "name": "Donation Expense Test",
+            "code": "DONTEST01",
+            "account_type": "expense",
+        })
+        cls.company.donation_account_id = cls.expense_account.id
+
+        cls.donation_product = cls.env["product.template"].create({
+            "name": "Producto de Donación",
+            "type": "service",
+            "is_donation_product": True,
+        })
+
+        cls.regular_product = cls.env["product.product"].create({
+            "name": "Producto Regular",
+            "type": "service",
+        })
+
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", cls.company.id)], limit=1
+        )
+
+    def _create_donation_invoice(self):
+        company_partner = self.company.partner_id
+        return self.env["account.move"].create({
+            "move_type": "out_invoice",
+            "is_donation": True,
+            "partner_id": company_partner.id,
+            "journal_id": self.journal.id,
+            "invoice_date": fields.Date.today(),
+            "invoice_date_display": fields.Date.today(),
+            "invoice_line_ids": [
+                Command.create({
+                    "product_id": self.regular_product.id,
+                    "quantity": 1,
+                    "price_unit": 100.0,
+                })
+            ],
+        })
+
+    def test_donation_reversal_creates_credit_note_with_donation_product(self):
+        """Fix: the automatic reversal must succeed even though the credit
+        note's product (donation product) differs from the invoice's
+        product (regular product)."""
+        invoice = self._create_donation_invoice()
+        invoice.action_post()
+
+        credit_note = self.env["account.move"].search([
+            ("reversed_entry_id", "=", invoice.id),
+            ("move_type", "=", "out_refund"),
+        ], limit=1)
+
+        self.assertTrue(credit_note, "The donation invoice was not auto-reversed into a credit note.")
+        # Whether the move reaches "posted" depends on unrelated accounting
+        # setup (chart of accounts, sequences), not on this fix -- what
+        # matters here is that creating it didn't raise ValidationError.
+        self.assertEqual(
+            credit_note.invoice_line_ids.mapped("product_id"),
+            self.donation_product.product_variant_ids,
+        )
+
+    def test_regression_without_bypass_would_block_the_reversal(self):
+        """Guard: proves *why* the bypass in `_reverse_moves()` is
+        necessary. Reproducing the exact same credit note but WITHOUT the
+        `l10n_ve_skip_refund_origin_validation` context key must be
+        rejected by `l10n_ve_invoice`'s validation, because the donation
+        product is never part of the original invoice."""
+        invoice = self._create_donation_invoice()
+        invoice.action_post()
+
+        with self.assertRaises(ValidationError):
+            self.env["account.move"].create({
+                "move_type": "out_refund",
+                "is_donation": True,
+                "partner_id": self.company.partner_id.id,
+                "journal_id": self.journal.id,
+                "reversed_entry_id": invoice.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_date_display": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create({
+                        "product_id": self.donation_product.product_variant_ids[:1].id,
+                        "quantity": 1,
+                        "price_unit": 100.0,
+                    })
+                ],
+            })

--- a/l10n_ve_exchange_difference/models/account_move_line.py
+++ b/l10n_ve_exchange_difference/models/account_move_line.py
@@ -811,6 +811,18 @@ class AccountMoveLine(models.Model):
             # no un usuario editando la nota a mano -- sin este flag, la
             # NC quedaría marcada en auditoría como "editada
             # manualmente" cuando en realidad nadie la tocó.
-            note.with_context(skip_is_manually_modified=True).write({'reversed_entry_id': invoice.id})
+            # `l10n_ve_skip_refund_origin_validation` -- este `write` es el
+            # único punto que setea `reversed_entry_id` en esta nota (el
+            # `create()` de arriba deliberadamente no lo trae), así que es
+            # el único lugar donde el constrains de origen de
+            # `l10n_ve_invoice` podría llegar a evaluarla. Hoy ese
+            # constrains no se dispara por escribir `reversed_entry_id`
+            # (solo por `invoice_line_ids`/`product_id`/`price_unit`/
+            # `quantity`/`discount`), pero repetir el flag acá deja esto a
+            # prueba de que ese alcance cambie más adelante.
+            note.with_context(
+                skip_is_manually_modified=True,
+                l10n_ve_skip_refund_origin_validation=True,
+            ).write({'reversed_entry_id': invoice.id})
 
         return note

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.10",
+    "version": "19.0.1.0.11",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -786,3 +786,35 @@ msgid ""
 msgstr ""
 "Ninguna de las órdenes de venta seleccionadas está confirmada.\n"
 "Solo las órdenes no borrador se pueden imprimir."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+msgid ""
+"Every product line on this credit note must have a product, so it can "
+"be matched against the original invoice '%(origin)s'."
+msgstr ""
+"Toda línea de producto de esta nota de crédito debe tener un producto, "
+"para poder contrastarla contra la factura original '%(origin)s'."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+msgid ""
+"You cannot add the product '%(product)s' to this credit note: it is not "
+"part of the original invoice '%(origin)s'."
+msgstr ""
+"No puede agregar el producto '%(product)s' a esta nota de crédito: no "
+"forma parte de la factura original '%(origin)s'."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+msgid ""
+"The amount credited for product '%(product)s' (%(amount)s, including "
+"%(already)s already credited by other credit notes) exceeds the amount "
+"invoiced on the original document '%(origin)s' (%(max)s)."
+msgstr ""
+"El monto acreditado para el producto '%(product)s' (%(amount)s, "
+"incluyendo %(already)s ya acreditado por otras notas de crédito) supera "
+"el monto facturado en el documento original '%(origin)s' (%(max)s)."

--- a/l10n_ve_invoice/models/__init__.py
+++ b/l10n_ve_invoice/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_move
+from . import account_move_line
 from . import account_journal
 from . import res_company
 from . import res_config_settings

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -4,7 +4,7 @@ import logging
 import calendar
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
-from odoo.tools import format_date
+from odoo.tools import format_date, float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -117,8 +117,113 @@ class AccountMove(models.Model):
                     raise ValidationError(_("An invoice cannot have a line with a price of zero"))
 
 
+    @api.constrains("invoice_line_ids")
+    def _check_refund_against_origin(self):
+        """Restrict a credit note (out_refund/in_refund) to the products
+        and amounts already present on the invoice it reverses.
+
+        Ticket #13965: a credit note must not introduce a product the
+        original invoice never had, nor credit more than what was
+        originally invoiced for a given product -- counting ALL other
+        credit notes already posted against the same origin, not just the
+        one being validated. Two separate $100 credit notes against a
+        single $100 line must not both pass just because each one, in
+        isolation, stays within the origin's amount. Modules that generate
+        credit notes automatically with a product of their own (e.g. a
+        dedicated exchange-difference or donation product, never part of
+        the original invoice) must opt out explicitly with the
+        `l10n_ve_skip_refund_origin_validation` context key -- this is
+        NOT exposed in the UI, only meant for internal server-side use by
+        those modules.
+        """
+        if self.env.context.get("l10n_ve_skip_refund_origin_validation"):
+            return
+
+        product_line_types = ("line_section", "line_note")
+        for move in self:
+            if move.move_type not in ("out_refund", "in_refund"):
+                continue
+            origin = move.reversed_entry_id
+            if not origin:
+                continue
+
+            origin_totals = {}
+            for line in origin.invoice_line_ids.filtered(
+                lambda l: l.display_type not in product_line_types and l.product_id
+            ):
+                origin_totals[line.product_id.id] = (
+                    origin_totals.get(line.product_id.id, 0.0) + line.price_subtotal
+                )
+
+            # Other credit notes against this same origin (draft or
+            # posted, but not cancelled) -- their amounts count against
+            # the origin's total too. Counting drafts closes the gap
+            # where two never-posted credit notes could each individually
+            # fit under the cap and only exceed it once both are posted,
+            # at which point this constrains would no longer re-trigger.
+            sibling_refunds = self.env["account.move"].search([
+                ("reversed_entry_id", "=", origin.id),
+                ("move_type", "=", move.move_type),
+                ("state", "!=", "cancel"),
+                ("id", "!=", move.id),
+            ])
+            refund_totals = {}
+            for line in sibling_refunds.invoice_line_ids.filtered(
+                lambda l: l.display_type not in product_line_types and l.product_id
+            ):
+                refund_totals[line.product_id.id] = (
+                    refund_totals.get(line.product_id.id, 0.0) + line.price_subtotal
+                )
+
+            current_totals = {}
+            for line in move.invoice_line_ids.filtered(
+                lambda l: l.display_type not in product_line_types
+            ):
+                if not line.product_id:
+                    # A line with no product (e.g. a manual description
+                    # line) can't be matched against the origin at all --
+                    # letting it through would credit an arbitrary amount
+                    # with no product to check it against, defeating both
+                    # the product and the amount restriction below.
+                    raise ValidationError(_(
+                        "Every product line on this credit note must have "
+                        "a product, so it can be matched against the "
+                        "original invoice '%(origin)s'.",
+                        origin=origin.display_name,
+                    ))
+                if line.product_id.id not in origin_totals:
+                    raise ValidationError(_(
+                        "You cannot add the product '%(product)s' to this credit "
+                        "note: it is not part of the original invoice "
+                        "'%(origin)s'.",
+                        product=line.product_id.display_name,
+                        origin=origin.display_name,
+                    ))
+                current_totals[line.product_id.id] = (
+                    current_totals.get(line.product_id.id, 0.0) + line.price_subtotal
+                )
+
+            precision = move.currency_id.rounding
+            for product_id, current_amount in current_totals.items():
+                max_amount = origin_totals.get(product_id, 0.0)
+                already_credited = refund_totals.get(product_id, 0.0)
+                total_credited = already_credited + current_amount
+                if float_compare(total_credited, max_amount, precision_rounding=precision) > 0:
+                    product = self.env["product.product"].browse(product_id)
+                    raise ValidationError(_(
+                        "The amount credited for product '%(product)s' "
+                        "(%(amount)s, including %(already)s already credited "
+                        "by other credit notes) exceeds the amount invoiced "
+                        "on the original document '%(origin)s' (%(max)s).",
+                        product=product.display_name,
+                        amount=total_credited,
+                        already=already_credited,
+                        origin=origin.display_name,
+                        max=max_amount,
+                    ))
+
     def action_post(self):
-        
+
         for record in self:
             if record.move_type in ("out_invoice", "in_invoice", "out_refund", "in_refund"):
                 for line in record.invoice_line_ids:

--- a/l10n_ve_invoice/models/account_move_line.py
+++ b/l10n_ve_invoice/models/account_move_line.py
@@ -1,0 +1,17 @@
+from odoo import api, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    @api.constrains("product_id", "price_unit", "quantity", "discount")
+    def _check_refund_line_against_origin(self):
+        """A write() on the line itself does not trigger the parent
+        account.move constrains on invoice_line_ids, so the same check
+        (see account.move._check_refund_against_origin) is repeated here.
+        """
+        moves = self.mapped("move_id").filtered(
+            lambda m: m.move_type in ("out_refund", "in_refund") and m.reversed_entry_id
+        )
+        if moves:
+            moves._check_refund_against_origin()

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-credit-note-origin-validation/proposal.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-credit-note-origin-validation/proposal.md
@@ -1,0 +1,62 @@
+# Feat: Validar productos y monto de una Nota de Crédito contra su factura origen
+
+## Why
+
+Ticket Helpdesk #13965. Hoy no existe ninguna restricción en `l10n_ve_invoice`
+que ligue las líneas de una Nota de Crédito (`out_refund`/`in_refund`) con lo
+facturado en el documento que revierte (`reversed_entry_id`). Un usuario puede:
+
+- Agregar a la NC un producto que la factura original nunca tuvo.
+- Acreditar, para un producto dado, un monto mayor al que se facturó por ese
+  mismo producto.
+
+Ambos casos generan una NC que no corresponde con la factura que dice
+originarla, lo cual es un riesgo fiscal/contable para la localización
+venezolana.
+
+## What Changes
+
+- Nuevo `@api.constrains` `_check_refund_against_origin` en `account.move`
+  (`models/account_move.py`): para toda NC con `reversed_entry_id`, agrupa las
+  líneas de producto por `product_id` (tanto de la NC como de la factura
+  origen) y valida:
+  1. Todo producto de la NC debe existir entre los productos de la factura
+     origen.
+  2. El monto acreditado acumulado por producto no puede superar el monto
+     facturado por ese producto en el origen (comparación con
+     `float_compare` y la precisión de la moneda del documento).
+- Réplica del mismo chequeo en `account.move.line`
+  (`models/account_move_line.py`, nuevo) sobre `product_id`, `price_unit`,
+  `quantity`, `discount`: un `write()` directo sobre la línea no dispara el
+  `constrains` del padre definido sobre `invoice_line_ids`.
+- Mecanismo de excepción: la clave de contexto
+  `l10n_ve_skip_refund_origin_validation` (ya prevista y documentada de
+  antemano en `l10n_ve_exchange_difference`, hasta ahora un no-op) hace que
+  la validación se salte por completo. Pensada para módulos que generan NC de
+  forma automática con un producto propio, no para exponerse en UI.
+- `l10n_ve_donation` (`models/account_move.py`, `_reverse_moves`) pasa ahora
+  ese mismo flag al crear su NC de donación, porque usa un producto dedicado
+  (`is_donation_product`) que nunca es el de la factura original.
+
+## Módulos revisados por posible conflicto
+
+- `l10n_ve_exchange_difference`: crea NC de diferencial cambiario con un
+  producto dedicado. Ya pasaba el flag de bypass de forma anticipada en los
+  dos puntos donde crea/postea la nota (`account_move_line.py:697,745`,
+  `account_move.py:475`) — sin cambios necesarios.
+- `l10n_ve_donation`: creaba NC con producto de donación sin el flag — se
+  agregó (ver arriba). Regresión evitada.
+- `integra-addons` (repo de cliente, `binaural_19/src/integra-addons`): sin
+  hallazgos. `binaural_commissions`, `binaural_stock_landed_foreign_costs` y
+  `binaural_pos_commissions` solo leen `move_type`/`reversed_entry_id`;
+  `set_reversed()` en `binaural_commissions` vincula un move ya existente
+  por `ref`, no crea una NC nueva. Ninguno requiere el bypass.
+- Resto de módulos de `odoo-venezuela`: no se encontró ningún otro punto que
+  cree `account.move` con `move_type` `out_refund`/`in_refund` de forma
+  programática.
+
+## Non-goals
+
+- No se valida Nota de Débito (`debit_origin_id`): el ticket 13965 solo pide
+  Notas de Crédito. El caso de ND queda fuera de alcance (ver ticket 13911 /
+  hallazgos de review para ese caso).

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-credit-note-origin-validation/specs/l10n_ve_invoice/spec.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-credit-note-origin-validation/specs/l10n_ve_invoice/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Productos de una Nota de Crédito restringidos a la factura origen
+El sistema DEBE (MUST) impedir que una Nota de Crédito (`out_refund`/`in_refund`) con `reversed_entry_id` incluya un producto que no esté presente en las líneas de producto de la factura que revierte, salvo que la creación se realice con la clave de contexto `l10n_ve_skip_refund_origin_validation` activa.
+
+#### Scenario: Producto presente en la factura origen
+- **WHEN** se crea o edita una Nota de Crédito cuyas líneas de producto son un subconjunto de los productos de su factura origen
+- **THEN** la Nota de Crédito se guarda sin error
+
+#### Scenario: Producto ajeno a la factura origen
+- **WHEN** se crea o edita una Nota de Crédito agregando un producto que la factura origen nunca facturó
+- **THEN** el sistema rechaza la operación con un `ValidationError` indicando el producto y la factura origen
+
+#### Scenario: Edición directa de una línea ya creada
+- **WHEN** se modifica el `product_id` de una línea de una Nota de Crédito ya existente, sin pasar por el `write()` del documento padre
+- **THEN** la validación se ejecuta igual y rechaza el producto ajeno
+
+#### Scenario: Bypass explícito para módulos automáticos
+- **WHEN** un módulo crea la Nota de Crédito con el contexto `l10n_ve_skip_refund_origin_validation=True`
+- **THEN** la validación de producto y monto no se ejecuta, cualquiera sea el producto usado
+
+### Requirement: Monto acreditado por producto no puede superar lo facturado en el origen, contando todas las Notas de Crédito
+El sistema DEBE (MUST) impedir que, para un mismo producto, el monto acreditado acumulado entre la Nota de Crédito que se está guardando y todas las demás Notas de Crédito no canceladas contra el mismo origen supere el monto facturado por ese producto en la factura origen, usando la precisión de redondeo de la moneda del documento.
+
+#### Scenario: Nota de crédito parcial, sin otras Notas de Crédito previas
+- **WHEN** el monto acreditado por un producto es menor o igual al facturado por ese producto en el origen y no existen otras Notas de Crédito contra ese origen
+- **THEN** la Nota de Crédito se guarda sin error
+
+#### Scenario: Nota de crédito que excede el monto facturado por sí sola
+- **WHEN** el monto acreditado por un producto en una sola Nota de Crédito ya supera el monto facturado por ese producto en la factura origen
+- **THEN** el sistema rechaza la operación con un `ValidationError` indicando el producto, los montos y la factura origen
+
+#### Scenario: Dos Notas de Crédito parciales que juntas exceden el origen
+- **WHEN** una primera Nota de Crédito por un producto queda dentro del monto facturado, y se intenta crear una segunda Nota de Crédito para el mismo producto y origen cuyo monto, sumado al de la primera, supera lo facturado
+- **THEN** el sistema rechaza la segunda Nota de Crédito con un `ValidationError`, indicando el monto ya acreditado por otras Notas de Crédito
+
+#### Scenario: Diferencias de redondeo no bloquean la Nota de Crédito
+- **WHEN** el monto acreditado (incluyendo otras Notas de Crédito) difiere del monto facturado solo por un arrastre de punto flotante menor a la precisión de la moneda
+- **THEN** la Nota de Crédito se guarda sin error

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-credit-note-origin-validation/tasks.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-credit-note-origin-validation/tasks.md
@@ -1,0 +1,36 @@
+## 1. Validación en `l10n_ve_invoice`
+
+- [x] 1.1 Agregar `_check_refund_against_origin` (`@api.constrains("invoice_line_ids")`) en `models/account_move.py`: bloquea producto ajeno a la factura origen y monto acreditado por producto mayor al facturado, respetando `l10n_ve_skip_refund_origin_validation`. Verificado leyendo el diff.
+- [x] 1.1.1 Corrección post-review (code review interno): el chequeo de monto ahora suma también las demás Notas de Crédito no canceladas contra el mismo origen (`sibling_refunds`), no solo la que se está guardando -- cierra el hueco donde dos NC parciales, cada una individualmente dentro del tope, podían juntas exceder el monto facturado.
+- [x] 1.1.2 Corrección post-review (agente independiente `binaural-fn-programador:code-reviewer`): una línea de NC sin `product_id` (línea de descripción manual) ya no se ignora silenciosamente -- ahora se rechaza explícitamente con `ValidationError`, porque antes permitía acreditar cualquier monto sin pasar por ninguno de los dos chequeos (ni de producto ni de monto). Nueva traducción agregada.
+- [x] 1.2 Agregar `models/account_move_line.py` con `_check_refund_line_against_origin` (`@api.constrains("product_id", "price_unit", "quantity", "discount")`) que reusa el método anterior sobre `move_id`. Verificado leyendo el diff.
+- [x] 1.3 Registrar el nuevo archivo en `models/__init__.py`.
+- [x] 1.4 Bump de manifest `19.0.1.0.10` -> `19.0.1.0.11`.
+- [x] 1.5 Agregar traducciones ES-VE de los dos mensajes de error nuevos en `i18n/es_VE.po`. Verificado con `msgfmt --check`.
+
+## 2. Coordinación con módulos que crean NC automáticas
+
+- [x] 2.1 Confirmar que `l10n_ve_exchange_difference` ya pasa `l10n_ve_skip_refund_origin_validation=True` en los dos puntos donde crea/postea su NC de diferencial (`account_move_line.py:697,745`, `account_move.py:475`).
+- [x] 2.1.1 Corrección post-review (agente independiente): esos dos puntos crean la NC de diferencial **sin** `reversed_entry_id` (se vincula después, en un `write({'reversed_entry_id': ...})` posterior a postear y conciliar, `account_move_line.py:814`), así que el flag del `create()` era redundante y ese `write` tardío -- el único punto real donde se setea el vínculo -- no llevaba el bypass. Hoy no falla porque el constrains no se dispara al escribir `reversed_entry_id`, pero queda a un cambio de alcance del constrains de romperse silenciosamente. Se agregó el flag también en ese `write` como defensa en profundidad.
+- [x] 2.2 Agregar el mismo flag en `l10n_ve_donation/models/account_move.py` (`_reverse_moves`), que crea NC con un producto de donación dedicado. Bump de manifest `19.0.2.0.2` -> `19.0.2.0.3`.
+- [x] 2.3 Revisar `integra-addons` (repo de cliente, `binaural_19/src/integra-addons`) por creación programática de NC. Ningún módulo crea `account.move` con `move_type` refund vía `create()`; `binaural_commissions`, `binaural_stock_landed_foreign_costs` y `binaural_pos_commissions` solo leen `move_type`/`reversed_entry_id`, y `set_reversed()` en `binaural_commissions` vincula un move ya existente sin crear una NC nueva. No requieren el bypass.
+
+## 3. Tests
+
+- [x] 3.1 `l10n_ve_invoice/tests/test_refund_origin_validation.py`: NC válida (con aserción de monto/producto, no solo "no lanzó"), producto ajeno bloqueado, línea sin producto bloqueada, monto excedido bloqueado, NC de compra (`in_refund`) también validada, NC sin `reversed_entry_id` documentada como gap intencional, bypass permite producto ajeno, dos NC parciales que juntas exceden el origen quedan bloqueadas, `write()` de línea a producto ajeno bloqueado, `write()` de línea que sube el monto sobre el tope bloqueado. Registrado en `tests/__init__.py`.
+- [x] 3.1.1 Renombrado `test_line_write_after_post_is_also_validated` -> `test_line_write_to_foreign_product_is_blocked` (agente independiente señaló que el nombre prometía cobertura de posteo y de monto que el test no daba; la NC nunca llega a postear en ese test, solo prueba el camino de producto ajeno). Se agregó un test separado para el camino de monto vía `write()`.
+- [x] 3.2 `l10n_ve_donation/tests/test_donation_credit_note_regression.py` (módulo sin carpeta `tests/` previa, creada): confirma que la reversión automática de una factura de donación crea la NC con el producto de donación (corrección), y que la misma NC sin el bypass es rechazada por la validación de `l10n_ve_invoice` (reproduce la regresión que motivó el fix).
+
+## 5. Pendientes documentados (no resueltos en este cambio, señalados por el agente independiente)
+
+- [ ] 5.1 El bypass `l10n_ve_skip_refund_origin_validation` es una clave de contexto sin gate de permiso -- cualquier usuario con acceso a crear facturas puede forjarla vía RPC. Migrar a un campo persistido con `groups=` restringido resolvería esto y a la vez el punto 2.1.1 de forma más robusta.
+- [ ] 5.2 Sin conversión de moneda: si la NC queda en una moneda distinta a la de la factura origen, `price_subtotal` se compara crudo entre monedas. Requiere `currency_id._convert(...)` antes de comparar.
+- [ ] 5.3 Condición de carrera: dos transacciones concurrentes creando NC contra el mismo origen no se ven entre sí (`sibling_refunds` sin lock), así que en teoría ambas podrían pasar y exceder el tope igual. Requeriría `SELECT ... FOR UPDATE` sobre el origen.
+- [ ] 5.4 Performance: `_check_refund_line_against_origin` reejecuta el chequeo completo (incluyendo el `search` de `sibling_refunds`) por cada `write()` de línea -- O(n²) en escenarios de importación masiva. Aceptable para uso interactivo.
+
+## 4. Verificación manual
+
+- [ ] 4.1 Actualizar `l10n_ve_invoice`, `l10n_ve_donation` y `l10n_ve_exchange_difference` en un ambiente Odoo 19 real y confirmar que actualizan sin error.
+- [ ] 4.2 Crear factura, NC parcial válida, NC con producto distinto (debe fallar) y NC que exceda el monto (debe fallar).
+- [ ] 4.3 Confirmar que revertir una factura de donación sigue funcionando (regresión que motivó el punto 2.2).
+- [ ] 4.4 Confirmar que la conciliación con diferencial cambiario (NC de pérdida) sigue posteando sin el error nuevo.

--- a/l10n_ve_invoice/openspec/config.yaml
+++ b/l10n_ve_invoice/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/l10n_ve_invoice/tests/__init__.py
+++ b/l10n_ve_invoice/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_report_print_restriction
 from . import test_international_purchase
 from . import test_res_config_settings
 from . import test_accounting_reports
+from . import test_refund_origin_validation

--- a/l10n_ve_invoice/tests/test_refund_origin_validation.py
+++ b/l10n_ve_invoice/tests/test_refund_origin_validation.py
@@ -1,0 +1,221 @@
+from odoo.tests import TransactionCase, tagged
+from odoo import fields, Command
+from odoo.exceptions import ValidationError
+
+
+@tagged("post_install", "-at_install", "l10n_ve_invoice")
+class TestRefundOriginValidation(TransactionCase):
+    """Ticket #13965: a credit note (out_refund/in_refund) must not
+    introduce a product absent from its origin invoice, nor credit more
+    than what was invoiced for a given product."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tax = cls.env["account.tax"].create({
+            "name": "IVA 16%",
+            "amount": 16,
+            "amount_type": "percent",
+            "type_tax_use": "sale",
+        })
+        cls.purchase_tax = cls.env["account.tax"].create({
+            "name": "IVA Compra 16%",
+            "amount": 16,
+            "amount_type": "percent",
+            "type_tax_use": "purchase",
+        })
+        cls.product_a = cls.env["product.product"].create({
+            "name": "Producto A",
+            "type": "service",
+        })
+        cls.product_b = cls.env["product.product"].create({
+            "name": "Producto B",
+            "type": "service",
+        })
+        cls.product_c = cls.env["product.product"].create({
+            "name": "Producto C",
+            "type": "service",
+        })
+        cls.partner = cls.env["res.partner"].create({"name": "Cliente de prueba"})
+        cls.journal = cls.env["account.journal"].create({
+            "name": "Diario de Ventas Refund Test",
+            "code": "VRT",
+            "type": "sale",
+        })
+        cls.purchase_journal = cls.env["account.journal"].create({
+            "name": "Diario de Compras Refund Test",
+            "code": "VRTP",
+            "type": "purchase",
+        })
+
+    def _create_invoice_line(self, product, quantity=1, price_unit=100.0, tax=None):
+        return Command.create({
+            "product_id": product.id,
+            "quantity": quantity,
+            "price_unit": price_unit,
+            "tax_ids": [Command.set((tax or self.tax).ids)],
+        })
+
+    def _create_invoice(self, lines, move_type="out_invoice", reversed_entry_id=False, journal=None):
+        vals = {
+            "move_type": move_type,
+            "partner_id": self.partner.id,
+            "journal_id": (journal or self.journal).id,
+            "invoice_date": fields.Date.today(),
+            "invoice_date_display": fields.Date.today(),
+            "invoice_line_ids": lines,
+        }
+        if reversed_entry_id:
+            vals["reversed_entry_id"] = reversed_entry_id.id
+        return self.env["account.move"].create(vals)
+
+    def test_credit_note_with_same_product_and_lower_amount_is_allowed(self):
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        # No ValidationError expected: this is exactly the case the
+        # constrains must let through. Whether the move can later reach
+        # "posted" depends on unrelated accounting setup, not on this
+        # validation, so we don't assert the state here.
+        credit_note = self._create_invoice(
+            [self._create_invoice_line(self.product_a, 1, 50.0)],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+        self.assertEqual(credit_note.invoice_line_ids.product_id, self.product_a)
+        self.assertEqual(credit_note.amount_untaxed, 50.0)
+
+    def test_credit_note_with_foreign_product_is_blocked(self):
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [self._create_invoice_line(self.product_b, 1, 10.0)],
+                move_type="out_refund",
+                reversed_entry_id=invoice,
+            )
+
+    def test_credit_note_line_without_product_is_blocked(self):
+        """A manual description line has nothing to match against the
+        origin, so it must not be allowed to slip past both checks."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [Command.create({
+                    "name": "Ajuste manual",
+                    "quantity": 1,
+                    "price_unit": 1000000.0,
+                    "tax_ids": [Command.set(self.tax.ids)],
+                })],
+                move_type="out_refund",
+                reversed_entry_id=invoice,
+            )
+
+    def test_credit_note_exceeding_origin_amount_is_blocked(self):
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [self._create_invoice_line(self.product_a, 1, 150.0)],
+                move_type="out_refund",
+                reversed_entry_id=invoice,
+            )
+
+    def test_vendor_credit_note_in_refund_is_also_validated(self):
+        """The constrains covers both out_refund and in_refund -- a
+        vendor bill's credit note must respect the same rules."""
+        bill = self._create_invoice(
+            [self._create_invoice_line(self.product_a, 1, 100.0, tax=self.purchase_tax)],
+            move_type="in_invoice",
+            journal=self.purchase_journal,
+        )
+        bill.action_post()
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [self._create_invoice_line(self.product_b, 1, 10.0, tax=self.purchase_tax)],
+                move_type="in_refund",
+                reversed_entry_id=bill,
+                journal=self.purchase_journal,
+            )
+
+    def test_credit_note_without_origin_skips_validation(self):
+        """A credit note created with no reversed_entry_id at all (e.g.
+        a standalone credit note from the Accounting menu) is not tied
+        to any invoice, so there is nothing to validate it against --
+        this is a known, intentional gap, not covered by this ticket."""
+        credit_note = self._create_invoice(
+            [self._create_invoice_line(self.product_c, 1, 999999.0)],
+            move_type="out_refund",
+        )
+        self.assertTrue(credit_note.id)
+
+    def test_bypass_context_allows_foreign_product(self):
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        # The record must be created with the bypass context already
+        # active for the constrains to see it (a later with_context()
+        # on an existing recordset would be too late).
+        credit_note = self.env["account.move"].with_context(
+            l10n_ve_skip_refund_origin_validation=True
+        ).create({
+            "move_type": "out_refund",
+            "partner_id": self.partner.id,
+            "journal_id": self.journal.id,
+            "invoice_date": fields.Date.today(),
+            "invoice_date_display": fields.Date.today(),
+            "reversed_entry_id": invoice.id,
+            "invoice_line_ids": [self._create_invoice_line(self.product_b, 1, 999.0)],
+        })
+        self.assertTrue(credit_note.id)
+
+    def test_cumulative_credit_notes_cannot_exceed_origin_amount(self):
+        """Two credit notes, each individually within the origin's
+        amount, must not be allowed to jointly exceed it."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+
+        first_credit_note = self._create_invoice(
+            [self._create_invoice_line(self.product_a, 1, 60.0)],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+        self.assertTrue(first_credit_note.id)
+
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [self._create_invoice_line(self.product_a, 1, 60.0)],
+                move_type="out_refund",
+                reversed_entry_id=invoice,
+            )
+
+    def test_line_write_to_foreign_product_is_blocked(self):
+        """A write() directly on the line (not through the parent
+        move's invoice_line_ids) must trigger the same validation --
+        the parent's constrains does not fire on a plain line write()."""
+        invoice = self._create_invoice([
+            self._create_invoice_line(self.product_a, 1, 100.0),
+            self._create_invoice_line(self.product_b, 1, 100.0),
+        ])
+        invoice.action_post()
+        credit_note = self._create_invoice(
+            [self._create_invoice_line(self.product_a, 1, 50.0)],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+        line = credit_note.invoice_line_ids[0]
+        with self.assertRaises(ValidationError):
+            line.write({"product_id": self.product_c.id})
+
+    def test_line_write_raising_amount_over_cap_is_blocked(self):
+        """Same line-level trigger, but for the amount check instead of
+        the foreign-product check."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        credit_note = self._create_invoice(
+            [self._create_invoice_line(self.product_a, 1, 50.0)],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+        line = credit_note.invoice_line_ids[0]
+        with self.assertRaises(ValidationError):
+            line.write({"price_unit": 150.0})

--- a/l10n_ve_invoice/tests/test_refund_origin_validation.py
+++ b/l10n_ve_invoice/tests/test_refund_origin_validation.py
@@ -47,6 +47,10 @@ class TestRefundOriginValidation(TransactionCase):
             "code": "VRTP",
             "type": "purchase",
         })
+        cls.income_account = cls.env["account.account"].create({
+            "name": "Revenue Refund Test", "code": "4444442",
+            "account_type": "income",
+        })
 
     def _create_invoice_line(self, product, quantity=1, price_unit=100.0, tax=None):
         return Command.create({
@@ -103,6 +107,7 @@ class TestRefundOriginValidation(TransactionCase):
             self._create_invoice(
                 [Command.create({
                     "name": "Ajuste manual",
+                    "account_id": self.income_account.id,
                     "quantity": 1,
                     "price_unit": 1000000.0,
                     "tax_ids": [Command.set(self.tax.ids)],


### PR DESCRIPTION
[FIX] l10n_ve_invoice, l10n_ve_donation, l10n_ve_exchange_difference: validar productos y monto de Notas de Crédito contra su factura origen

Ninguna validación ligaba las líneas de una Nota de Crédito (out_refund/in_refund) con lo facturado en el documento que revierte, así que un usuario podía agregar un producto ajeno a la factura origen o acreditar un monto mayor al facturado por producto -- incluyendo el acumulado entre varias NC parciales contra la misma factura.

Se agrega _check_refund_against_origin en account.move (l10n_ve_invoice): bloquea producto ajeno al origen, y bloquea que el monto acreditado por producto -- sumando la NC actual más todas las demás NC no canceladas contra el mismo origen -- supere lo facturado. Replicado a nivel de línea en account_move_line.py porque un write() directo sobre la línea no dispara el constrains del padre. Las líneas sin product_id se rechazan explícitamente en vez de ignorarse, evitando que una línea de descripción manual esquive ambos chequeos.

El comportamiento es por defecto para la localización venezolana, con un mecanismo de excepción vía la clave de contexto
l10n_ve_skip_refund_origin_validation para módulos que generan NC automáticas con un producto propio, nunca el de la factura origen: l10n_ve_exchange_difference ya lo usaba de forma anticipada (se completa también en el write() tardío que vincula reversed_entry_id, hoy inocuo pero frágil ante un cambio futuro del alcance del constrains); l10n_ve_donation lo incorpora en _reverse_moves, que generaba una regresión confirmada al revertir facturas de donación.

Se agregan traducciones ES-VE de los mensajes nuevos, openspec por módulo, y tests: l10n_ve_invoice/tests/test_refund_origin_validation.py (NC válida, producto ajeno, línea sin producto, monto excedido, NC de compra in_refund, NC sin origen, bypass, acumulado entre NC parciales, write() de línea) y l10n_ve_donation/tests/test_donation_credit_note_regression.py (módulo sin carpeta tests/ previa). Bump de manifest en l10n_ve_invoice (19.0.1.0.10 -> .11) y l10n_ve_donation (19.0.2.0.2 -> .3).

Suite completa corrida en ambiente Docker real (208-212 tests según iteración), 0 fallidos, 0 errores.

References:
- Ticket: #13965
- Tarea:
- PR:
- Otros: https://binaural.odoo.com/odoo/helpdesk/action-389/13931