### PR TITLE
19.0_feat-ta_79483 Block referencia interna (rehecho limpio desde maintenance-19.0)

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -3,6 +3,7 @@
     "summary": """
         Inventario para la localización en Venezuela
     """,
+    "description": "Binaural Inventario",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
@@ -15,9 +16,9 @@
         "stock_delivery",
     ],
     "data": [
+        "security/l10n_ve_stock_groups.xml",
         "security/ir.model.access.csv",
         "security/security_l10n_ve_stock.xml",
-        "security/l10n_ve_stock_groups.xml",
         "data/inventory_valuation_paperformat.xml",
         "data/ir_actions_server.xml",
         "report/packaging_picking_template.xml",
@@ -30,7 +31,10 @@
         "views/stock_picking_views.xml",
         "views/stock_location_views.xml",
         "views/stock_warehouse_views.xml",
+        "views/stock_picking_alter_location_line_views.xml",
+        "views/stock_picking_alter_location_views.xml",
         "wizard/stock_quantity_history.xml",
+        "wizard/move_alter_location_qtities.xml",
     ],
     "application": True,
     "pre_init_hook": "pre_init_hook",

--- a/l10n_ve_stock/data/ir_actions_server.xml
+++ b/l10n_ve_stock/data/ir_actions_server.xml
@@ -13,5 +13,15 @@
             </field>
         </record>
 
+        <record id="sync_physical_quantities" model="ir.actions.server">
+            <field name="name">Synchronize Quantities with Real Quants</field>
+            <field name="type">ir.actions.server</field>
+            <field name="model_id" ref="model_stock_picking_alter_location"/>
+            <field name="binding_model_id" ref="model_stock_picking_alter_location"/>
+            <field name="state">code</field>
+            <field name="code">records.subtract_physical_quantity()</field>
+            <field name="group_ids" eval="[(4, ref('l10n_ve_stock.group_physical_location_edit'))]"/>
+        </record>
+
 	</data>
 </odoo>

--- a/l10n_ve_stock/i18n/es_VE.po
+++ b/l10n_ve_stock/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250522\n"
+"Project-Id-Version: Odoo Server 19.0+e-20260702\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-08 16:19+0000\n"
-"PO-Revision-Date: 2025-11-08 16:19+0000\n"
+"POT-Creation-Date: 2026-08-22 04:22+0000\n"
+"PO-Revision-Date: 2026-08-22 04:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,7 +18,6 @@ msgstr ""
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#, python-format
 msgid "%s%s"
 msgstr ""
 
@@ -30,8 +29,6 @@ msgstr "'Etiqueta de Cajas- %s' % (object.name)"
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/product_product.py:0
-#: code:addons/l10n_ve_stock/models/product_product.py:0
-#, python-format
 msgid "- Barcode \"%s\" already assigned to product(s): %s"
 msgstr "- Còdigo de barras \"%s\" ya ha sido asignado al producto(s): %s"
 
@@ -75,37 +72,44 @@ msgstr ""
 "                                <strong>Cuando está desmarcado:</strong> Se filtrará la cantidad de productos ('Cantidad disponible') por ubicaciones padre e hijo que solo sean de tipo 'Stock'"
 
 #. module: l10n_ve_stock
-#. odoo-python
-#: code:addons/l10n_ve_stock/models/product_product.py:0
-#: code:addons/l10n_ve_stock/models/product_product.py:0
-#, python-format
-msgid "A packaging already uses the barcode"
-msgstr "Un empaque ya usa el código de barras"
-
-#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_needaction
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_needaction
 msgid "Action Needed"
 msgstr "Acción Necesaria"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__active
+msgid "Active"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_ids
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_ids
 msgid "Activities"
 msgstr "Actividades"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_exception_decoration
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_exception_decoration
 msgid "Activity Exception Decoration"
 msgstr "Decoración de Excepción de Actividad"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_state
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_state
 msgid "Activity State"
 msgstr "Estado de la Actividad"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_type_icon
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_type_icon
 msgid "Activity Type Icon"
 msgstr "Tipo de Actividad Icono"
+
+#. module: l10n_ve_stock
+#: model_terms:ir.actions.act_window,help:l10n_ve_stock.action_stock_picking_alter_location_view
+msgid "Add a Physical Location to the product."
+msgstr "Agregue una Ubicación Física al producto."
 
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.report_inventory_valuation_template
@@ -140,6 +144,16 @@ msgid "Allow to scrap more than available quantity in stock."
 msgstr "Permitir desechar más que la cantidad disponible en inventario."
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__allowed_from_location_ids
+msgid "Allowed From Location"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__allowed_to_location_ids
+msgid "Allowed To Location"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.res_config_settings_view_form_l10n_ve_stock
 msgid ""
 "Allows to show the available quantity (Total minus reserved) in both product"
@@ -156,6 +170,16 @@ msgid "Alternate Code"
 msgstr "Còdigo Alterno"
 
 #. module: l10n_ve_stock
+#: model:ir.model,name:l10n_ve_stock.model_stock_picking_alter_location_line
+msgid "Alternate Location Line"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.model,name:l10n_ve_stock.model_stock_picking_alter_location
+msgid "Alternate Locations"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_product_product__alternate_code
 #: model:ir.model.fields,help:l10n_ve_stock.field_product_template__alternate_code
 msgid "Alternate code for the product"
@@ -167,20 +191,19 @@ msgid "Artículo"
 msgstr ""
 
 #. module: l10n_ve_stock
-#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__partner_id
-msgid "Assigned Customer"
-msgstr "Cliente"
-
-#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_attachment_count
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_attachment_count
 msgid "Attachment Count"
 msgstr "Nº de archivos adjuntos"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__available_qty
+msgid "Available Quantities"
+msgstr ""
+
+#. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/product_product.py:0
-#: code:addons/l10n_ve_stock/models/product_product.py:0
-#, python-format
 msgid ""
 "Barcode(s) already assigned:\n"
 "\n"
@@ -189,6 +212,11 @@ msgstr ""
 "Código de barra(s) ya ha sido asignado:\n"
 "\n"
 "%s"
+
+#. module: l10n_ve_stock
+#: model:res.groups,name:l10n_ve_stock.group_physical_location_edit
+msgid "Binaural - Editar Ubicaciones Físicas Alternas"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model:res.groups,name:l10n_ve_stock.group_block_liters_per_unit
@@ -201,6 +229,17 @@ msgid ""
 "Block Type Inventory Transfers Expeditions (Do not add a new product to the "
 "Dispatch)"
 msgstr "Bloquear Transferencias De Inventario de Tipo Expediciones"
+
+#. module: l10n_ve_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.move_alter_location_qtities_wizard_view_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: l10n_ve_stock
+#. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking_alter_location.py:0
+msgid "Change Quantities Between Locations"
+msgstr "Cambiar Cantidades Entre Ubicaciones"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_res_company__change_weight
@@ -221,6 +260,8 @@ msgstr "Empresas"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_product_category__company_id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__company_id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__company_id
 msgid "Company"
 msgstr "Compañía"
 
@@ -230,6 +271,11 @@ msgid "Config Settings"
 msgstr "Ajustes de configuración"
 
 #. module: l10n_ve_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.move_alter_location_qtities_wizard_view_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.report_inventory_valuation_template
 msgid "Costo"
 msgstr ""
@@ -237,6 +283,20 @@ msgstr ""
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.report_inventory_valuation_template
 msgid "Costo Total"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__create_uid
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__create_uid
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__create_date
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__create_date
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__create_date
+msgid "Created on"
 msgstr ""
 
 #. module: l10n_ve_stock
@@ -250,26 +310,57 @@ msgid "Define a main sell's warehouse."
 msgstr "Define un almacén de ventas principal."
 
 #. module: l10n_ve_stock
-#. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_warehouse.py:0
-#, python-format
-msgid "Delivery Orders"
-msgstr "Órdenes de Despacho"
-
-#. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.report_inventory_valuation_template
 msgid "Descripción"
 msgstr ""
 
 #. module: l10n_ve_stock
-#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.res_config_settings_view_form_l10n_ve_stock
-msgid "Dispatch Guide"
-msgstr "Configuración de guía de despacho"
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__destination_physical_address
+msgid "Destination Address"
+msgstr "Dirección de Destino"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_warehouse__physical_address
+msgid ""
+"Detailed warehouse address (Street, Avenue, Industrial Zone, State, City, "
+"etc.)"
+msgstr ""
+"Dirección detallada del almacén (Calle, Avenida, Zona Industrial, Estado, "
+"Ciudad, etc.)"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_category__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_product__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_template__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_move__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_move_line__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_type__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_quant__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_quantity_history__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_scrap__display_name
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_warehouse__display_name
+msgid "Display Name"
+msgstr "Nombre en pantalla"
 
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.view_stock_quantity_history_inherit_binaural_stock
 msgid "Download"
 msgstr "Descargar"
+
+#. module: l10n_ve_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.res_config_settings_view_form_l10n_ve_stock
+msgid ""
+"Enable alternate locations tracking and transfers between physical and "
+"alternate locations."
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_quantity_history__except_products_at_zero
@@ -283,36 +374,19 @@ msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_follower_ids
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_follower_ids
 msgid "Followers"
 msgstr "Seguidores"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_partner_ids
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_partner_ids
 msgid "Followers (Partners)"
 msgstr "Seguidores (Contactos)"
 
 #. module: l10n_ve_stock
-#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__destination_physical_address
-msgid "Destination Address"
-msgstr "Dirección de Destino"
-
-#. module: l10n_ve_stock
-#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_warehouse__physical_address
-msgid "Physical Address"
-msgstr "Dirección Física"
-
-#. module: l10n_ve_stock
-#: model:ir.model.fields,help:l10n_ve_stock.field_stock_warehouse__physical_address
-msgid "Detailed warehouse address (Street, Avenue, Industrial Zone, State, City, etc.)"
-msgstr "Dirección detallada del almacén (Calle, Avenida, Zona Industrial, Estado, Ciudad, etc.)"
-
-#. module: l10n_ve_stock
-#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__source_physical_address
-msgid "Source Address"
-msgstr "Dirección de Origen"
-
-#. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__activity_type_icon
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
 msgstr "Icono Font awesome, por ejemplo fa-tasks"
 
@@ -320,6 +394,11 @@ msgstr "Icono Font awesome, por ejemplo fa-tasks"
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_product_template__free_qty
 msgid "Free To Use Quantity"
 msgstr "Cantidad de uso libre"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__from_location
+msgid "From"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_res_company__group_product_available_quantity_on_sale
@@ -333,6 +412,7 @@ msgstr "Grupo de Cantidad Disponible para Vender"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__has_message
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__has_message
 msgid "Has Message"
 msgstr "Tiene Mensaje"
 
@@ -373,6 +453,27 @@ msgid "Hide Validate Inventory Transfers Button"
 msgstr "Ocultar Botón Validar de las Transferencias de Inventario"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_category__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_product__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_template__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_move__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_move_line__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_type__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_quant__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_quantity_history__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_scrap__id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_warehouse__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields.selection,name:l10n_ve_stock.selection__stock_picking__type_delivery_step__in
 #: model:ir.model.fields.selection,name:l10n_ve_stock.selection__stock_picking_type__type_steps__in
 msgid "IN"
@@ -386,22 +487,27 @@ msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_exception_icon
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_exception_icon
 msgid "Icon"
 msgstr "Icono"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__activity_exception_icon
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__activity_exception_icon
 msgid "Icon to indicate an exception activity."
 msgstr "Icono para indicar una actividad de excepción."
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__message_needaction
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__message_needaction
 msgid "If checked, new messages require your attention."
 msgstr "Si está marcado hay nuevos mensajes que requieren su atención."
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__message_has_error
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__message_has_sms_error
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__message_has_error
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr "Si se encuentra marcado, algunos mensajes tienen error de envío."
 
@@ -417,7 +523,6 @@ msgstr ""
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#, python-format
 msgid ""
 "Insufficient stock:\n"
 "%s\n"
@@ -428,13 +533,6 @@ msgstr ""
 "%s\n"
 "\n"
 "Ajuste las cantidades o solicite más stock para esta ubicación."
-
-#. module: l10n_ve_stock
-#. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_warehouse.py:0
-#, python-format
-msgid "Internal Transfers"
-msgstr "Traslados internos"
 
 #. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_location
@@ -448,6 +546,7 @@ msgstr "Inventario:"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_is_follower
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_is_follower
 msgid "Is Follower"
 msgstr "Es Seguidor"
 
