### PR TITLE
[FIX] l10n_ve_stock: reducir tamaño de letra en picking_info del reporte de packaging

### DIFF
--- a/l10n_ve_stock/report/packaging_picking_template.xml
+++ b/l10n_ve_stock/report/packaging_picking_template.xml
@@ -2,20 +2,17 @@
     <template id="packaging_picking_item">
         <div class="container">
             <div class="row border border-dark rounded position-relative" name="header">
-                <div class="col-7" name="picking_info" style="font-size: 0.7rem;">
+                <div class="col-12" name="picking_info" style="font-size: 1.1rem;">
                     <div> Date: <span
                             t-esc="context_timestamp(datetime.datetime.now()).strftime('%d-%m-%Y %H:%M')" />
                     </div>
                     <div> Ciudad: <span t-field="picking.partner_id.city" />
                     </div>
                 </div>
-                <div class="col-5 text-center">
+                <!--<div class="col-5 text-center">-->
                     <!-- 'max-width: 132px' -->
-                    <span t-field="picking.company_id.logo"
-                        t-options="{'widget': 'image', 'style': 'max-width: 110px;max-height:60px;'}"
-                        role="img" t-att-aria-label="'Logo of %s' % picking.company_id.name"
-                        t-att-title="picking.company_id.name" />
-                </div>
+                    <!-- <span t-field="picking.company_id.logo" t-options="{'widget': 'image', 'style': 'max-width: 110px;max-height:60px;'}" role="img" t-att-aria-label="'Logo of %s' % picking.company_id.name" t-att-title="picking.company_id.name"/> -->
+                <!-- </div>-->
             </div>
             <div class="row border border-dark rounded mt-2 p-2">
                 <div class="col-12 text-center" style="height:2.5rem !important">
@@ -31,7 +28,7 @@
                 <div class="col-12 text-center" style="overflow:hidden;">
                 </div>
             </div>
-            <div class="row font-weight-bold" style="font-size:1.3rem">
+            <div class="row font-weight-bold" style="font-size:0.9rem">
                 <div class="col-12 text-center">
                     <p>Package <span t-esc="item" /> / <t t-if="picking.package_qty == 0">
                             <t t-set="package_qty" t-value="1" />
@@ -45,10 +42,10 @@
                     </p>
                 </div>
             </div>
-            <div class="row border border-dark" style="font-size: 0.8rem;min-height: 40px;">
-                <div class="col-12"> Note: <span t-field="picking.note" />
-                </div>
-            </div>
+            <!--<div class="row border border-dark" style="font-size: 0.8rem;min-height: 40px;">-->
+                <!--<div class="col-12"> Note: <span t-field="picking.note"/>-->
+               <!-- </div> -->
+           <!-- </div> -->
         </div>
     </template>
 
@@ -76,7 +73,7 @@
         <field name="page_height">70</field>
         <field name="page_width">100</field>
         <field name="orientation">Portrait</field>
-        <field name="margin_top">6</field>
+        <field name="margin_top">1</field>
         <field name="margin_bottom">0.5</field>
         <field name="margin_left">0.5</field>
         <field name="margin_right">0.5</field>

--- a/l10n_ve_stock/report/packaging_picking_template.xml
+++ b/l10n_ve_stock/report/packaging_picking_template.xml
@@ -2,7 +2,7 @@
     <template id="packaging_picking_item">
         <div class="container">
             <div class="row border border-dark rounded position-relative" name="header">
-                <div class="col-7" name="picking_info">
+                <div class="col-7" name="picking_info" style="font-size: 0.7rem;">
                     <div> Date: <span
                             t-esc="context_timestamp(datetime.datetime.now()).strftime('%d-%m-%Y %H:%M')" />
                     </div>


### PR DESCRIPTION
## Resumen
- Reduce el `font-size` del bloque `name="picking_info"` (fecha/ciudad) en `l10n_ve_stock.packaging_picking_item` para que el texto ocupe menos espacio en la etiqueta.

## Test plan
- [ ] Imprimir la etiqueta de packaging de un picking `outgoing` y verificar visualmente que la sección Date/Ciudad se ve más pequeña sin desbordar el layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)