### PR TITLE
docs(l10n_ve_stock_purchase): visibilizar código alterno en summary/description y README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Esta localización incluye los siguientes módulos, diseñados para cumplir con 
    Gestión de contabilidad de inventarios adaptada a las normativas fiscales venezolanas. Permite realizar el seguimiento y la contabilidad de los movimientos de inventarios de acuerdo con los requerimientos del SENIAT.
 
 - **l10n_ve_stock_purchase**  
-   Gestión de compras de inventarios con integración fiscal. Este módulo permite la creación de órdenes de compra y la integración de los movimientos de inventario con el sistema contable y fiscal.
+   Gestión de compras de inventarios con integración fiscal. Este módulo permite la creación de órdenes de compra y la integración de los movimientos de inventario con el sistema contable y fiscal. Incluye búsqueda de producto por Código Alterno y su columna de referencia en la línea de compra.
 
 - **l10n_ve_stock_reports**  
    Informes relacionados con la gestión de inventarios y operaciones fiscales. Este módulo genera reportes detallados que ayudan a las empresas a cumplir con las regulaciones fiscales en términos de inventarios.

--- a/l10n_ve_stock_purchase/__manifest__.py
+++ b/l10n_ve_stock_purchase/__manifest__.py
@@ -1,10 +1,14 @@
 {
     "name": "Venezuela - Inventario/Compras",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.2.1",
     "license": "LGPL-3",
-    "summary": "Módulo para gestionar inventario/compras en Venezuela",
+    "summary": "Inventario/compras VE: código alterno de producto en línea de compra",
     "description": """
         Este módulo personaliza el proceso de gestión de inventario/compras para cumplir con las regulaciones venezolanas.
+
+        Incluye:
+        * Búsqueda de producto por Código Alterno (name_search) en la línea de compra.
+        * Columna "Código Alterno" (solo lectura) en la línea de la orden de compra.
     """,
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_stock_purchase/openspec/changes/l10n-ve-stock-purchase-alternate-code-discoverability/proposal.md
+++ b/l10n_ve_stock_purchase/openspec/changes/l10n-ve-stock-purchase-alternate-code-discoverability/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The module already resolves and displays a product's `alternate_code` (Código Alterno) in the purchase order line — shipped by `l10n-ve-stock-purchase-alternate-code-search` (ticket 14833). But nothing about the module's `name`, `summary`, `description`, or its entry in the repo-root `README.md` mentioned that capability; both stayed generic ("gestión de inventario/compras en Venezuela"). Anyone searching Apps or the README for "código alterno" would not find this module.
+
+This is not hypothetical: the same ticket's Odoo.sh diagnostic surfaced a loose, unversioned module (`maxcam_purchase_alternate_code`) mounted directly in a client build's editor, duplicating this exact functionality — created because nobody could tell the capability already existed here.
+
+## What Changes
+
+- Update the manifest `summary`/`description` of `l10n_ve_stock_purchase` to explicitly mention the Código Alterno search and column.
+- Update the module's entry in the repo-root `README.md` module summary to mention the same.
+- No functional/behavioral change; no data, model, or view changes.
+
+## Capabilities
+
+### New Capabilities
+- `l10n_ve_stock_purchase`: adds a discoverability requirement — the module's metadata (manifest `summary`/`description`) and its `README.md` entry must state that it handles Código Alterno, so the capability added by `l10n-ve-stock-purchase-alternate-code-search` is findable without reading the code.
+
+### Modified Capabilities
+(none)
+
+## Impact
+
+- **Module**: `l10n_ve_stock_purchase` (repo `odoo-venezuela`, base branch `maintenance-19.0`).
+- **Changed files**: `__manifest__.py` (`summary`, `description`, version bump), repo-root `README.md`.
+- **No security/ACL/behavior changes.**
+- **Source ticket**: Helpdesk 14833 (same ticket as the original search fix, follow-up finding).

--- a/l10n_ve_stock_purchase/openspec/changes/l10n-ve-stock-purchase-alternate-code-discoverability/specs/l10n_ve_stock_purchase/spec.md
+++ b/l10n_ve_stock_purchase/openspec/changes/l10n-ve-stock-purchase-alternate-code-discoverability/specs/l10n_ve_stock_purchase/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Descubribilidad del Código Alterno en la metadata del módulo
+El summary y la description del manifest del módulo, así como su entrada en el `README.md` raíz del repositorio, DEBEN (MUST) mencionar explícitamente que el módulo resuelve búsqueda y visualización de Código Alterno en la línea de compra, de forma que la capacidad sea encontrable desde el listado de Apps o el README sin necesidad de leer el código.
+
+#### Scenario: Búsqueda en Apps por código alterno
+- **WHEN** un usuario busca "código alterno" en Settings > Apps
+- **THEN** `l10n_ve_stock_purchase` aparece en los resultados, por coincidir con su summary/description
+
+#### Scenario: Lectura del README raíz
+- **WHEN** alguien lee la tabla de módulos del `README.md` del repositorio buscando dónde se resuelve el código alterno en compras
+- **THEN** la entrada de `l10n_ve_stock_purchase` lo menciona explícitamente

--- a/l10n_ve_stock_purchase/openspec/changes/l10n-ve-stock-purchase-alternate-code-discoverability/tasks.md
+++ b/l10n_ve_stock_purchase/openspec/changes/l10n-ve-stock-purchase-alternate-code-discoverability/tasks.md
@@ -1,0 +1,9 @@
+## 1. Manifest and README
+
+- [x] 1.1 Update `summary` and `description` in `__manifest__.py` to mention Código Alterno search/column. Verified by `python3 -c "import ast; ast.parse(open('__manifest__.py').read())"`.
+- [x] 1.2 Bump the manifest `version` from `19.0.1.2.0` to `19.0.1.2.1` (docs-only patch bump).
+- [x] 1.3 Update the `l10n_ve_stock_purchase` entry in the repo-root `README.md` to mention Código Alterno.
+
+## 2. Verification
+
+- [ ] 2.1 Confirm the manifest `summary`/`description` render correctly in Apps (Settings > Apps > search "código alterno" finds the module).


### PR DESCRIPTION
## Qué

Actualiza `summary`/`description` del manifest de `l10n_ve_stock_purchase` y su entrada en el `README.md` raíz para mencionar explícitamente la funcionalidad de Código Alterno (búsqueda + columna en línea de compra).

## Por qué

El módulo resuelve esto desde el fix del ticket 14833 (#1234), pero nada visible desde Apps o el README lo indicaba — el nombre y summary originales eran genéricos ("gestión de inventario/compras en Venezuela"). Sin esa señal, no hay forma de descubrir que esta funcionalidad ya existe acá.

Esto no es hipotético: en el diagnóstico de ese mismo ticket en Odoo.sh apareció un módulo suelto `maxcam_purchase_alternate_code`, montado directo en el editor de un build, nunca versionado en ningún repo — duplicando exactamente esta funcionalidad porque nadie sabía que `l10n_ve_stock_purchase` ya la tenía.

## Cambios

- `__manifest__.py`: summary/description mencionan Código Alterno; bump `19.0.1.2.0` → `19.0.1.2.1`.
- `README.md`: entrada de `l10n_ve_stock_purchase` menciona la funcionalidad.

Sin cambios de comportamiento ni de código funcional.

## Test plan

- [ ] Verificar que el módulo actualiza sin errores (`-u l10n_ve_stock_purchase`).
- [ ] Confirmar en Apps que summary/description muestran la mención a Código Alterno.