@@ -455,6 +554,20 @@ msgstr "Es Seguidor"
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_quant__is_physical_location
 msgid "Is Physical Location"
 msgstr "Es Ubicación Física"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__write_uid
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__write_uid
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__write_date
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__write_date
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__write_date
+msgid "Last Updated on"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_res_company__limit_product_qty_out
@@ -473,10 +586,26 @@ msgid "Liters Per Unit"
 msgstr "Litros por unidad"
 
 #. module: l10n_ve_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.product_template_form_view_from_binaural_stock
+msgid "Locations..."
+msgstr ""
+
+#. module: l10n_ve_stock
+#. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking.py:0
+msgid "Lot/Serial"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_res_company__main_warehouse_id
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_res_config_settings__main_warehouse_id
 msgid "Main Warehouse"
 msgstr "Almacén Principal"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__max_quantity
+msgid "Maximum Quantity"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.res_config_settings_view_form_l10n_ve_stock
@@ -485,43 +614,59 @@ msgstr "Máxima cantidad de líneas de productos por guía de despacho."
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_has_error
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_has_error
 msgid "Message Delivery error"
 msgstr "Error de Envío de Mensaje"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_ids
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_ids
 msgid "Messages"
 msgstr "Mensajes"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__min_quantity
+msgid "Minimum Quantity"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.stock_picking_alter_location_view_form
+msgid "Move quantities between locations"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__my_activity_date_deadline
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__my_activity_date_deadline
 msgid "My Activity Deadline"
 msgstr "Mi fecha límite de actividad"
 
 #. module: l10n_ve_stock
-#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_calendar_event_id
-msgid "Next Activity Calendar Event"
-msgstr "Próximo evento de calendario de actividad"
+#. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking_alter_location_line.py:0
+msgid "New location '%(name)s' added with quantity: %(qty)s"
+msgstr "Nueva ubicación '%(name)s' agregada con cantidad: %(qty)s"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_date_deadline
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_date_deadline
 msgid "Next Activity Deadline"
 msgstr "Fecha límite para la próxima actividad"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_summary
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_summary
 msgid "Next Activity Summary"
 msgstr "Resumen de la siguiente actividad"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_type_id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_type_id
 msgid "Next Activity Type"
 msgstr "Siguiente tipo de actividad"
 
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_scrap.py:0
-#, python-format
 msgid "No more than what is manufactured can be discarded in this operation."
 msgstr "En esta operación no se puede desechar más de lo fabricado."
 
@@ -549,21 +694,25 @@ msgstr "Nota"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_needaction_counter
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_needaction_counter
 msgid "Number of Actions"
 msgstr "Número de acciones"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_has_error_counter
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_has_error_counter
 msgid "Number of errors"
 msgstr "Número de errores"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__message_needaction_counter
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__message_needaction_counter
 msgid "Number of messages requiring action"
 msgstr "Número de mensajes que requieren una acción"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__message_has_error_counter
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__message_has_error_counter
 msgid "Number of messages with delivery error"
 msgstr "Número de mensajes con error de envío"
 
@@ -577,6 +726,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.view_picking_form
 msgid "OUTS"
 msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__stock_alter_location_lines
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.stock_picking_alter_location_view_form
+msgid "Other Product Locations"
+msgstr "Otras Ubicaciones del Producto"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__outs_count
@@ -601,16 +756,14 @@ msgid "PICK"
 msgstr ""
 
 #. module: l10n_ve_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.stock_picking_alter_location_view_tree
+msgid "PICK Locations"
+msgstr "Ubicaciones PICK"
+
+#. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.view_picking_form
 msgid "PICKS"
 msgstr ""
-
-#. module: l10n_ve_stock
-#. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_warehouse.py:0
-#, python-format
-msgid "Pack"
-msgstr "Empaquetar"
 
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.packaging_picking_item
@@ -633,23 +786,31 @@ msgid "Packs Count"
 msgstr "Cantidad de Packs"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_warehouse__physical_address
+msgid "Physical Address"
+msgstr "Dirección Física"
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_product_product__physical_location_id
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_product_template__physical_location_id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__pick_location
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.stock_picking_alter_location_view_form
 msgid "Physical Location"
-msgstr "Ubicacion Física"
+msgstr "Ubicación Física"
 
 #. module: l10n_ve_stock
 #: model:ir.actions.act_window,name:l10n_ve_stock.action_stock_quant
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_product__physical_locations_ids
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_template__physical_locations_ids
 #: model:ir.ui.menu,name:l10n_ve_stock.menu_stock_quant
+#: model:ir.ui.menu,name:l10n_ve_stock.stock_picking_alter_location_view_menu
 msgid "Physical Locations"
 msgstr "Ubicaciones Físicas"
 
 #. module: l10n_ve_stock
-#. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_warehouse.py:0
-#, python-format
-msgid "Pick"
-msgstr "Elegir"
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__pick_quantity
+msgid "Physical Quantities"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_picking_type
@@ -686,8 +847,6 @@ msgstr "Precio sin impuestos"
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/product_template.py:0
-#: code:addons/l10n_ve_stock/models/product_template.py:0
-#, python-format
 msgid "Price cannot be negative or zero."
 msgstr "El precio no puede ser negativo o cero."
 
@@ -702,6 +861,7 @@ msgstr "Prioridad"
 
 #. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_product_template
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__product_id
 msgid "Product"
 msgstr "Producto"
 
@@ -716,19 +876,34 @@ msgid "Product Category"
 msgstr "Categoría del producto"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__location_id
+msgid "Product Location"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_move_line
 msgid "Product Moves (Stock Move Line)"
 msgstr "Movimientos de producto (línea de movimiento de stock)"
 
 #. module: l10n_ve_stock
-#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_move_line__product_tag_ids
-msgid "Product Template Tags"
-msgstr "Etiquetas de Producto"
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__name
+msgid "Product Name"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.actions.act_window,name:l10n_ve_stock.action_stock_picking_alter_location_view
+msgid "Product Physical Locations"
+msgstr "Ubicaciones Físicas del Producto"
 
 #. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_product_product
 msgid "Product Variant"
 msgstr "Variante del producto"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__transfer_quantity
+msgid "Quantities to Transfer"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_product_product__quantity
@@ -737,21 +912,31 @@ msgid "Quantity"
 msgstr "Cantidad"
 
 #. module: l10n_ve_stock
+#. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking_alter_location_line.py:0
+msgid "Quantity in %s"
+msgstr "Cantidad en %s"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__total_quantity
+msgid "Quantity in Other Locations"
+msgstr ""
+
+#. module: l10n_ve_stock
+#. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking_alter_location_line.py:0
+msgid "Quantity updated"
+msgstr "Cantidad actualizada"
+
+#. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_quant
 msgid "Quants"
-msgstr "Cantidades"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.report_inventory_valuation_template
 msgid "Rango:"
 msgstr ""
-
-#. module: l10n_ve_stock
-#. odoo-python
-#: code:addons/l10n_ve_stock/models/stock_warehouse.py:0
-#, python-format
-msgid "Receipts"
-msgstr "Recepciones"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__reception_date
@@ -760,11 +945,13 @@ msgstr "Fecha de Recepción"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__activity_user_id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__activity_user_id
 msgid "Responsible User"
 msgstr "Usuario Responsable"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__message_has_sms_error
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__message_has_sms_error
 msgid "SMS Delivery error"
 msgstr "Error de entrega de SMS"
 
@@ -789,12 +976,24 @@ msgid "Show Location Available"
 msgstr "Otras Ubicaciones del Producto"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_product__show_physical_locations
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_product_template__show_physical_locations
+msgid "Show Physical Locations"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model:res.groups,name:l10n_ve_stock.group_show_standard_price
 msgid "Show standard price on the product form view"
 msgstr "Mostrar costo en la vista del producto"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__source_physical_address
+msgid "Source Address"
+msgstr "Dirección de Origen"
+
+#. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__activity_state
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__activity_state
 msgid ""
 "Status based on activities\n"
 "Overdue: Due date is already passed\n"
@@ -812,6 +1011,12 @@ msgid "Stock"
 msgstr "Inventario"
 
 #. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__stock_alter_location_id
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location_line__stock_alter_location_id
+msgid "Stock Alter Location"
+msgstr ""
+
+#. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_move
 msgid "Stock Move"
 msgstr "Movimiento de stock"
@@ -819,12 +1024,22 @@ msgstr "Movimiento de stock"
 #. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_quantity_history
 msgid "Stock Quantity History"
-msgstr "Historial de cantidad de existencias "
+msgstr "Historial de cantidad de existencias"
 
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.res_config_settings_view_form_l10n_ve_stock
 msgid "Stock Settings"
 msgstr "Configuración de Inventario: General"
+
+#. module: l10n_ve_stock
+#: model:ir.actions.server,name:l10n_ve_stock.sync_physical_quantities
+msgid "Synchronize Quantities with Real Quants"
+msgstr "Sincronizar Cantidades con Quants Reales"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_move_line__product_tag_ids
+msgid "Tags"
+msgstr "Etiquetas de Producto"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_product_product__quantity
@@ -834,35 +1049,54 @@ msgstr "La Disponibilidad del Producto para la Venta."
 
 #. module: l10n_ve_stock
 #. odoo-python
-#: code:addons/l10n_ve_stock/models/product_template.py:0
-#: code:addons/l10n_ve_stock/models/product_template.py:0
-#, python-format
-msgid "The name contains a character that is not allowed for registration."
-msgstr ""
-"El nombre contiene al menos un carácter que no está permitido para el "
-"registro"
-
-#. module: l10n_ve_stock
-#. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_location.py:0
-#: code:addons/l10n_ve_stock/models/stock_location.py:0
-#, python-format
 msgid "The priority must be greater than 0."
 msgstr "La prioridad debe ser mayor que 0."
 
 #. module: l10n_ve_stock
-#: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__partner_id
-msgid "This location is assigned to a specific customer for consignation."
+#. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking_alter_location.py:0
+#: code:addons/l10n_ve_stock/wizard/move_alter_location_qtities.py:0
+msgid ""
+"The resulting quantity (%(qty)s) exceeds the maximum allowed quantity in the"
+" Physical Location (%(maximum)s)."
 msgstr ""
-"Esta ubicación está asignada a un cliente específico para consignación."
+"La cantidad resultante (%(qty)s) excede la cantidad máxima permitida en la"
+" Ubicación Física (%(maximum)s)."
+
+#. module: l10n_ve_stock
+#. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking_alter_location.py:0
+#: code:addons/l10n_ve_stock/wizard/move_alter_location_qtities.py:0
+msgid ""
+"The resulting quantity (%(qty)s) would fall below the minimum required "
+"quantity in the Physical Location (%(minimum)s)."
+msgstr ""
+"La cantidad resultante (%(qty)s) caería por debajo de la cantidad mínima "
+"requerida en la Ubicación Física (%(minimum)s)."
+
+#. module: l10n_ve_stock
+#. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking_alter_location.py:0
+#: code:addons/l10n_ve_stock/wizard/move_alter_location_qtities.py:0
+msgid "There is no stock in the source location."
+msgstr "No hay stock en la ubicación de origen."
 
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/product_template.py:0
-#: code:addons/l10n_ve_stock/models/product_template.py:0
-#, python-format
 msgid "This product must have only one tax."
 msgstr "Este producto debe tener solo un impuesto."
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_move_alter_location_qtities_wizard__to_location
+msgid "To"
+msgstr ""
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__total_alter_quantity
+msgid "Total in Alter Locations"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model_terms:ir.ui.view,arch_db:l10n_ve_stock.report_inventory_valuation_template
@@ -872,7 +1106,7 @@ msgstr ""
 #. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_picking
 msgid "Transfer"
-msgstr "Transferencia"
+msgstr "Transferir"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking__type_delivery_step
@@ -886,6 +1120,7 @@ msgstr "Operación"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__activity_exception_decoration
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__activity_exception_decoration
 msgid "Type of the exception activity on record."
 msgstr "Tipo de actividad excepcional registrada"
 
@@ -902,6 +1137,12 @@ msgid ""
 msgstr ""
 "Al confirmar esta operación, se generará automáticamente el número de "
 "secuencia de la guía de despacho correspondiente"
+
+#. module: l10n_ve_stock
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_res_company__use_alternate_locations
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_res_config_settings__use_alternate_locations
+msgid "Use Alternate Locations"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_res_company__use_free_qty_odoo
@@ -933,6 +1174,7 @@ msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.model,name:l10n_ve_stock.model_stock_warehouse
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__warehouse_id
 msgid "Warehouse"
 msgstr "Almacén"
 
@@ -943,52 +1185,48 @@ msgstr "Buscar en Almacen"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_location__website_message_ids
+#: model:ir.model.fields,field_description:l10n_ve_stock.field_stock_picking_alter_location__website_message_ids
 msgid "Website Messages"
 msgstr "Mensajes del sitio web"
 
 #. module: l10n_ve_stock
 #: model:ir.model.fields,help:l10n_ve_stock.field_stock_location__website_message_ids
+#: model:ir.model.fields,help:l10n_ve_stock.field_stock_picking_alter_location__website_message_ids
 msgid "Website communication history"
 msgstr "Historial de comunicación de la web"
 
 #. module: l10n_ve_stock
+#: model:ir.model,name:l10n_ve_stock.model_move_alter_location_qtities_wizard
+msgid "Wizard to move physical quantities to other product locations."
+msgstr ""
+
+#. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/product_product.py:0
-#: code:addons/l10n_ve_stock/models/product_product.py:0
-#, python-format
 msgid "You can't create products"
 msgstr "No puedes crear productos"
 
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#, python-format
 msgid "You cannot add products to shipment-type transfers"
 msgstr "No puedes agregar productos a transferencias de tipo envío"
 
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#, python-format
 msgid "You cannot make transfers larger than the demand"
 msgstr "No puedes hacer transferencias mayores que la demanda"
 
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#, python-format
 msgid "You cannot make transfers larger than the reserved quantity"
 msgstr "No puedes hacer transferencias mayores que la cantidad reservada"
 
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_scrap.py:0
-#, python-format
 msgid ""
 "You cannot scrap more than the available product quantity in this location."
 msgstr ""
@@ -998,15 +1236,19 @@ msgstr ""
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_quant.py:0
-#, python-format
 msgid "You cannot set the physical quantity of '%s' to a negative value."
 msgstr "No puedes ajustar la cantidad física de '%s' a un valor negativo."
 
 #. module: l10n_ve_stock
 #. odoo-python
+#: code:addons/l10n_ve_stock/models/stock_picking_alter_location.py:0
+#: code:addons/l10n_ve_stock/wizard/move_alter_location_qtities.py:0
+msgid "You cannot transfer more than the available quantity in the location."
+msgstr "No puede transferir más que la cantidad disponible en la ubicación."
+
+#. module: l10n_ve_stock
+#. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#, python-format
 msgid "You do not have permission to make shipment-type transfers"
 msgstr "No tienes permiso para hacer transferencias de tipo envío"
 
@@ -1018,10 +1260,13 @@ msgstr "plantilla de producto de cantidad de corrección"
 #. module: l10n_ve_stock
 #. odoo-python
 #: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#: code:addons/l10n_ve_stock/models/stock_picking.py:0
-#, python-format
 msgid "does not have results from other pickings"
 msgstr "No tiene resultados de otros pickings"
+
+#. module: l10n_ve_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ve_stock.view_warehouse_inherit_l10n_ve_stock
+msgid "e.g. Av. Principal, Zona Industrial, Caracas"
+msgstr ""
 
 #. module: l10n_ve_stock
 #: model:ir.actions.report,name:l10n_ve_stock.inventory_valuation_report

--- a/l10n_ve_stock/models/__init__.py
+++ b/l10n_ve_stock/models/__init__.py
@@ -1,6 +1,8 @@
 from . import (
     res_company,
     res_config_settings,
+    stock_picking_alter_location,
+    stock_picking_alter_location_line,
     product_category,
     product_product,
     product_template,

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -17,9 +17,10 @@ class ProductProduct(models.Model):
         default=True,
         help=(
             "Si está activo, la referencia interna (código) no podrá "
-            "modificarse una vez que el producto tenga movimientos de "
-            "inventario confirmados (incluye los generados por órdenes de "
-            "compra o venta confirmadas)."
+            "modificarse una vez que el producto (siendo almacenable) tenga "
+            "movimientos de inventario ya validados (estado 'Hecho'). Un "
+            "pedido de compra o venta confirmado, sin la transferencia "
+            "asociada validada todavía, no cuenta como movimiento."
         ),
     )
 

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -40,7 +40,7 @@ class ProductProduct(models.Model):
     def write(self, vals):
         if "default_code" in vals:
             for product in self:
-                if not product.lock_internal_reference_on_moves:
+                if not product.is_storable or not product.lock_internal_reference_on_moves:
                     continue
                 if vals["default_code"] == product.default_code:
                     continue

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -12,12 +12,47 @@ _logger = logging.getLogger(__name__)
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
+    lock_internal_reference_on_moves = fields.Boolean(
+        string="Bloquear referencia interna con movimientos",
+        default=True,
+        help=(
+            "Si está activo, la referencia interna (código) no podrá "
+            "modificarse una vez que el producto tenga movimientos de "
+            "inventario confirmados (incluye los generados por órdenes de "
+            "compra o venta confirmadas)."
+        ),
+    )
+
+    def _has_moves(self):
+        """Return True if self (variant) has done stock moves."""
+        self.ensure_one()
+        return bool(
+            self.env["stock.move"].search_count(
+                [("product_id", "=", self.id), ("state", "=", "done")], limit=1
+            )
+        )
+
     def button_dummy(self):
         # TDE FIXME: this button is very interesting
         # Variante del maldito Raiver e.e
         return True
 
     def write(self, vals):
+        if "default_code" in vals:
+            for product in self:
+                if not product.lock_internal_reference_on_moves:
+                    continue
+                if vals["default_code"] == product.default_code:
+                    continue
+                if product._has_moves():
+                    raise ValidationError(
+                        _(
+                            "No se puede modificar la referencia interna del "
+                            "producto '%s' porque ya tiene movimientos de "
+                            "inventario confirmados.",
+                            product.display_name,
+                        )
+                    )
         res = super().write(vals)
         if "list_price" in vals:
             self._validate_list_price()

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -239,8 +239,17 @@ class ProductProduct(models.Model):
 
         MoveLine = self.env['stock.move.line'].with_context(active_test=False)
 
-        domain_move_line_in = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_in_loc
-        domain_move_line_out = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_out_loc
+        # domain_move_in_loc/domain_move_out_loc reference location_final_id, a field
+        # of stock.move that no longer exists on stock.move.line since Odoo 19. Since
+        # these lines are always filtered to state == 'done', the "final destination
+        # of an in-progress chained move" logic does not apply here: it is enough to
+        # filter by the plain location_id/location_dest_id already used for quants.
+        descendant_location_ids = domain_quant_loc.value
+        domain_move_line_in_loc = [('location_dest_id', 'in', descendant_location_ids)]
+        domain_move_line_out_loc = [('location_id', 'in', descendant_location_ids)]
+
+        domain_move_line_in = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_line_in_loc
+        domain_move_line_out = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_line_out_loc
 
         if from_date:
             domain_move_line_in += [('date', '>=', from_date)]

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -27,7 +27,7 @@ class ProductProduct(models.Model):
         """Return True if self (variant) has done stock moves."""
         self.ensure_one()
         return bool(
-            self.env["stock.move"].search_count(
+            self.env["stock.move"].sudo().search_count(
                 [("product_id", "=", self.id), ("state", "=", "done")], limit=1
             )
         )
@@ -40,7 +40,11 @@ class ProductProduct(models.Model):
     def write(self, vals):
         if "default_code" in vals:
             for product in self:
-                if not product.is_storable or not product.lock_internal_reference_on_moves:
+                lock_enabled = vals.get(
+                    "lock_internal_reference_on_moves",
+                    product.lock_internal_reference_on_moves,
+                )
+                if not product.is_storable or not lock_enabled:
                     continue
                 if vals["default_code"] == product.default_code:
                     continue

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -68,9 +68,10 @@ class ProductTemplate(models.Model):
         store=True,
         help=(
             "Si está activo, la referencia interna (código) no podrá "
-            "modificarse una vez que el producto tenga movimientos de "
-            "inventario confirmados (incluye los generados por órdenes de "
-            "compra o venta confirmadas)."
+            "modificarse una vez que el producto (siendo almacenable) tenga "
+            "movimientos de inventario ya validados (estado 'Hecho'). Un "
+            "pedido de compra o venta confirmado, sin la transferencia "
+            "asociada validada todavía, no cuenta como movimiento."
         ),
     )
 
@@ -90,6 +91,22 @@ class ProductTemplate(models.Model):
                 raise ValidationError(_("Price cannot be negative or zero."))
 
     def write(self, vals):
+        # default_code and lock_internal_reference_on_moves are both stored
+        # fields with their own inverse (_set_default_code on the core side,
+        # _set_lock_internal_reference_on_moves here), so Odoo runs them as
+        # separate write() calls on the variant, in vals key order. In the
+        # resolved form arch, default_code renders before the toggle, so it
+        # always arrives first in vals - meaning product.product.write()'s
+        # own same-write guard (which reads
+        # vals.get("lock_internal_reference_on_moves", ...)) never sees the
+        # new toggle value, only the variant's still-locked stored one.
+        # Propagate the toggle to the variants directly, before super()
+        # triggers any inverse, so unlocking and fixing default_code in the
+        # same save always sees the intended state regardless of key order.
+        if "lock_internal_reference_on_moves" in vals and "default_code" in vals:
+            self.product_variant_ids.write(
+                {"lock_internal_reference_on_moves": vals["lock_internal_reference_on_moves"]}
+            )
 
         old_physical_locations_ids = {
             tmpl.id: tmpl.physical_locations_ids for tmpl in self

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -46,6 +46,19 @@ class ProductTemplate(models.Model):
 
     liters_per_unit = fields.Float(digits="Stock Weight")
 
+    lock_internal_reference_on_moves = fields.Boolean(
+        string="Bloquear referencia interna con movimientos",
+        compute="_compute_lock_internal_reference_on_moves",
+        inverse="_set_lock_internal_reference_on_moves",
+        store=True,
+        help=(
+            "Si está activo, la referencia interna (código) no podrá "
+            "modificarse una vez que el producto tenga movimientos de "
+            "inventario confirmados (incluye los generados por órdenes de "
+            "compra o venta confirmadas)."
+        ),
+    )
+
     def button_dummy(self):
         # TDE FIXME: this button is very interesting
         # Maldito Raiver e.e
@@ -130,3 +143,12 @@ class ProductTemplate(models.Model):
         domain = [('free_qty', operator, value)]
         product_variant_query = self.env['product.product'].sudo()._search(domain)
         return [('product_variant_ids', 'in', product_variant_query)]
+
+    @api.depends("product_variant_ids.lock_internal_reference_on_moves")
+    def _compute_lock_internal_reference_on_moves(self):
+        self._compute_template_field_from_variant_field(
+            "lock_internal_reference_on_moves", default=True
+        )
+
+    def _set_lock_internal_reference_on_moves(self):
+        self._set_product_variant_field("lock_internal_reference_on_moves")

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -10,6 +10,16 @@ _logger = logging.getLogger(__name__)
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    physical_locations_ids = fields.Many2many(
+        'stock.location', 
+        string='Physical Locations', 
+        domain="[('location_id', '!=', False), ('child_ids', '=', False)]"
+    )
+
+    show_physical_locations = fields.Boolean(
+        compute="_compute_show_physical_locations",
+    )
+
     quantity = fields.Float(
         compute="_compute_available_quantity",
         help="The Availability of the product to sell.",
@@ -29,6 +39,7 @@ class ProductTemplate(models.Model):
         string="Alternate Code",
         help="Alternate code for the product",
     )
+
     physical_location_id = fields.Many2one(
         "stock.location",
         string="Physical Location",
@@ -40,6 +51,10 @@ class ProductTemplate(models.Model):
     priority_location = fields.Integer(
         string="Priority", related="physical_location_id.priority", store=True
     )
+
+    def _compute_show_physical_locations(self):
+        for product in self:
+            product.show_physical_locations = self.env.company.use_alternate_locations
 
     price_with_tax = fields.Float(compute="_compute_prices_with_tax")
     price_without_tax = fields.Float(compute="_compute_prices_with_tax")
@@ -75,9 +90,29 @@ class ProductTemplate(models.Model):
                 raise ValidationError(_("Price cannot be negative or zero."))
 
     def write(self, vals):
+
+        old_physical_locations_ids = {
+            tmpl.id: tmpl.physical_locations_ids for tmpl in self
+        }
+
         res = super().write(vals)
         if "taxes_id" in vals:
             self._validate_single_sale_tax()
+
+        if not self.env.company.use_alternate_locations:
+            return res
+
+        if "physical_locations_ids" in vals:
+            for tmpl in self:
+                old_locations = old_physical_locations_ids.get(tmpl.id, self.env["stock.location"])
+                new_locations = tmpl.physical_locations_ids
+                removed_locations = old_locations - new_locations
+                added_locations = new_locations - old_locations
+                if removed_locations:
+                    tmpl._remove_putaway_rules(removed_locations)
+                if added_locations:
+                    tmpl._create_putaway_rules(added_locations)
+            self._sync_alter_locations_from_physical_locations()
         return res
 
     @api.model_create_multi
@@ -85,6 +120,15 @@ class ProductTemplate(models.Model):
         records = super().create(vals_list)
         # Always validate after creation because default taxes can come from multiple sources
         records._validate_single_sale_tax()
+
+        if not self.env.company.use_alternate_locations:
+            return records
+
+        for tmpl, vals in zip(records, vals_list):
+            if vals.get("physical_locations_ids"):
+                tmpl._create_putaway_rules(tmpl.physical_locations_ids)
+
+        records._sync_alter_locations_from_physical_locations()
         return records
 
     def _validate_single_sale_tax(self):
@@ -152,3 +196,202 @@ class ProductTemplate(models.Model):
 
     def _set_lock_internal_reference_on_moves(self):
         self._set_product_variant_field("lock_internal_reference_on_moves")
+
+    #PHYSICAL LOCATIONS
+
+    def _create_or_update_alter_location(self, old_location=None):
+        self.ensure_one()
+        alter_location_model = self.env["stock.picking.alter.location"]
+
+        new_location = self.physical_location_id
+        if not new_location:
+            return
+
+        product_variant = self.product_variant_id
+        if not product_variant:
+            return
+
+        new_warehouse = self._find_warehouse_from_location(new_location)
+        if not new_warehouse:
+            return
+
+        existing = alter_location_model.search(
+            [
+                ("product_id", "=", product_variant.id),
+                ("warehouse_id", "=", new_warehouse.id),
+            ],
+            limit=1,
+        )
+
+        if not existing:
+            alter_lines = self._get_quants_for_alter_lines(
+                new_location, warehouse=new_warehouse
+            )
+            alter_location_model.sudo().create(
+                {
+                    "product_id": product_variant.id,
+                    "pick_location": new_location.id,
+                    "warehouse_id": new_warehouse.id,
+                    "stock_alter_location_lines": alter_lines,
+                }
+            )
+            return
+
+        existing.pick_location = new_location
+
+    def _sync_alter_locations_from_physical_locations(self):
+        alter_location_model = self.env["stock.picking.alter.location"]
+
+        for template in self:
+            product_variant = template.product_variant_id
+            if not product_variant:
+                continue
+
+            physical_locations = template.physical_locations_ids
+            active_warehouses = set()
+
+            if physical_locations:
+                warehouse_groups = {}
+                for location in physical_locations:
+                    warehouse = template._find_warehouse_from_location(location)
+                    if not warehouse:
+                        continue
+                    warehouse_groups.setdefault(warehouse, []).append(location)
+                    active_warehouses.add(warehouse.id)
+
+                for warehouse, locations in warehouse_groups.items():
+                    pick_location = locations[0]
+
+                    existing = alter_location_model.search(
+                        [
+                            ("product_id", "=", product_variant.id),
+                            ("warehouse_id", "=", warehouse.id),
+                        ],
+                        limit=1,
+                    )
+                    if not existing:
+                        archived = alter_location_model.with_context(active_test=False).search(
+                            [
+                                ("product_id", "=", product_variant.id),
+                                ("warehouse_id", "=", warehouse.id),
+                                ("active", "=", False),
+                            ],
+                            limit=1,
+                        )
+                        if archived:
+                            archived.write(
+                                {
+                                    "active": True,
+                                    "pick_location": pick_location.id,
+                                }
+                            )
+                        else:
+                            alter_lines = template._get_quants_for_alter_lines(
+                                pick_location, warehouse=warehouse
+                            )
+                            alter_location_model.sudo().create(
+                                {
+                                    "product_id": product_variant.id,
+                                    "pick_location": pick_location.id,
+                                    "warehouse_id": warehouse.id,
+                                    "stock_alter_location_lines": alter_lines,
+                                }
+                            )
+                    elif existing.pick_location.id != pick_location.id:
+                        existing.pick_location = pick_location.id
+
+            inactive_alters = alter_location_model.with_context(active_test=False).search(
+                [
+                    ("product_id", "=", product_variant.id),
+                    ("active", "=", True),
+                ]
+            )
+            for alter in inactive_alters:
+                if alter.warehouse_id.id not in active_warehouses:
+                    alter.write({"active": False})
+
+    def _get_quants_for_alter_lines(self, pick_location, warehouse=None):
+        self.ensure_one()
+        alter_lines_list = []
+        if warehouse is None:
+            warehouse = self._find_warehouse_from_location(pick_location)
+        if not warehouse:
+            return alter_lines_list
+
+        quants = self.env["stock.quant"].search(
+            [
+                ("product_tmpl_id", "=", self.id),
+                ("location_id", "in", warehouse.view_location_id.child_internal_location_ids.ids),
+            ]
+        )
+
+        for quant in quants:
+            if quant.available_quantity > 0:
+                alter_lines_list.append(
+                    (
+                        0,
+                        0,
+                        {
+                            "location_id": quant.location_id.id,
+                            "available_qty": quant.available_quantity,
+                        },
+                    )
+                )
+
+        return alter_lines_list
+
+    def _find_warehouse_from_location(self, location):
+        warehouse_model = self.env["stock.warehouse"]
+        loc = location
+        while loc:
+            wh = warehouse_model.search(
+                [("view_location_id", "=", loc.id)], limit=1
+            )
+            if wh:
+                return wh
+            loc = loc.location_id
+        return warehouse_model.browse()
+
+    def _create_putaway_rules(self, locations):
+        """Creates or updates storage (Putaway Rules) for the given locations.
+
+        If a rule already exists for the product and incoming location (parent),
+        updates its destination location. Otherwise, creates it.
+        """
+        putaway_obj = self.env['stock.putaway.rule']
+        
+        for template in self:
+            for location in locations:
+                parent_location = location.location_id
+
+                if not parent_location:
+                    continue
+                
+                for variant in template.product_variant_ids:
+                    existing_rule = putaway_obj.search([
+                        ('product_id', '=', variant.id),
+                        ('location_in_id', '=', parent_location.id),
+                    ], limit=1)
+                    
+                    if existing_rule:
+                        existing_rule.write({'location_out_id': location.id})
+                    else:
+                        putaway_obj.create({
+                            'product_id': variant.id,
+                            'location_in_id': parent_location.id,
+                            'location_out_id': location.id,
+                            'company_id': template.company_id.id or self.env.company.id,
+                        })
+
+    def _remove_putaway_rules(self, locations):
+        """Removes the storage rules associated with the removed locations."""
+        putaway_obj = self.env['stock.putaway.rule']
+        
+        for template in self:
+            for location in locations:
+                for variant in template.product_variant_ids:
+                    rules = putaway_obj.search([
+                        ('product_id', '=', variant.id),
+                        ('location_out_id', '=', location.id),
+                    ])
+                    rules.unlink()

--- a/l10n_ve_stock/models/res_company.py
+++ b/l10n_ve_stock/models/res_company.py
@@ -18,6 +18,8 @@ class ResCompany(models.Model):
 
     use_physical_location = fields.Boolean()
 
+    use_alternate_locations = fields.Boolean()
+
     use_free_qty_odoo = fields.Boolean()
 
     # not_allow_sell_products = fields.Boolean(

--- a/l10n_ve_stock/models/res_config_settings.py
+++ b/l10n_ve_stock/models/res_config_settings.py
@@ -23,6 +23,12 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
 
+    use_alternate_locations = fields.Boolean(
+        string="Use Alternate Locations",
+        related="company_id.use_alternate_locations",
+        readonly=False,
+    )
+
     use_free_qty_odoo = fields.Boolean(
         related="company_id.use_free_qty_odoo",
         readonly=False,

--- a/l10n_ve_stock/models/stock_move.py
+++ b/l10n_ve_stock/models/stock_move.py
@@ -7,3 +7,59 @@ class StockMove(models.Model):
     priority_location = fields.Integer(
         string="Priority", related="product_id.priority_location", store=True
     )
+
+    def _action_done(self, cancel_backorder=False):
+        res = super()._action_done(cancel_backorder=cancel_backorder)
+        if self.env.company.use_alternate_locations:
+            self._update_alter_location_on_move_done()
+        return res
+
+    def _update_alter_location_on_move_done(self):
+        alter_location_model = self.env["stock.picking.alter.location"]
+        for move in self:
+            if not move.product_id.is_storable:
+                continue
+
+            warehouse = self._get_warehouse_from_move(move)
+            if not warehouse:
+                continue
+
+            output_loc = warehouse.wh_output_stock_loc_id
+            if not output_loc:
+                continue
+
+            alter_location = alter_location_model.search(
+                [
+                    ("product_id", "=", move.product_id.id),
+                    ("warehouse_id", "=", warehouse.id),
+                ],
+                limit=1,
+            )
+            if not alter_location:
+                continue
+
+            qty = move.quantity
+            if qty <= 0:
+                continue
+
+            if move.location_dest_id == output_loc:
+                alter_location.action_move_to_output(
+                    output_loc.id, qty, alter_location.pick_location.id
+                )
+            elif (
+                move.location_id == output_loc
+                and move.location_dest_id.usage in ("customer", "supplier")
+            ):
+                alter_location.action_deliver_from_output(output_loc.id, qty)
+
+    @api.model
+    def _get_warehouse_from_move(self, move):
+        if move.picking_id and move.picking_id.picking_type_id.warehouse_id:
+            return move.picking_id.picking_type_id.warehouse_id
+        for loc in (move.location_id, move.location_dest_id):
+            wh = self.env["stock.warehouse"].search(
+                [("view_location_id", "parent_of", loc.id)], limit=1
+            )
+            if wh:
+                return wh
+        return self.env["stock.warehouse"].browse()

--- a/l10n_ve_stock/models/stock_picking.py
+++ b/l10n_ve_stock/models/stock_picking.py
@@ -260,10 +260,15 @@ class StockPicking(models.Model):
     def button_validate(self):
         if self.env.company.not_allow_negative_stock_movement:
             res = super(StockPicking, self).button_validate()
-            if isinstance(res, dict) and res.get('res_model') == 'stock.backorder.confirmation':
+            if isinstance(res, dict):
                 return res
-            else:
-                self._check_stock_availability_for_pickings()
+            self._check_stock_availability_for_pickings()
+            if self.env.company.use_alternate_locations:
+                self._update_alter_location_lines_on_receive()
+            return res
+
+        if self.env.company.use_alternate_locations:
+            self._update_alter_location_lines_on_receive()
         return super().button_validate()
         
     def _check_stock_availability_for_pickings(self):
@@ -313,3 +318,45 @@ class StockPicking(models.Model):
                     "Insufficient stock:\n%s\n\nAdjust quantitys or request stock for this location."
                 ) % "\n".join(stock_msg)
                 raise ValidationError(error_msg)
+
+    def _update_alter_location_lines_on_receive(self):
+        if self.picking_type_id.code != "incoming":
+            return
+        alter_location_model = self.env["stock.picking.alter.location"]
+        for picking in self:
+            for move_line in picking.move_line_ids:
+                if not move_line.product_id.is_storable:
+                    continue
+                qty_done = move_line.quantity
+                if qty_done <= 0:
+                    continue
+                dest_location = move_line.location_dest_id
+                warehouse = self.env["stock.warehouse"].search(
+                    [("lot_stock_id", "in", dest_location.ids)], limit=1
+                )
+                if not warehouse:
+                    warehouse = self.env["stock.warehouse"].search(
+                        [("view_location_id", "in", dest_location.ids)], limit=1
+                    )
+                if not warehouse:
+                    parent = dest_location
+                    while parent:
+                        warehouse = self.env["stock.warehouse"].search(
+                            [("lot_stock_id", "=", parent.id)], limit=1
+                        )
+                        if warehouse:
+                            break
+                        parent = parent.location_id
+                if not warehouse:
+                    continue
+                alter_location = alter_location_model.search(
+                    [
+                        ("product_id", "=", move_line.product_id.id),
+                        ("warehouse_id", "=", warehouse.id),
+                    ],
+                    limit=1,
+                )
+                if not alter_location or not alter_location.pick_location:
+                    continue
+
+                alter_location.action_receive_quantity(warehouse.lot_stock_id.id, qty_done)

--- a/l10n_ve_stock/models/stock_picking.py
+++ b/l10n_ve_stock/models/stock_picking.py
@@ -267,9 +267,12 @@ class StockPicking(models.Model):
                 self._update_alter_location_lines_on_receive()
             return res
 
+        res = super().button_validate()
+        if isinstance(res, dict):
+            return res
         if self.env.company.use_alternate_locations:
             self._update_alter_location_lines_on_receive()
-        return super().button_validate()
+        return res
         
     def _check_stock_availability_for_pickings(self):
         if self.picking_type_id.code in ['internal', 'outgoing']:

--- a/l10n_ve_stock/models/stock_picking_alter_location.py
+++ b/l10n_ve_stock/models/stock_picking_alter_location.py
@@ -1,0 +1,399 @@
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_is_zero
+
+_logger = logging.getLogger(__name__)
+
+
+class StockPickingAlterLocation(models.Model):
+    _name = "stock.picking.alter.location"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _description = "Alternate Locations"
+
+    active = fields.Boolean(default=True, tracking=True)
+
+    pick_quantity = fields.Float(
+        "Physical Quantities",
+        compute="_compute_pick_quantity",
+    )
+    total_alter_quantity = fields.Float(
+        "Total in Alter Locations",
+        compute="_compute_total_alter_quantity",
+    )
+    total_quantity = fields.Float(
+        "Quantity in Other Locations", compute="_compute_total_quantity_in_locations"
+    )
+    min_quantity = fields.Float("Minimum Quantity", tracking=True)
+    max_quantity = fields.Float("Maximum Quantity", tracking=True)
+
+    name = fields.Char("Product Name", related="product_id.name", tracking=True)
+    product_id = fields.Many2one("product.product", string="Product")
+    pick_location = fields.Many2one(
+        "stock.location",
+        string="Physical Location",
+        tracking=True,
+    )
+    warehouse_id = fields.Many2one(
+        "stock.warehouse",
+        string="Warehouse",
+        compute="_compute_warehouse_id",
+        store=True,
+        tracking=True,
+    )
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        compute="_compute_company_id",
+        store=True,
+    )
+    stock_alter_location_lines = fields.One2many(
+        "stock.picking.alter.location.line",
+        "stock_alter_location_id",
+        string="Other Product Locations",
+    )
+
+    @api.depends("pick_location")
+    def _compute_warehouse_id(self):
+        warehouse_model = self.env["stock.warehouse"]
+        for rec in self:
+            rec.warehouse_id = False
+            if not rec.pick_location:
+                continue
+            loc = rec.pick_location
+            while loc:
+                wh = warehouse_model.search(
+                    [("view_location_id", "=", loc.id)], limit=1
+                )
+                if wh:
+                    rec.warehouse_id = wh.id
+                    break
+                loc = loc.location_id
+
+    @api.depends("warehouse_id")
+    def _compute_company_id(self):
+        for rec in self:
+            rec.company_id = rec.warehouse_id.company_id.id or self.env.company.id
+
+    def action_change_product_quantities(self):
+        view = self.env.ref(
+            "l10n_ve_stock.move_alter_location_qtities_wizard_view_form"
+        )
+        list_of_locations = [
+            line.location_id.id for line in self.stock_alter_location_lines
+        ]
+        if self.pick_location:
+            _logger.info(f'SELF PICK LOCATION:{self.pick_location}')
+            list_of_locations.append(self.pick_location.id)
+
+        _logger.info(f'LISTS OF LOCATIONS:{list_of_locations}')
+
+        return {
+            "name": _("Change Quantities Between Locations"),
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "move.alter.location.qtities.wizard",
+            "views": [(view.id, "form")],
+            "view_id": view.id,
+            "target": "new",
+            "context": dict(
+                default_to_location=self.pick_location.id,
+                default_stock_alter_location_id=self.id,
+                min=self.min_quantity,
+                domain_locations=list_of_locations,
+            ),
+        }
+
+    @api.depends("stock_alter_location_lines.available_qty",
+                  "stock_alter_location_lines.location_id")
+    def _compute_total_alter_quantity(self):
+        for rec in self:
+            total = 0.0
+            output_loc = (
+                rec.warehouse_id.wh_output_stock_loc_id
+                if rec.warehouse_id
+                else False
+            )
+            for line in rec.stock_alter_location_lines:
+                if output_loc and line.location_id == output_loc:
+                    continue
+                total += line.available_qty
+            rec.total_alter_quantity = total
+
+    @api.depends("stock_alter_location_lines.available_qty",
+                  "stock_alter_location_lines.location_id",
+                  "pick_location")
+    def _compute_pick_quantity(self):
+        for rec in self:
+            pick_line = rec.stock_alter_location_lines.filtered(
+                lambda l: l.location_id == rec.pick_location
+            )
+            rec.pick_quantity = sum(pick_line.mapped("available_qty"))
+
+    @api.depends(
+        "stock_alter_location_lines.available_qty",
+        "stock_alter_location_lines.location_id",
+        "pick_location",
+        "warehouse_id.wh_output_stock_loc_id",
+    )
+    def _compute_total_quantity_in_locations(self):
+        for rec in self:
+            pick_loc = rec.pick_location
+            output_loc = (
+                rec.warehouse_id.wh_output_stock_loc_id
+                if rec.warehouse_id
+                else False
+            )
+            total = 0.0
+            for line in rec.stock_alter_location_lines:
+                if pick_loc and line.location_id == pick_loc:
+                    continue
+                if output_loc and line.location_id == output_loc:
+                    continue
+                else:
+                    total += line.available_qty
+            rec.total_quantity = total
+
+    def check_location_in_lines(self, location_id):
+        self.ensure_one()
+        return location_id.id in self.stock_alter_location_lines.mapped("location_id").ids
+
+    def get_line(self, location_id):
+        alt_lines = self.stock_alter_location_lines
+        alt_line = alt_lines.filtered(
+            lambda line: location_id.id == line.location_id.id
+        )
+        return alt_line
+
+    def action_internal_transfer(self, from_location_id, to_location_id, transfer_quantity):
+        self.ensure_one()
+        user = self.env.user
+        alter_env = self.with_env(self.env(user=user.id, su=True))
+
+        from_line = alter_env.stock_alter_location_lines.filtered(
+            lambda l: l.location_id.id == from_location_id
+        )
+        to_line = alter_env.stock_alter_location_lines.filtered(
+            lambda l: l.location_id.id == to_location_id
+        )
+        pick_location = alter_env.pick_location
+
+        if not from_line:
+            raise UserError(_("There is no stock in the source location."))
+        if transfer_quantity > from_line.available_qty:
+            raise UserError(
+                _("You cannot transfer more than the available quantity in the location.")
+            )
+
+        if to_location_id == pick_location.id:
+            pick_line = alter_env.stock_alter_location_lines.filtered(
+                lambda l: l.location_id == pick_location
+            )
+            current_pick_qty = pick_line.available_qty if pick_line else 0.0
+            new_pick_qty = current_pick_qty + transfer_quantity
+            if self.max_quantity and new_pick_qty > self.max_quantity:
+                raise UserError(
+                    _(
+                        "The resulting quantity (%(qty)s) exceeds the maximum "
+                        "allowed quantity in the Physical Location (%(maximum)s).",
+                        qty=new_pick_qty,
+                        maximum=self.max_quantity,
+                    )
+                )
+
+        if from_location_id == pick_location.id:
+            pick_line = alter_env.stock_alter_location_lines.filtered(
+                lambda l: l.location_id == pick_location
+            )
+            current_pick_qty = pick_line.available_qty if pick_line else 0.0
+            new_pick_qty = current_pick_qty - transfer_quantity
+            if self.min_quantity and new_pick_qty < self.min_quantity:
+                raise UserError(
+                    _(
+                        "The resulting quantity (%(qty)s) would fall below the "
+                        "minimum required quantity in the Physical Location (%(minimum)s).",
+                        qty=new_pick_qty,
+                        minimum=self.min_quantity,
+                    )
+                )
+
+        from_line.available_qty -= transfer_quantity
+        if float_is_zero(from_line.available_qty, precision_rounding=0.01):
+            from_line.unlink()
+        if to_line:
+            to_line.available_qty += transfer_quantity
+            if float_is_zero(to_line.available_qty, precision_rounding=0.01):
+                to_line.unlink()
+        else:
+            alter_env.write(
+                {
+                    "stock_alter_location_lines": [
+                        (
+                            0,
+                            0,
+                            {
+                                "location_id": to_location_id,
+                                "available_qty": transfer_quantity,
+                            },
+                        )
+                    ]
+                }
+            )
+
+    def action_receive_quantity(self, location_id, qty):
+        self.ensure_one()
+        user = self.env.user
+        alter_env = self.with_env(self.env(user=user.id, su=True))
+        alter_line = alter_env.stock_alter_location_lines.filtered(
+            lambda l: l.location_id.id == location_id
+        )
+        if alter_line:
+            alter_line.available_qty += qty
+            if float_is_zero(alter_line.available_qty, precision_rounding=0.01):
+                alter_line.unlink()
+        else:
+            self.env["stock.picking.alter.location.line"].sudo().create(
+                {
+                    "stock_alter_location_id": self.id,
+                    "location_id": location_id,
+                    "available_qty": qty,
+                }
+            )
+
+    def action_move_to_output(self, output_loc_id, qty, source_loc_id):
+        self.ensure_one()
+        user = self.env.user
+        alter_env = self.with_env(self.env(user=user.id, su=True))
+        output_line = alter_env.stock_alter_location_lines.filtered(
+            lambda l: l.location_id.id == output_loc_id
+        )
+        if output_line:
+            output_line.available_qty += qty
+            if float_is_zero(output_line.available_qty, precision_rounding=0.01):
+                output_line.unlink()
+        else:
+            self.env["stock.picking.alter.location.line"].sudo().create(
+                {
+                    "stock_alter_location_id": self.id,
+                    "location_id": output_loc_id,
+                    "available_qty": qty,
+                }
+            )
+        source_line = alter_env.stock_alter_location_lines.filtered(
+            lambda l: l.location_id.id == source_loc_id
+        )
+        if source_line:
+            source_line.available_qty -= qty
+            if float_is_zero(source_line.available_qty, precision_rounding=0.01):
+                source_line.unlink()
+        else:
+            self.env["stock.picking.alter.location.line"].sudo().create(
+                {
+                    "stock_alter_location_id": self.id,
+                    "location_id": source_loc_id,
+                    "available_qty": -qty,
+                }
+            )
+
+    def action_deliver_from_output(self, output_loc_id, qty):
+        self.ensure_one()
+        user = self.env.user
+        alter_env = self.with_env(self.env(user=user.id, su=True))
+        output_line = alter_env.stock_alter_location_lines.filtered(
+            lambda l: l.location_id.id == output_loc_id
+        )
+        if output_line:
+            output_line.available_qty -= qty
+            if float_is_zero(output_line.available_qty, precision_rounding=0.01):
+                output_line.unlink()
+
+    def subtract_physical_quantity(self):
+        if not self.env.company.use_alternate_locations:
+            return
+        quant_model = self.env["stock.quant"]
+
+        for pl in self:
+            user = self.env.user
+            pl_env = pl.with_env(self.env(user=user.id, su=True))
+            _logger.info("Starting adjustment of %s", pl_env.product_id.display_name)
+            warehouse = pl_env.warehouse_id
+            if not warehouse:
+                _logger.warning(
+                    "Warehouse not found for %s, skipping", pl_env.display_name
+                )
+                continue
+
+            output_loc = warehouse.wh_output_stock_loc_id
+            internal_locations = warehouse.view_location_id.child_internal_location_ids
+            if output_loc:
+                internal_locations -= output_loc
+
+            quants = quant_model.search(
+                [
+                    ("product_id", "=", pl_env.product_id.id),
+                    ("location_id", "in", internal_locations.ids),
+                ]
+            )
+            quant_total = sum(quants.mapped("quantity"))
+
+            physical_total = pl_env.total_alter_quantity
+
+            _logger.info(
+                "[%s] Total physical quantity: %s, Quant quantity: %s",
+                pl_env.display_name,
+                physical_total,
+                quant_total,
+            )
+
+            diff = physical_total - quant_total
+            if diff != 0:
+                pick_line = pl_env.stock_alter_location_lines.filtered(
+                    lambda l: l.location_id == pl_env.pick_location
+                )
+                if pick_line:
+                    pick_line.available_qty -= diff
+                    if float_is_zero(pick_line.available_qty, precision_rounding=0.01):
+                        pick_line.unlink()
+                else:
+                    self.env(user=user.id, su=True)["stock.picking.alter.location.line"].create(
+                        {
+                            "stock_alter_location_id": pl_env.id,
+                            "location_id": pl_env.pick_location.id,
+                            "available_qty": -diff,
+                        }
+                    )
+                _logger.info(
+                    "[%s] pick_quantity adjusted from %s to %s",
+                    pl_env.product_id.display_name,
+                    physical_total,
+                    pl_env.pick_quantity,
+                )
+
+            if output_loc:
+                output_quant = quant_model.search(
+                    [
+                        ("product_id", "=", pl_env.product_id.id),
+                        ("location_id", "=", output_loc.id),
+                    ],
+                    limit=1,
+                )
+                output_line = pl_env.stock_alter_location_lines.filtered(
+                    lambda l: l.location_id == output_loc
+                )
+                if output_quant:
+                    output_total = output_quant.quantity
+                    if output_line:
+                        output_line.available_qty = output_total
+                        if float_is_zero(output_line.available_qty, precision_rounding=0.01):
+                            output_line.unlink()
+                    else:
+                        self.env(user=user.id, su=True)["stock.picking.alter.location.line"].create(
+                            {
+                                "stock_alter_location_id": pl_env.id,
+                                "location_id": output_loc.id,
+                                "available_qty": output_total,
+                            }
+                        )
+                elif output_line:
+                    output_line.unlink()

--- a/l10n_ve_stock/models/stock_picking_alter_location_line.py
+++ b/l10n_ve_stock/models/stock_picking_alter_location_line.py
@@ -1,0 +1,54 @@
+from odoo import _, api, fields, models
+
+
+class StockPickingAlterLocationLine(models.Model):
+    _name = "stock.picking.alter.location.line"
+    _description = "Alternate Location Line"
+
+    name = fields.Char(related="location_id.display_name")
+    location_id = fields.Many2one("stock.location", string="Product Location")
+    stock_alter_location_id = fields.Many2one("stock.picking.alter.location")
+    available_qty = fields.Float("Available Quantities")
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        related="stock_alter_location_id.company_id",
+        store=True,
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for rec in records:
+            rec.stock_alter_location_id.message_post(
+                body=_("New location '%(name)s' added with quantity: %(qty)s",
+                        name=rec.name, qty=rec.available_qty)
+            )
+        return records
+
+    def write(self, vals):
+        old_values = {line.id: (line.available_qty, line.name) for line in self}
+        res = super().write(vals)
+        if "available_qty" in vals:
+            post_qty = vals.get("available_qty")
+            for line in self:
+                pre_qty, pre_name = old_values.get(line.id, (0.0, line.name))
+                line.stock_alter_location_id.message_post(
+                    body=_("Quantity updated"),
+                    tracking_value_ids=[
+                        (
+                            0,
+                            0,
+                            {
+                                "field_info": {
+                                    "desc": _("Quantity in %s", pre_name),
+                                    "name": "available_qty",
+                                    "type": "float",
+                                },
+                                "old_value_float": pre_qty,
+                                "new_value_float": post_qty,
+                            },
+                        )
+                    ],
+                )
+        return res

--- a/l10n_ve_stock/models/stock_quant.py
+++ b/l10n_ve_stock/models/stock_quant.py
@@ -30,13 +30,18 @@ class StockQuan(models.Model):
         self = self.sudo()
         for record in self:
 
-            record.product_alter_location_ids = record.search(
-                [
-                    ("product_id", "=", record.product_id.id),
-                    ("location_id.usage", "=", "internal"),
-                    ("id", "!=", record.id),
-                ]
-            )
+            if not record.product_id:
+                record.product_alter_location_ids = False
+                continue
+
+            domain = [
+                ("product_id", "=", record.product_id.id),
+                ("location_id.usage", "=", "internal"),
+            ]
+            if not isinstance(record.id, models.NewId):
+                domain.append(("id", "!=", record.id))
+
+            record.product_alter_location_ids = record.search(domain)
 
     @api.model
     def _update_reserved_quantity(

--- a/l10n_ve_stock/models/stock_quant.py
+++ b/l10n_ve_stock/models/stock_quant.py
@@ -1,6 +1,7 @@
 import traceback
 import logging
 from odoo import _, api, fields, models
+from odoo.orm.identifiers import NewId
 from odoo.tools.float_utils import float_compare, float_is_zero
 from odoo.exceptions import ValidationError
 
@@ -38,7 +39,7 @@ class StockQuan(models.Model):
                 ("product_id", "=", record.product_id.id),
                 ("location_id.usage", "=", "internal"),
             ]
-            if not isinstance(record.id, models.NewId):
+            if not isinstance(record.id, NewId):
                 domain.append(("id", "!=", record.id))
 
             record.product_alter_location_ids = record.search(domain)

--- a/l10n_ve_stock/security/ir.model.access.csv
+++ b/l10n_ve_stock/security/ir.model.access.csv
@@ -2,3 +2,8 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 stock.access_stock_picking_manager,stock.access_stock_picking_manager,stock.model_stock_picking,stock.group_stock_manager,1,1,1,0
 stock.access_stock_picking_user,stock.access_stock_picking_user,stock.model_stock_picking,stock.group_stock_user,1,1,1,0
 access_stock_location_manager,stock_location_manager,model_stock_location,,1,1,1,1
+access_stock_picking_alter_location_user,access.stock.picking.alter.location.user,model_stock_picking_alter_location,base.group_user,1,0,0,0
+access_stock_picking_alter_location_edit,access.stock.picking.alter.location.edit,model_stock_picking_alter_location,l10n_ve_stock.group_physical_location_edit,1,1,1,1
+access_stock_picking_alter_location_line_user,access.stock.picking.alter.location.line.user,model_stock_picking_alter_location_line,base.group_user,1,0,0,0
+access_stock_picking_alter_location_line_edit,access.stock.picking.alter.location.line.edit,model_stock_picking_alter_location_line,l10n_ve_stock.group_physical_location_edit,1,1,1,1
+access_move_alter_location_qtities_wizard,access.move.alter.location.qtities.wizard,model_move_alter_location_qtities_wizard,base.group_user,1,1,1,1

--- a/l10n_ve_stock/security/l10n_ve_stock_groups.xml
+++ b/l10n_ve_stock/security/l10n_ve_stock_groups.xml
@@ -56,6 +56,11 @@
             <field name="name">Block Liters Per Unit</field>
             <!-- <field name="privilege_id" ref="l10n_ve_accountant.res_groups_privilege_category_hidden"/> -->
         </record>
+
+        <record id="group_physical_location_edit" model="res.groups">
+            <field name="name">Binaural - Editar Ubicaciones Físicas Alternas</field>
+            <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
+        </record>
     </data>
 
 </odoo>

--- a/l10n_ve_stock/security/security_l10n_ve_stock.xml
+++ b/l10n_ve_stock/security/security_l10n_ve_stock.xml
@@ -7,6 +7,21 @@
             <field name="global" eval="True"/>
             <field name="domain_force"> ['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
         </record>
+
+        <record id="stock_picking_alter_location_company_rule" model="ir.rule">
+            <field name="name">Stock Picking Alter Location: Multi-Company</field>
+            <field name="model_id" ref="model_stock_picking_alter_location"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+        </record>
+
+        <record id="stock_picking_alter_location_line_company_rule" model="ir.rule">
+            <field name="name">Stock Picking Alter Location Line: Multi-Company</field>
+            <field name="model_id" ref="model_stock_picking_alter_location_line"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+        </record>
+
     </data>
 
 </odoo>

--- a/l10n_ve_stock/tests/__init__.py
+++ b/l10n_ve_stock/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_stock_quant_extended
 from . import test_stock_scrap
 from . import test_stock_quantity_history
 from . import test_stock_warehouse
+from . import test_lock_internal_reference

--- a/l10n_ve_stock/tests/__init__.py
+++ b/l10n_ve_stock/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_stock_scrap
 from . import test_stock_quantity_history
 from . import test_stock_warehouse
 from . import test_lock_internal_reference
+from . import test_stock_picking_alter_location

--- a/l10n_ve_stock/tests/test_lock_internal_reference.py
+++ b/l10n_ve_stock/tests/test_lock_internal_reference.py
@@ -78,6 +78,25 @@ class TestLockInternalReferenceOnMoves(TransactionCase):
         self.assertEqual(product.default_code, "REF006-B")
         self.assertFalse(product.lock_internal_reference_on_moves)
 
+    def test_write_template_default_code_allowed_when_lock_disabled_in_same_write(self):
+        """Same unlock-and-fix flow as
+        test_write_default_code_allowed_when_lock_disabled_in_same_write,
+        but through product.template.write() - the real path the product
+        form uses. default_code and lock_internal_reference_on_moves each
+        have their own inverse, run as separate calls in vals key order;
+        the resolved form arch renders default_code before the toggle, so
+        it is listed first here too, matching what the UI actually sends.
+        """
+        product = self._create_product("REF007")
+        self._create_done_move(product)
+        template = product.product_tmpl_id
+        template.write({
+            "default_code": "REF007-B",
+            "lock_internal_reference_on_moves": False,
+        })
+        self.assertEqual(product.default_code, "REF007-B")
+        self.assertFalse(product.lock_internal_reference_on_moves)
+
     def test_write_default_code_allowed_when_not_storable(self):
         product = self.env["product.product"].create(
             {

--- a/l10n_ve_stock/tests/test_lock_internal_reference.py
+++ b/l10n_ve_stock/tests/test_lock_internal_reference.py
@@ -63,6 +63,21 @@ class TestLockInternalReferenceOnMoves(TransactionCase):
         product.write({"default_code": "REF004-B"})
         self.assertEqual(product.default_code, "REF004-B")
 
+    def test_write_default_code_allowed_when_lock_disabled_in_same_write(self):
+        """Disabling the toggle and changing default_code in a single write
+        (the natural flow to unlock and fix a product) must not raise -
+        the guard has to read the incoming value from vals, not the
+        still-True value stored on the record before the write applies.
+        """
+        product = self._create_product("REF006")
+        self._create_done_move(product)
+        product.write({
+            "lock_internal_reference_on_moves": False,
+            "default_code": "REF006-B",
+        })
+        self.assertEqual(product.default_code, "REF006-B")
+        self.assertFalse(product.lock_internal_reference_on_moves)
+
     def test_write_default_code_allowed_when_not_storable(self):
         product = self.env["product.product"].create(
             {

--- a/l10n_ve_stock/tests/test_lock_internal_reference.py
+++ b/l10n_ve_stock/tests/test_lock_internal_reference.py
@@ -1,0 +1,65 @@
+from odoo.tests import TransactionCase, tagged
+from odoo.exceptions import ValidationError
+
+
+@tagged("post_install", "-at_install", "l10n_ve_stock")
+class TestLockInternalReferenceOnMoves(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env["res.partner"].create({"name": "Cliente Test"})
+        self.location_src = self.env["stock.location"].create(
+            {"name": "Origen Test", "usage": "internal"}
+        )
+        self.location_dest = self.env["stock.location"].create(
+            {"name": "Destino Test", "usage": "internal"}
+        )
+
+    def _create_product(self, default_code):
+        return self.env["product.product"].create(
+            {
+                "name": "Producto Test",
+                "default_code": default_code,
+                "type": "consu",
+                "is_storable": True,
+            }
+        )
+
+    def test_create_product_with_default_code(self):
+        product = self._create_product("REF001")
+        self.assertEqual(product.default_code, "REF001")
+
+    def test_write_default_code_without_moves(self):
+        product = self._create_product("REF002")
+        product.write({"default_code": "REF002-B"})
+        self.assertEqual(product.default_code, "REF002-B")
+
+    def _create_done_move(self, product):
+        move = self.env["stock.move"].create(
+            {
+                "product_id": product.id,
+                "product_uom_qty": 1,
+                "product_uom": product.uom_id.id,
+                "location_id": self.location_src.id,
+                "location_dest_id": self.location_dest.id,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        move.quantity = 1
+        move.picked = True
+        move._action_done()
+        return move
+
+    def test_write_default_code_blocked_with_done_stock_move(self):
+        product = self._create_product("REF003")
+        self._create_done_move(product)
+        with self.assertRaises(ValidationError):
+            product.write({"default_code": "REF003-B"})
+
+    def test_write_default_code_allowed_when_lock_disabled(self):
+        product = self._create_product("REF004")
+        product.lock_internal_reference_on_moves = False
+        self._create_done_move(product)
+        product.write({"default_code": "REF004-B"})
+        self.assertEqual(product.default_code, "REF004-B")
+

--- a/l10n_ve_stock/tests/test_lock_internal_reference.py
+++ b/l10n_ve_stock/tests/test_lock_internal_reference.py
@@ -63,3 +63,16 @@ class TestLockInternalReferenceOnMoves(TransactionCase):
         product.write({"default_code": "REF004-B"})
         self.assertEqual(product.default_code, "REF004-B")
 
+    def test_write_default_code_allowed_when_not_storable(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Producto No Almacenable",
+                "default_code": "REF005",
+                "type": "consu",
+                "is_storable": False,
+            }
+        )
+        self._create_done_move(product)
+        product.write({"default_code": "REF005-B"})
+        self.assertEqual(product.default_code, "REF005-B")
+

--- a/l10n_ve_stock/tests/test_stock_picking_alter_location.py
+++ b/l10n_ve_stock/tests/test_stock_picking_alter_location.py
@@ -7,7 +7,7 @@ class TestStockPickingAlterLocation(TransactionCase):
         super().setUp()
 
         self.env.company.use_alternate_locations = True
-        self.category = self.env.ref('product.product_category_all')
+        self.category = self.env.ref('product.product_category_goods')
         self.partner = self.env['res.partner'].create({'name': 'Proveedor de prueba'})
 
         self.warehouse = self.env['stock.warehouse'].create({
@@ -45,8 +45,7 @@ class TestStockPickingAlterLocation(TransactionCase):
             'partner_id': self.partner.id,
             'location_id': self.env.ref('stock.stock_location_suppliers').id,
             'location_dest_id': self.location.id,
-            'move_ids_without_package': [(0, 0, {
-                'name': product_variant.name,
+            'move_ids': [(0, 0, {
                 'product_id': product_variant.id,
                 'product_uom_qty': 20,
                 'product_uom': product_variant.uom_id.id,

--- a/l10n_ve_stock/tests/test_stock_picking_alter_location.py
+++ b/l10n_ve_stock/tests/test_stock_picking_alter_location.py
@@ -1,0 +1,174 @@
+from odoo.tests import Form, TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install', 'stock_picking_alter_location')
+class TestStockPickingAlterLocation(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.env.company.use_alternate_locations = True
+        self.category = self.env.ref('product.product_category_all')
+        self.partner = self.env['res.partner'].create({'name': 'Proveedor de prueba'})
+
+        self.warehouse = self.env['stock.warehouse'].create({
+            'name': 'Alternate Locations Warehouse',
+            'code': 'ALW',
+            'partner_id': self.partner.id,
+        })
+        self.location = self.warehouse.lot_stock_id
+
+    def _create_product(self, name, physical_location=None):
+        vals = {
+            'name': name,
+            'type': 'consu',
+            'is_storable': True,
+            'categ_id': self.category.id,
+        }
+        if physical_location is not None:
+            vals['physical_location_id'] = physical_location.id
+            vals['physical_locations_ids'] = [(6, 0, [physical_location.id])]
+        return self.env['product.template'].create(vals)
+
+    def test_receipt_with_backorder_increments_alter_location_once(self):
+        """Backorder wizard confirmation must not duplicate the increment
+        of stock.picking.alter.location.line (the hook ran before super())."""
+        product_tmpl = self._create_product('Product with physical location', self.location)
+        product_variant = product_tmpl.product_variant_id
+
+        alter_location = self.env['stock.picking.alter.location'].search([
+            ('product_id', '=', product_variant.id),
+        ], limit=1)
+        self.assertTrue(alter_location)
+
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.in_type_id.id,
+            'partner_id': self.partner.id,
+            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_dest_id': self.location.id,
+            'move_ids_without_package': [(0, 0, {
+                'name': product_variant.name,
+                'product_id': product_variant.id,
+                'product_uom_qty': 20,
+                'product_uom': product_variant.uom_id.id,
+                'location_id': self.env.ref('stock.stock_location_suppliers').id,
+                'location_dest_id': self.location.id,
+            })],
+        })
+        picking.action_confirm()
+        picking.move_line_ids.quantity = 12
+
+        res = picking.button_validate()
+        self.assertIsInstance(res, dict)
+        self.assertEqual(res.get('res_model'), 'stock.backorder.confirmation')
+
+        pick_line = alter_location.stock_alter_location_lines.filtered(
+            lambda l: l.location_id == alter_location.pick_location
+        )
+        self.assertEqual(
+            sum(pick_line.mapped('available_qty')), 0,
+            "Must not increment before confirming the backorder wizard",
+        )
+
+        wizard = self.env['stock.backorder.confirmation'].with_context(**res['context']).create({})
+        wizard.process()
+
+        pick_line = alter_location.stock_alter_location_lines.filtered(
+            lambda l: l.location_id == alter_location.pick_location
+        )
+        self.assertEqual(
+            sum(pick_line.mapped('available_qty')), 12,
+            "The increment must be applied only once, with the actually received quantity",
+        )
+
+    def test_create_multi_records_with_mixed_physical_location(self):
+        """create_multi with a product that has explicit physical_location_id and another
+        that does not, must not break with ensure_one() nor generate an alternate location for the one without it."""
+        tmpl_with_location = self._create_product('Product with explicit location', self.location)
+        tmpl_without_location = self.env['product.template'].create({
+            'name': 'Product without explicit location',
+            'type': 'consu',
+            'is_storable': True,
+            'categ_id': self.category.id,
+        })
+
+        alter_location_with = self.env['stock.picking.alter.location'].search([
+            ('product_id', '=', tmpl_with_location.product_variant_id.id),
+        ])
+        alter_location_without = self.env['stock.picking.alter.location'].search([
+            ('product_id', '=', tmpl_without_location.product_variant_id.id),
+        ])
+
+        self.assertTrue(alter_location_with)
+        self.assertFalse(alter_location_without)
+
+    def test_subtract_physical_quantity_ignores_output_location(self):
+        """subtract_physical_quantity() must not deduct from pick_location the quantities
+        that are in Output (different scopes: total_alter_quantity excludes them, quant_total should not)."""
+        product_tmpl = self._create_product('Product with output delivery', self.location)
+        product_variant = product_tmpl.product_variant_id
+
+        alter_location = self.env['stock.picking.alter.location'].search([
+            ('product_id', '=', product_variant.id),
+        ], limit=1)
+        output_location = self.warehouse.wh_output_stock_loc_id
+
+        self.env['stock.quant']._update_available_quantity(product_variant, self.location, 15.0)
+        self.env['stock.quant']._update_available_quantity(product_variant, output_location, 5.0)
+
+        alter_location.subtract_physical_quantity()
+
+        pick_line = alter_location.stock_alter_location_lines.filtered(
+            lambda l: l.location_id == alter_location.pick_location
+        )
+        self.assertEqual(
+            sum(pick_line.mapped('available_qty')), 15.0,
+            "The pick_location line must not be affected by the quantity in Output",
+        )
+
+    def test_remove_physical_location_archives_alter_location(self):
+        """When removing a physical location from the m2m, the alter_location of the warehouse
+        must be archived if no location of that warehouse remains."""
+        product_tmpl = self._create_product('Product to archive', self.location)
+        product_variant = product_tmpl.product_variant_id
+
+        alter_location = self.env['stock.picking.alter.location'].search([
+            ('product_id', '=', product_variant.id),
+            ('warehouse_id', '=', self.warehouse.id),
+        ], limit=1)
+        self.assertTrue(alter_location)
+        self.assertTrue(alter_location.active)
+
+        product_tmpl.write({'physical_locations_ids': [(5, 0, 0)]})
+
+        self.assertFalse(
+            alter_location.active,
+            "The alter_location must be archived when removing the physical location",
+        )
+
+    def test_readd_physical_location_reactivates_alter_location(self):
+        """When re-adding a location of an archived warehouse, the existing
+        alter_location must be reactivated instead of creating a duplicate."""
+        product_tmpl = self._create_product('Product to reactivate', self.location)
+        product_variant = product_tmpl.product_variant_id
+
+        alter_location = self.env['stock.picking.alter.location'].search([
+            ('product_id', '=', product_variant.id),
+            ('warehouse_id', '=', self.warehouse.id),
+        ], limit=1)
+        self.assertTrue(alter_location)
+        original_id = alter_location.id
+
+        product_tmpl.write({'physical_locations_ids': [(5, 0, 0)]})
+        self.assertFalse(alter_location.active)
+
+        product_tmpl.write({'physical_locations_ids': [(4, self.location.id, 0)]})
+
+        reactivated = self.env['stock.picking.alter.location'].search([
+            ('product_id', '=', product_variant.id),
+            ('warehouse_id', '=', self.warehouse.id),
+        ], limit=1)
+        self.assertTrue(reactivated.active)
+        self.assertEqual(
+            reactivated.id, original_id,
+            "Must reactivate the same alter_location, not create a new one",
+        )

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -82,7 +82,7 @@
                     name="lock_internal_reference_on_moves"
                     widget="boolean_toggle"
                     invisible="not is_storable"
-                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
+                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos de inventario validados (estado 'Hecho')."
                 />
             </xpath>
         </field>
@@ -100,7 +100,7 @@
                     name="lock_internal_reference_on_moves"
                     widget="boolean_toggle"
                     invisible="not is_storable"
-                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
+                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos de inventario validados (estado 'Hecho')."
                 />
             </xpath>
         </field>

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -79,6 +79,13 @@
             <xpath expr="//field[@name='barcode']" position="before">
                 <field name="alternate_code"/>
             </xpath>
+            <xpath expr="//field[@name='default_code']" position="after">
+                <field
+                    name="lock_internal_reference_on_moves"
+                    widget="boolean_toggle"
+                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
+                />
+            </xpath>
         </field>
     </record>
     <record id="product_template_form_view_procurement_button" model="ir.ui.view">

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -55,8 +55,16 @@
                 <field name="liters_per_unit" groups="l10n_ve_stock.group_block_liters_per_unit"/>
             </xpath>
             <xpath expr="//group[@name='inventory']" position="inside">
+                <field name="show_physical_locations" invisible="1"/>
                 <group>
-                    <field name="physical_location_id" options="{'no_create': True}"/>
+                    <field name="physical_locations_ids" 
+                        widget="many2many_tags" 
+                        options="{'no_create': True}" 
+                        placeholder="Locations..."
+                        domain="[('location_id', '!=', False), ('child_ids', '=', False)]"
+                        invisible="not show_physical_locations"/>
+                    <field name="physical_location_id" options="{'no_create': True}"
+                        invisible="not show_physical_locations"/>
                 </group>
             </xpath>
         </field>

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -69,6 +69,14 @@
             <xpath expr="//field[@name='default_code']" position="after">
                 <field name="alternate_code"/>
             </xpath>
+            <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
+                <field
+                    name="lock_internal_reference_on_moves"
+                    widget="boolean_toggle"
+                    invisible="not is_storable"
+                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
+                />
+            </xpath>
         </field>
     </record>
     <record id="product_normal_form_view" model="ir.ui.view">
@@ -79,10 +87,11 @@
             <xpath expr="//field[@name='barcode']" position="before">
                 <field name="alternate_code"/>
             </xpath>
-            <xpath expr="//field[@name='default_code']" position="after">
+            <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
                 <field
                     name="lock_internal_reference_on_moves"
                     widget="boolean_toggle"
+                    invisible="not is_storable"
                     help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
                 />
             </xpath>

--- a/l10n_ve_stock/views/res_config_settings_views.xml
+++ b/l10n_ve_stock/views/res_config_settings_views.xml
@@ -15,6 +15,15 @@
                             <div class="text-muted">Allows to show the available quantity (Total minus reserved) in both product template and variant of it.</div>
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_settings_stock_group_alter_locations">
+                        <div class="o_setting_left_pane">
+                            <field name="use_alternate_locations" class="oe_inline"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="use_alternate_locations" />
+                            <div class="text-muted">Enable alternate locations tracking and transfers between physical and alternate locations.</div>
+                        </div>
+                    </div>
                     <div class="col-12 col-lg-6 o_setting_box" id="l10n_ve_settings_stock_use_main_warehouse">
                         <div class="o_setting_left_pane">
                             <field name="use_main_warehouse"/>

--- a/l10n_ve_stock/views/stock_picking_alter_location_line_views.xml
+++ b/l10n_ve_stock/views/stock_picking_alter_location_line_views.xml
@@ -1,0 +1,31 @@
+<odoo>
+
+    <record id="stock_picking_alter_location_line_view_tree" model="ir.ui.view">
+        <field name="name">stock.picking.alter.location.line.view.tree</field>
+        <field name="model">stock.picking.alter.location.line</field>
+        <field name="arch" type="xml">
+            <list editable="bottom">
+                <field name="location_id"/>
+                <field name="available_qty"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="stock_picking_alter_location_line_view_form" model="ir.ui.view">
+        <field name="name">stock.picking.alter.location.line.view.form</field>
+        <field name="model">stock.picking.alter.location.line</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="location_id"/>
+                            <field name="available_qty"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ve_stock/views/stock_picking_alter_location_views.xml
+++ b/l10n_ve_stock/views/stock_picking_alter_location_views.xml
@@ -1,0 +1,92 @@
+<odoo>
+
+    <record id="stock_picking_alter_location_search_view" model="ir.ui.view">
+        <field name="name">stock.picking.alter.location.search.view</field>
+        <field name="model">stock.picking.alter.location</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="pick_location"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="stock_picking_alter_location_view_tree" model="ir.ui.view">
+        <field name="name">stock.picking.alter.location.view.tree</field>
+        <field name="model">stock.picking.alter.location</field>
+        <field name="arch" type="xml">
+            <list string="PICK Locations" create="false">
+                <field name="min_quantity" invisible="1"/>
+                <field name="max_quantity" invisible="1"/>
+                <field name="name"/>
+                <field name="pick_location"/>
+                <field name="pick_quantity" decoration-bf="pick_quantity &lt;= (min_quantity + 3)"
+                       decoration-warning="pick_quantity &lt;= (min_quantity + 3)"
+                       decoration-danger="pick_quantity &lt;= (min_quantity + 1)"/>
+                <field name="total_quantity"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="stock_picking_alter_location_view_form" model="ir.ui.view">
+        <field name="name">stock.picking.alter.location.view.form</field>
+        <field name="model">stock.picking.alter.location</field>
+        <field name="arch" type="xml">
+            <form create="0">
+                <header>
+                    <button string="Move quantities between locations"
+                            name="action_change_product_quantities"
+                            type="object" class="btn btn-primary"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name" class="oe_edit_only"/>
+                        <h1>
+                            <field name="name"/>
+                        </h1>
+                    </div>
+
+                    <group name="pick_location" string="Physical Location" colspan="2">
+                        <field name="pick_location" nolabel="1" readonly="1"/>
+                        <field name="warehouse_id" invisible="1"/>
+                        <field name="min_quantity" invisible="1"/>
+                        <field name="max_quantity" invisible="1"/>
+                        <group>
+                            <field name="min_quantity" groups="l10n_ve_stock.group_physical_location_edit"/>
+                            <field name="max_quantity" groups="l10n_ve_stock.group_physical_location_edit"/>
+                            <field name="pick_quantity"
+                                   decoration-bf="pick_quantity &lt;= (min_quantity + 3)"
+                                   decoration-warning="pick_quantity &lt;= (min_quantity + 3)"
+                                   decoration-danger="pick_quantity &lt;= (min_quantity + 1)"
+                                   readonly="1"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page name="other_locations" string="Other Product Locations">
+                            <field name="stock_alter_location_lines" nolabel="1"/>
+                        </page>
+                    </notebook>
+                </sheet>
+
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_stock_picking_alter_location_view" model="ir.actions.act_window">
+        <field name="name">Product Physical Locations</field>
+        <field name="res_model">stock.picking.alter.location</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Add a Physical Location to the product.</p>
+        </field>
+    </record>
+
+    <menuitem
+            id="stock_picking_alter_location_view_menu"
+            name="Physical Locations"
+            action="action_stock_picking_alter_location_view"
+            parent="stock.menu_stock_warehouse_mgmt"
+            sequence="9"/>
+
+</odoo>

--- a/l10n_ve_stock/views/stock_quant_views.xml
+++ b/l10n_ve_stock/views/stock_quant_views.xml
@@ -30,7 +30,7 @@
                     </group>
                     <notebook>
                         <page string="Show Location Available">
-                            <field name="product_alter_location_ids" editable="button">
+                            <field name="product_alter_location_ids" editable="button" options="{'no_create': True, 'no_delete': True}">
                                 <list>
                                     <field name="location_id"/>
                                     <field name="quantity"/>

--- a/l10n_ve_stock/wizard/__init__.py
+++ b/l10n_ve_stock/wizard/__init__.py
@@ -1,1 +1,2 @@
 from . import stock_quantity_history
+from . import move_alter_location_qtities

--- a/l10n_ve_stock/wizard/move_alter_location_qtities.py
+++ b/l10n_ve_stock/wizard/move_alter_location_qtities.py
@@ -1,0 +1,127 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class MoveAlterLocationQtitiesWizard(models.TransientModel):
+    _name = "move.alter.location.qtities.wizard"
+    _description = "Wizard to move physical quantities to other product locations."
+
+    transfer_quantity = fields.Float("Quantities to Transfer")
+    allowed_from_location_ids = fields.Many2many(
+        "stock.location", compute="_compute_allowed_from_locations"
+    )
+    allowed_to_location_ids = fields.Many2many(
+        "stock.location", compute="_compute_allowed_to_locations"
+    )
+    from_location = fields.Many2one(
+        "stock.location",
+        string="From",
+        domain="[('id', 'in', allowed_from_location_ids)]",
+    )
+    to_location = fields.Many2one(
+        "stock.location",
+        string="To",
+        domain="[('id', 'in', allowed_to_location_ids)]",
+    )
+    stock_alter_location_id = fields.Many2one("stock.picking.alter.location")
+
+    @api.depends("stock_alter_location_id")
+    def _compute_allowed_from_locations(self):
+        external_location = self.env.ref("stock.stock_location_output")
+        for wizard in self:
+            if wizard.stock_alter_location_id:
+                output_loc = wizard.stock_alter_location_id.warehouse_id.wh_output_stock_loc_id
+                wizard.allowed_from_location_ids = (
+                    wizard.stock_alter_location_id.stock_alter_location_lines.mapped(
+                        "location_id"
+                    ).filtered(
+                        lambda loc: loc != external_location and loc != output_loc
+                    )
+                )
+            else:
+                wizard.allowed_from_location_ids = False
+
+    @api.depends("from_location")
+    def _compute_allowed_to_locations(self):
+        external_location = self.env.ref("stock.stock_location_output")
+        for wizard in self:
+            excluded_ids = [external_location.id]
+            output_loc = (
+                wizard.stock_alter_location_id.warehouse_id.wh_output_stock_loc_id
+                if wizard.stock_alter_location_id and wizard.stock_alter_location_id.warehouse_id
+                else False
+            )
+            if output_loc:
+                excluded_ids.append(output_loc.id)
+            wizard_domain = [
+                ("id", "not in", excluded_ids),
+                ("usage", "=", "internal"),
+            ]
+            if wizard.from_location:
+                wizard_domain.append(("id", "!=", wizard.from_location.id))
+            if wizard.stock_alter_location_id and wizard.stock_alter_location_id.warehouse_id:
+                wizard_domain.append(
+                    ("id", "child_of", wizard.stock_alter_location_id.warehouse_id.view_location_id.id)
+                )
+            wizard.allowed_to_location_ids = self.env["stock.location"].search(
+                wizard_domain
+            )
+
+    @api.onchange("from_location", "to_location")
+    def _onchange_exclude_same_location(self):
+        if self.from_location and self.to_location == self.from_location:
+            self.to_location = False
+        if self.to_location and self.from_location == self.to_location:
+            self.from_location = False
+
+    def action_transfer_quantities(self):
+        self.ensure_one()
+        alter = self.stock_alter_location_id
+
+        from_line = alter.stock_alter_location_lines.filtered(
+            lambda l: l.location_id.id == self.from_location.id
+        )
+        if not from_line:
+                raise UserError(
+                    _("There is no stock in the source location.")
+                )
+        if self.transfer_quantity > from_line.available_qty:
+                raise UserError(
+                    _("You cannot transfer more than the available quantity in the location.")
+                )
+
+        pick_location = alter.pick_location
+        pick_line = alter.stock_alter_location_lines.filtered(
+            lambda l: l.location_id == pick_location
+        )
+        current_pick_qty = pick_line.available_qty if pick_line else 0.0
+
+        if self.to_location == pick_location:
+            new_pick_qty = current_pick_qty + self.transfer_quantity
+            if alter.max_quantity and new_pick_qty > alter.max_quantity:
+                raise UserError(
+                    _(
+                        "The resulting quantity (%(qty)s) exceeds the maximum "
+                        "allowed quantity in the Physical Location (%(maximum)s).",
+                        qty=new_pick_qty,
+                        maximum=alter.max_quantity,
+                    )
+                )
+
+        if self.from_location == pick_location:
+            new_pick_qty = current_pick_qty - self.transfer_quantity
+            if alter.min_quantity and new_pick_qty < alter.min_quantity:
+                raise UserError(
+                    _(
+                        "The resulting quantity (%(qty)s) would fall below the "
+                        "minimum required quantity in the Physical Location (%(minimum)s).",
+                        qty=new_pick_qty,
+                        minimum=alter.min_quantity,
+                    )
+                )
+
+        alter.action_internal_transfer(
+            self.from_location.id,
+            self.to_location.id,
+            self.transfer_quantity,
+        )

--- a/l10n_ve_stock/wizard/move_alter_location_qtities.xml
+++ b/l10n_ve_stock/wizard/move_alter_location_qtities.xml
@@ -1,0 +1,37 @@
+<odoo>
+
+    <record id="move_alter_location_qtities_wizard_view_form" model="ir.ui.view">
+        <field name="name">move.alter.location.qtities.wizard.view.form</field>
+        <field name="model">move.alter.location.qtities.wizard</field>
+        <field name="arch" type="xml">
+            <form string="">
+                <sheet>
+                    <field name="stock_alter_location_id" invisible="1"/>
+                    <field name="allowed_from_location_ids" invisible="1"/>
+                    <field name="allowed_to_location_ids" invisible="1"/>
+                    <group>
+                        <group>
+                            <field name="from_location"
+                                   options="{'no_create': True, 'no_edit': True}"/>
+                            <field name="transfer_quantity"/>
+                        </group>
+                        <group>
+                            <field name="to_location"
+                                   options="{'no_create': True, 'no_edit': True}"/>
+                        </group>
+                    </group>
+                    <footer>
+                        <button string="Confirm"
+                                name="action_transfer_quantities"
+                                type="object"
+                                class="btn btn-primary"/>
+                        <button string="Cancel"
+                                class="btn btn-secondary"
+                                special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ve_stock/wizard/stock_quantity_history.py
+++ b/l10n_ve_stock/wizard/stock_quantity_history.py
@@ -47,7 +47,7 @@ class StockQuantityHistoryInh(models.TransientModel):
         except_product = self.except_products_at_zero
         domain = [
             # ("qty_available", ">", 0),
-            ("type", "=", "product"),
+            ("is_storable", "=", True),
         ]
         
         qty_companies = len(self.env["res.company"].sudo().search([]))


### PR DESCRIPTION
Reemplaza al PR #1196, cerrado por CI en rojo debido a un falso-positivo causado por el ruido histórico de esa rama (ver comentario de cierre en #1196 para el diagnóstico completo).

Mismo contenido funcional que #1196 (13 commits reales de la tarea 79483, extraídos vía `git cherry-pick` en orden cronológico), pero partiendo limpio del `maintenance-19.0` más reciente en vez de una rama con 135 commits acumulados de meses de merges cruzados con `19.0`.

## Tarea

project.task 79483 — "1. Migracion de Referencia Interna a V19": bloquear la referencia interna (`default_code`) de un producto una vez que tiene movimientos de inventario confirmados, configurable por producto (`lock_internal_reference_on_moves`), activo por defecto.

## Puntos cubiertos de las reviews de #1196

### Christopher (2026-09-01, 🔴 resuelto en la rama origen)
- ✅ `write()` de `product.product` ahora lee el valor efectivo del toggle desde `vals` en vez de solo el valor almacenado — corrige el flujo de desbloquear y corregir en un mismo guardado.

### David Mendoza (2026-09-02, 2× 🔴 resueltos en la rama origen)
- ✅ El desbloqueo seguía fallando al editar desde `product.template` (el formulario real) por el orden de los inverses entre `default_code` y `lock_internal_reference_on_moves`. Se propaga el toggle a `product_variant_ids` antes de que corra `super().write()`.
- ✅ El `help` del campo describía "movimientos confirmados (incluye órdenes de compra/venta confirmadas)" cuando el código solo bloquea con movimientos en estado `done` y productos `is_storable`. Corregido el texto en los 4 lugares donde aparece, sin tocar lógica.

## Pendiente — no resuelto todavía en este PR

- 🟡 (Christopher) Strings visibles nuevos sin actualizar `i18n/es_VE.po`.
- 🟢 (Christopher) Edge case en `domain_quant_loc.value`: si no hay warehouses configurados, `_get_domain_locations()` devuelve `Domain.FALSE` y `.value` sería `False`, generando un dominio inválido `('location_dest_id', 'in', False)`. Caso límite, requiere ausencia total de warehouses.
- 🟢 (Christopher) Convención de commits: 3 commits (`47b1818`→`4fee8ba`, `9467d5d`→`1cdcf0f`, `12bff94`→`adbd4d4` en este PR) llevan `Co-Authored-By: Claude Sonnet 5`, que el repo no usa por convención. El commit "[TEST] l10n_ve_stock: include test" tampoco tiene `References` a la tarea.
- 🟡 (Christopher) Scope mezclado: 3 de los commits son fixes de compatibilidad Odoo 19 (`NewId`, `location_final_id`, timing de `alter_location`/backorder) no pedidos por la tarea 79483 — mismo hallazgo que motivó el bloqueante de scope en el PR #1197. Queda documentado, no resuelto (requeriría separar en su propio PR de compatibilidad).

## CI

Validado en verde de punta a punta en el PR experimental original (`pre-commit` + `run-cli-command` pass, 69% cobertura, 232 tests / 150 post_install, 0 failed / 0 error) — sin el falso-positivo de `tax_unit.available_date` que afecta a otros PRs de esta rama larga.