### PR TITLE
 Generar Retencion sin emitir diferencial cambiari

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.26",
+    "version": "19.0.2.0.27",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_move_line.py
+++ b/l10n_ve_payment_extension/models/account_move_line.py
@@ -14,3 +14,36 @@ class AccountMoveLine(models.Model):
             if not line.product_id or line.ciu_id or not line.product_id.ciu_ids:
                 continue
             line.ciu_id = line.product_id.ciu_ids[0]
+
+    @api.model
+    def _prepare_reconciliation_amls(self, values_list, shadowed_aml_values=None):
+        # 1. Dejar que Odoo ejecute el bucle while True original
+        all_results, fully_reconciled_aml_ids = super()._prepare_reconciliation_amls(
+            values_list, 
+            shadowed_aml_values=shadowed_aml_values
+        )
+
+        # 2. Interceptamos solo si pasamos nuestro flag en el contexto
+        if self.env.context.get('no_exchange_difference') and self.env.context.get('group_in_single_partial'):
+            if len(all_results) > 1:
+                # Tomamos la estructura del primer parcial como base
+                base_result = all_results[0]
+                first_partial = base_result['partial_values']
+
+                # Sumamos los importes de todos los parciales generados en el bucle
+                total_amount = sum(r['partial_values']['amount'] for r in all_results if r.get('partial_values'))
+                total_debit_curr = sum(r['partial_values']['debit_amount_currency'] for r in all_results if r.get('partial_values'))
+                total_credit_curr = sum(r['partial_values']['credit_amount_currency'] for r in all_results if r.get('partial_values'))
+
+                # Actualizamos los valores consolidados en el primer registro
+                first_partial['amount'] = total_amount
+                first_partial['debit_amount_currency'] = total_debit_curr
+                first_partial['credit_amount_currency'] = total_credit_curr
+
+                # Eliminamos los valores de diferencia de cambio si sobrevivió alguno
+                base_result.pop('exchange_values', None)
+
+                # Reemplazamos la lista con únicamente el resultado consolidado
+                all_results = [base_result]
+
+        return all_results, fully_reconciled_aml_ids

--- a/l10n_ve_payment_extension/models/account_payment.py
+++ b/l10n_ve_payment_extension/models/account_payment.py
@@ -80,35 +80,10 @@ class AccountPayment(models.Model):
                     f"-{retention_line_id.economic_activity_id.branch_id.name}"
                 )
 
-            vals_to_change = {"name": move_name, "is_manually_modified": True}
+            vals_to_change = {"name": move_name, "is_manually_modified": True, "foreign_rate": retention_line_id.move_id.foreign_rate, "foreign_inverse_rate": retention_line_id.move_id.foreign_inverse_rate}
             move.write(vals_to_change)
         return res
 
-    def _generate_move_vals(self, write_off_line_vals=None, force_balance=None, line_ids=None):
-        """
-        A retention payment's move must land in the same fiscal period as (and use
-        the same exchange rate as) the invoice it retains from, even though
-        payment.date stays as the retention's own date_accounting chosen by the
-        user. Writing move.date after the move is created/posted is NOT enough
-        (and was tried and reverted): the move's amounts are already computed
-        using payment.date's rate at generation time, so forcing only the date
-        label afterwards desyncs date from the rate actually used, producing a
-        bogus exchange difference on reconciliation. Instead, inject
-        l10n_ve_conversion_date (read by l10n_ve_accountant's
-        _prepare_move_lines_per_type override) BEFORE generating the move, so the
-        liquidity line is converted with the invoice's rate, then align 'date' to
-        that same value so the two never drift apart.
-        """
-        self.ensure_one()
-        if self.is_retention and self.retention_line_ids:
-            invoice_date = self.retention_line_ids[0].move_id.date
-            if invoice_date:
-                vals = super(
-                    AccountPayment, self.with_context(l10n_ve_conversion_date=invoice_date)
-                )._generate_move_vals(write_off_line_vals, force_balance, line_ids)
-                vals['date'] = invoice_date
-                return vals
-        return super()._generate_move_vals(write_off_line_vals, force_balance, line_ids)
 
     def unlink(self):
         for payment in self:

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -732,7 +732,9 @@ class AccountRetention(models.Model):
                     _("No registered lines found in the move to reconcile.")
                 )
             
-            payment.retention_line_ids.move_id.js_assign_outstanding_line(lines[0].id)
+            payment.retention_line_ids.move_id.with_context(
+                no_exchange_difference=True,group_in_single_partial=True
+            ).js_assign_outstanding_line(lines[0].id)
 
     @api.model
     def compute_retention_lines_data(self, invoice_id, payment=None):


### PR DESCRIPTION
[FIX] l10n_ve_payment_extension: Generar Retencion sin emitir diferencial cambiario

Ya que las retenciones en Bolivares sonbre una factura en Divisas genera diferencial cambiario, no hay forma de evitar el diferencial o no indexar este monto de alguna forma , como solucion:

Se agrega el contexto no_exchange_difference, este evita generar el asiento de diferencial cambiario, sin enbargo odoo base emite las conciliaciones parciales en base la cantidad de tasas que generen diferencias para poder llegar al monto declarado por lo cual 1 solo pago con esto puede emitir mas de 1 conciliacion parcial

Ya que la suma de todas las conciliaciones es el monto corecto se agrega group_in_single_partial el cual actua unicamente sobre _prepare_reconciliation_amls el cual detecta que al no generar el diferencial y tener este contexto si existe mas de 1 coniliacion parcial el mismo las agrupa, esto solo sucede des las retenciones por lo cual no afecta otros asientos contable a menos q se pasen estos 2 contextos exclusivamente.

Como la conciliacion queda correcta para este caso logrando no indexar los bolivaes, el monto correspondera a la tasa de la facttura por lo ccual para no afectar el asiento tambien se fuerza la tasa alerna de la factura en _synchronize_to_moves y de esta forma el monto del asiento correspondera a dicha tasa, la fecha del pago y su asiento correspondera a la fecha Contable sin generar diferencial cambiario respetando la logica de que la fecha de pago debe correspoder con la fecha de su propio asiento, de esta forma no se alterna los libros contables y la busqueda en libros de ventas y compras no se vera afectada en su funcionamiento actual

References:
- Ticket:
- Tarea:
- PR:
- Otros: