### PR TITLE
[FIX] l10n_ve_iot_mf: Corrige print_type que bloqueaba impresión fiscal

### DIFF
--- a/l10n_ve_iot_mf/__manifest__.py
+++ b/l10n_ve_iot_mf/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": "Implementación de DLLs de The Factory HKA (VE) y desarrollos PnP para Internet of Things (IoT) y compatibilidad con Odoo.",
     "license": "LGPL-3",
     "category": "Accounting",
-    "version": "17.0.0.2.3",
+    "version": "17.0.0.2.4",
     "author": "Binaural",
     "website": "https://binauraldev.com",
     "depends": [

--- a/l10n_ve_iot_mf/migrations/17.0.0.2.4/post-migration.py
+++ b/l10n_ve_iot_mf/migrations/17.0.0.2.4/post-migration.py
@@ -1,0 +1,9 @@
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE account_move
+        SET print_type = 'fiscal'
+        WHERE mf_serial IS NOT NULL AND mf_serial != ''
+          AND mf_invoice_number IS NOT NULL AND mf_invoice_number != ''
+        """
+    )

--- a/l10n_ve_iot_mf/models/account_move.py
+++ b/l10n_ve_iot_mf/models/account_move.py
@@ -36,9 +36,13 @@ class AccountMoveInh(models.Model):
     )
     mf_reportz = fields.Char(string="Report number Z", default=False, copy=False, tracking=True)
     
+    def _default_print_type(self):
+        return self.env.company.invoice_print_type
+
     print_type = fields.Selection(
-        related='company_id.invoice_print_type',
-        store=True
+        selection=lambda self: self.env['res.company']._fields['invoice_print_type'].selection,
+        default=_default_print_type,
+        store=True,
     )
 
     def has_printed(self, invoice_number):

--- a/l10n_ve_iot_mf/views/account_move.xml
+++ b/l10n_ve_iot_mf/views/account_move.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <button name="button_draft" position="after">
-                <field name='print_type' invisible="1"/>
+                <field name='print_type' invisible="1" readonly="1"/>
                 <field name='mf_invoice_number' invisible="1"/>
                 <widget name="iot-mf-button" action="print_out_invoice" invisible="state != 'posted' or move_type != 'out_invoice' or mf_invoice_number != False or is_debit_journal != False or print_type != 'fiscal' or correlative != False"/>                
                 <widget name="iot-mf-button" action="reprint_document" invisible="mf_invoice_number == False or print_type != 'fiscal' or correlative != False"/>


### PR DESCRIPTION
## Resumen
Corrige el campo `print_type` de `account.move` en `l10n_ve_iot_mf` para dejar de ser un campo `related+store` sobre `company_id.invoice_print_type`.

## Problema
Ticket 14760: al validar la impresión desde contabilidad no se establece conexión con la máquina fiscal, solo se genera el PDF. Adicionalmente, guardar el ajuste "Tipo de Impresión de Factura" de la compañía en producción (Odoo.sh, ~275k facturas históricas) mataba el worker por OOM y dejaba la pantalla en blanco.

## Causa
`print_type` era `related='company_id.invoice_print_type', store=True`. Cualquier cambio del ajuste de compañía disparaba la recomputación de esa columna sobre TODAS las facturas históricas en una sola transacción. Además, al ser un related en vivo, no reflejaba si la factura fue realmente impresa por máquina fiscal, sino el ajuste actual de la compañía — ocultando el botón de reimpresión fiscal en facturas ya impresas si el ajuste cambiaba después.

## Solución
- `print_type` pasa de `related` a `Selection` normal con `default=_default_print_type` (snapshot de `company_id.invoice_print_type` solo al crear el registro), evitando el recompute masivo.
- `readonly="1"` en la vista, reflejando que ya no es editable en vivo.
- Migración `migrations/17.0.0.2.4/post-migration.py`: marca `fiscal` las facturas con `mf_serial` + `mf_invoice_number` reales (evidencia de impresión por MF), preservando el botón de reimpresión sobre facturas ya impresas.
- Bump de versión `17.0.0.2.3` → `17.0.0.2.4` (no se reutilizó `0.2.3`, ya usada en mantenimiento por otro fix sin migración, para asegurar que la migración se dispare en toda instalación).

## Evidencia de verificación
Cherry-pick del fix validado en el staging del cliente (PR #206 de `countryclub`, rama `188759197_fix-ti_14760_print_type_fiscal_machine_oom`) aplicado limpio sobre `maintenance-17.0` sin conflictos de código.

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/14760