### PR TITLE
[FIX] l10n_ve_sale, l10n_ve_accountant: resolver colisión de versión y evitar el recompute masivo de tasas (TA-74966)

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.13",
+    "version": "19.0.1.0.14",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "19.0.1.0.6",
+    "version": "19.0.1.0.7",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/migrations/19.0.1.0.7/pre-set_foreign_rate_date.py
+++ b/l10n_ve_sale/migrations/19.0.1.0.7/pre-set_foreign_rate_date.py
@@ -22,10 +22,50 @@ Solo se tocan las ordenes que todavia no se han facturado por completo: son
 las unicas donde el valor va a usarse. En las ya facturadas se deja NULL, con
 lo que siguen cayendo a date_order y conservan exactamente el comportamiento
 que tenian antes de esta version.
+
+POR QUE ES UNA MIGRACION `pre-` Y NO `post-`
+============================================
+
+foreign_rate_date es un campo calculado almacenado que comparte
+compute="_compute_rate" con foreign_rate (que lleva tracking=True) y con
+foreign_inverse_rate.
+
+Cuando el ORM crea la columna de un calculado almacenado marca TODOS los
+registros existentes para computar -- odoo/orm/models.py, _auto_init:
+
+    new = field.update_db(self, columns)
+    if new and field.compute:
+        fields_to_compute.append(field)
+    ...
+    for field in fields_to_compute:
+        self.env.add_to_compute(field, records)   # records = toda la tabla
+
+y al ejecutarse _compute_rate se asignan los tres campos que comparten el
+metodo. En las companias con "Update sale order rate using date order" activo
+no hay guard que lo pare, asi que las ordenes historicas quedarian con la tasa
+reescrita a partir de date_order -- que el core ya movio a la fecha de
+confirmacion -- y con un mensaje en el chatter por cada una, al ser
+foreign_rate un campo con tracking.
+
+Creando la columna aqui, antes de que el ORM cargue el modelo, update_db la
+encuentra existente, no la trata como nueva y no dispara ese recompute. La
+version anterior de este script era `post-`: corria despues del recompute, de
+modo que reparaba foreign_rate_date pero no el reescrito colateral de la tasa.
 """
 
 
 def migrate(cr, version):
+    cr.execute(
+        """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'sale_order'
+          AND column_name = 'foreign_rate_date'
+        """
+    )
+    if not cr.fetchone():
+        cr.execute("ALTER TABLE sale_order ADD COLUMN foreign_rate_date date")
+
     cr.execute(
         """
         UPDATE sale_order so


### PR DESCRIPTION
Follow-up del **[#1208](https://github.com/binaural-dev/odoo-venezuela/pull/1208)** (TA-74966). Tres puntos de empaquetado que quedaron abiertos al mergearlo; ninguno es de lógica de negocio.

## 1. Colisión de versión de `l10n_ve_sale`

El #1208 subió `l10n_ve_sale` a `19.0.1.0.6` sobre `maintenance-19.0`, y el **[#1228](https://github.com/binaural-dev/odoo-venezuela/pull/1228)** tomó ese mismo número sobre `19.0`. Odoo solo ejecuta los scripts de `migrations/<version>/` cuando la versión instalada es **menor** que la del manifest, así que una instancia que instalara primero la `.6` del #1228 se quedaba en `.6` y **nunca corría la migración** de `foreign_rate_date`: el campo quedaba NULL y las órdenes caían al respaldo `date_order`, que es justo el bug que el #1208 arregla.

Se sube a `19.0.1.0.7` y se renombra la carpeta de la migración. Con esto la migración corre también en las instancias que ya hayan tomado cualquiera de las dos `.6`.

## 2. Recompute masivo de tasas al actualizar el módulo

`foreign_rate_date` es un calculado almacenado que comparte `compute="_compute_rate"` con `foreign_rate` (que lleva `tracking=True`) y con `foreign_inverse_rate`.

Cuando el ORM crea la columna de un calculado almacenado marca **todos** los registros existentes para computar — `odoo/orm/models.py`, `_auto_init`:

```python
new = field.update_db(self, columns)
if new and field.compute:
    fields_to_compute.append(field)
...
for field in fields_to_compute:
    self.env.add_to_compute(field, records)   # records = toda la tabla
```

y al ejecutarse `_compute_rate` se asignan los tres campos que comparten el método. En las compañías con *"Update sale order rate using date order"* activo no hay guard que lo pare: las órdenes históricas quedaban con la tasa reescrita a partir de `date_order` —que el core ya movió a la fecha de confirmación— y con un mensaje en el chatter cada una, al ser `foreign_rate` un campo con tracking.

La migración pasa de `post-` a `pre-`: crea la columna antes de que el ORM cargue el modelo, de modo que `update_db` la encuentra existente, no la trata como nueva y no dispara el recompute. La versión `post-` corría *después* del recompute, así que reparaba `foreign_rate_date` pero no el reescrito colateral de la tasa.

El criterio de relleno **no cambia** (tasa viva → `date_order`, tasa congelada → `create_date`, ya facturadas en NULL) y la creación de la columna va con guard de existencia para que sea idempotente en las instancias que ya estén en `.6`. El porqué del `pre-` queda documentado en el docstring del script para que no vuelva a `post-` en un refactor.

Las compañías con la opción desactivada (el default) nunca estuvieron expuestas: el guard de `_compute_rate` las cubre.

## 3. Bump faltante de `l10n_ve_accountant`

El #1208 modificó `account_move.py` y `account_move_line.py` sin subir la versión del módulo. `19.0.1.0.13` → `19.0.1.0.14`.

## Cómo probar

El cambio es de empaquetado; lo que hay que verificar es que la migración corra y que **no** haya recompute masivo:

1. Instancia en `l10n_ve_sale` `19.0.1.0.5` (o `.6`) con órdenes de venta históricas y la compañía con *"Update sale order rate using date order"* **activo**.
2. Anotar `foreign_rate` de unas cuantas órdenes confirmadas y la cantidad de mensajes en su chatter.
3. Actualizar el módulo (`-u l10n_ve_sale`).
4. `foreign_rate_date` queda relleno en las órdenes no facturadas del todo, con `date_order` como valor.
5. **`foreign_rate` de las órdenes históricas no cambia y no aparece ningún mensaje nuevo en su chatter.**
6. Repetir con la opción desactivada: `foreign_rate_date` sale de `create_date` y las tasas tampoco se mueven.

Verificación hecha: el `ALTER` + `UPDATE` se ejecutó contra el esquema real de una base 19 con `l10n_ve_sale` instalado, dentro de una transacción revertida. No hay bases locales con órdenes de venta, así que el relleno no se pudo medir sobre filas reales; el `UPDATE` es el del #1208 sin cambios.

## Nota de despliegue

Una instancia que **ya** haya actualizado a la `19.0.1.0.6` ya sufrió el recompute. A esas hay que revisarles la tasa de las órdenes históricas aparte — esta migración no lo revierte.

References:
- Tarea: https://binaural.odoo.com/odoo/action-341/74966
- PR: https://github.com/binaural-dev/odoo-venezuela/pull/1208
- Otros: https://github.com/binaural-dev/odoo-venezuela/pull/1228 (origen de la colisión de versión)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEP9WGEPrH2CZQKw5BJ6dc
