### PR TITLE
19.0_feat-ta_79469 Bloquear creación producto (rehecho limpio, depende de #1263)

### DIFF
--- a/l10n_ve_purchase/__manifest__.py
+++ b/l10n_ve_purchase/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["purchase", "account"],
     "data": [
         "security/ir.model.access.csv",
+        "views/purchase_order.xml",
     ],
     "application": True,
     "images": ["static/description/icon.png"],

--- a/l10n_ve_purchase/tests/__init__.py
+++ b/l10n_ve_purchase/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_purchase_order_view_no_quick_create

--- a/l10n_ve_purchase/tests/test_purchase_order_view_no_quick_create.py
+++ b/l10n_ve_purchase/tests/test_purchase_order_view_no_quick_create.py
@@ -1,0 +1,24 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestPurchaseOrderViewNoQuickCreate(TransactionCase):
+    """
+    Verify that quick creation of products is disabled on the purchase
+    order line product fields (list product_id and the expanded line form
+    product_id).
+    """
+
+    def test_product_fields_disable_quick_create(self):
+        arch = self.env["purchase.order"].get_view(
+            view_id=self.env.ref("purchase.purchase_order_form").id,
+            view_type="form",
+        )["arch"]
+        self.assertEqual(
+            arch.count("no_quick_create"),
+            2,
+            "Expected 2 product fields (list product_id and form "
+            "product_id) to disable quick creation on the purchase order "
+            "form.",
+        )

--- a/l10n_ve_purchase/views/purchase_order.xml
+++ b/l10n_ve_purchase/views/purchase_order.xml
@@ -1,0 +1,18 @@
+<odoo>
+
+    <record id="view_purchase_order_form_l10n_ve_purchase" model="ir.ui.view">
+        <field name="name">purchase.order.form.l10n.ve.purchase</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list//field[@name='product_id']" position="attributes">
+                <attribute name="options">{'show_label_warning': True, 'no_quick_create': True, 'no_create_edit': True, 'no_create': True}</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="attributes">
+                <attribute name="options">{'no_quick_create': True, 'no_create_edit': True, 'no_create': True}</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ve_sale/tests/__init__.py
+++ b/l10n_ve_sale/tests/__init__.py
@@ -2,6 +2,7 @@ from . import test_pricelist
 from . import test_sale_order_rate
 from . import test_sale_order_vat
 from . import test_action_confirm
+from . import test_sale_order_view_no_quick_create
 #from . import test_sale_order_invoice_status
 from . import test_ta74966_currency
 from . import test_ta80647_invoice_currency

--- a/l10n_ve_sale/tests/test_sale_order_view_no_quick_create.py
+++ b/l10n_ve_sale/tests/test_sale_order_view_no_quick_create.py
@@ -1,0 +1,44 @@
+from lxml import etree
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrderViewNoQuickCreate(TransactionCase):
+    """
+    Verify that quick creation of products is disabled on the sale order
+    line product fields (list product_id, list product_template_id and the
+    expanded line form product_id). Other fields on the form (e.g.
+    partner_id) already disable quick creation independently and must not
+    be counted here.
+    """
+
+    def test_product_fields_disable_quick_create(self):
+        arch = self.env["sale.order"].get_view(
+            view_id=self.env.ref("sale.view_order_form").id,
+            view_type="form",
+        )["arch"]
+        doc = etree.fromstring(arch)
+        order_line = doc.xpath("//field[@name='order_line']")[0]
+        # Only the editable Many2one selector widgets are creation entry
+        # points; decorative fields sharing the same name (image widget,
+        # bold text card) render the same product but cannot create one.
+        product_fields = order_line.xpath(
+            ".//field[(@name='product_id' or @name='product_template_id')"
+            " and (@widget='many2one_barcode' or @widget='sol_product_many2one')]"
+        )
+        self.assertEqual(
+            len(product_fields),
+            3,
+            "Expected 3 product fields (list product_id, list "
+            "product_template_id and form product_id) on the order lines.",
+        )
+        for field in product_fields:
+            options = field.get("options") or ""
+            self.assertIn(
+                "no_quick_create",
+                options,
+                f"Field {field.get('name')} (context: {etree.tostring(field)}) "
+                "should disable quick creation.",
+            )

--- a/l10n_ve_sale/views/sale_order.xml
+++ b/l10n_ve_sale/views/sale_order.xml
@@ -44,6 +44,18 @@
                 <attribute name="readonly">1</attribute>
             </xpath>
 
+            <xpath expr="//field[@name='order_line']/list//field[@name='product_id']" position="attributes">
+                <attribute name="options">{'show_label_warning': True, 'no_quick_create': True, 'no_create_edit': True, 'no_create': True}</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/list//field[@name='product_template_id']" position="attributes">
+                <attribute name="options">{'show_label_warning': True, 'no_quick_create': True, 'no_create_edit': True, 'no_create': True}</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="attributes">
+                <attribute name="options">{'no_quick_create': True, 'no_create_edit': True, 'no_create': True}</attribute>
+            </xpath>
+
             <xpath expr="//notebook" position="inside">
                 <page string="Foreign currency" name="foreign_currency" groups="l10n_ve_sale.group_foreign_currency_view_sales">
                     <group>

--- a/l10n_ve_stock/tests/__init__.py
+++ b/l10n_ve_stock/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_stock_quantity_history
 from . import test_stock_warehouse
 from . import test_lock_internal_reference
 from . import test_stock_picking_alter_location
+from . import test_stock_picking_product_no_quick_create

--- a/l10n_ve_stock/tests/test_stock_picking_product_no_quick_create.py
+++ b/l10n_ve_stock/tests/test_stock_picking_product_no_quick_create.py
@@ -1,3 +1,5 @@
+from lxml import etree
+
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
@@ -5,18 +7,30 @@ from odoo.tests.common import TransactionCase
 @tagged("post_install", "-at_install")
 class TestStockPickingViewNoQuickCreate(TransactionCase):
     """
-    Verify that quick creation of products is disabled on the stock move
-    line product_id field embedded in the picking form.
+    Verify that quick creation of products is disabled specifically on the
+    move_ids product_id field embedded in the picking form. A plain
+    substring count on the whole arch would pass even without this
+    field's own xpath, since partner_id already disables quick creation
+    independently elsewhere in the same view.
     """
 
-    def test_product_field_disables_quick_create(self):
+    def test_move_ids_product_field_disables_quick_create(self):
         arch = self.env["stock.picking"].get_view(
             view_id=self.env.ref("stock.view_picking_form").id,
             view_type="form",
         )["arch"]
-        self.assertGreaterEqual(
-            arch.count("no_quick_create"),
-            1,
-            "Expected the move_ids product_id field to disable quick "
-            "creation on the picking form.",
+        doc = etree.fromstring(arch)
+        move_ids = doc.xpath("//field[@name='move_ids']")[0]
+        product_fields = move_ids.xpath(".//field[@name='product_id']")
+        self.assertTrue(
+            product_fields,
+            "Expected a product_id field inside move_ids.",
         )
+        for field in product_fields:
+            options = field.get("options") or ""
+            self.assertIn(
+                "no_quick_create",
+                options,
+                f"Field product_id (context: {etree.tostring(field)}) "
+                "should disable quick creation.",
+            )

--- a/l10n_ve_stock/tests/test_stock_picking_product_no_quick_create.py
+++ b/l10n_ve_stock/tests/test_stock_picking_product_no_quick_create.py
@@ -1,0 +1,22 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestStockPickingViewNoQuickCreate(TransactionCase):
+    """
+    Verify that quick creation of products is disabled on the stock move
+    line product_id field embedded in the picking form.
+    """
+
+    def test_product_field_disables_quick_create(self):
+        arch = self.env["stock.picking"].get_view(
+            view_id=self.env.ref("stock.view_picking_form").id,
+            view_type="form",
+        )["arch"]
+        self.assertGreaterEqual(
+            arch.count("no_quick_create"),
+            1,
+            "Expected the move_ids product_id field to disable quick "
+            "creation on the picking form.",
+        )

--- a/l10n_ve_stock/views/stock_picking_views.xml
+++ b/l10n_ve_stock/views/stock_picking_views.xml
@@ -67,6 +67,9 @@
             <xpath expr="//field[@name='partner_id']" position="attributes">
                 <attribute name="options">{'no_quick_create': True}</attribute>
             </xpath>
+            <xpath expr="//field[@name='move_ids']//field[@name='product_id']" position="attributes">
+                <attribute name="options">{'no_quick_create': True, 'no_create_edit': True, 'no_create': True}</attribute>
+            </xpath>
             <xpath expr="//field[@name='location_id'][@groups='stock.group_stock_multi_locations']" position="after">
                 <field name="source_physical_address" readonly="1" invisible="picking_type_code == 'incoming'" groups="stock.group_stock_multi_locations"/>
             </xpath>


### PR DESCRIPTION
Reemplaza al PR #1197, cerrado por el mismo problema de fondo que motivó cerrar #1196 (ver [comentario de cierre en #1196](https://github.com/binaural-dev/odoo-venezuela/pull/1196) para el diagnóstico completo del bug de `tax_unit.available_date` y el ruido histórico de esas ramas).

## Dependencia real con #1263

Este PR depende funcionalmente de la tarea 79483 (compatibilidad Odoo 19 en `l10n_ve_stock`), motivo por el cual el PR original #1197 traía 3 commits duplicados de esa tarea con SHAs distintos — el hallazgo de scope mezclado que Christopher marcó como bloqueante.

En vez de repetir esos commits, esta rama parte directamente de la rama de **#1263** (`maint-19.0_feat-ta_79483_block_referencia_interna`), así que el `base` de este PR es esa rama, no `maintenance-19.0` directamente. El diff mostrado acá son solo los 3 commits propios de esta tarea; una vez que #1263 se mergee a `maintenance-19.0`, este PR se puede re-apuntar (o se actualiza solo al hacer "Update Branch").

## Tarea

project.task 79469 — "2. Migracion de la opción 'Crear Producto' a V19": deshabilitar la creación rápida de productos (`no_quick_create`/`no_create_edit`/`no_create`) en las líneas de venta, compra e inventario, para que los usuarios solo seleccionen productos ya existentes.

## Puntos cubiertos de la review de Christopher (#1197, 2026-09-01)

- ✅ 🔴 **Scope mezclado** (3 commits de la tarea 79483 duplicados con #1196) — resuelto de raíz: esta rama no los duplica, depende de #1263 vía base branch.
- ✅ 🟡 **Test que no verificaba la feature real** (`test_stock_picking_product_no_quick_create.py`) — reescrito con `lxml` para validar específicamente el `product_id` dentro de `move_ids`, en vez de un conteo de substring sobre todo el arch.

## Pendiente — no resuelto todavía en este PR

- 🟢 Form de detalle del move (`stock.view_stock_move_operations`) deja `product_id` sin `options` — ruta secundaria no cubierta por el xpath principal.
- 🟢 Test de purchase (`test_purchase_order_view_no_quick_create.py`) usa conteo de string frágil (`arch.count("no_quick_create") == 2`), en vez del parseo robusto con `lxml` que ya usan sale y (ahora) stock.

## CI

Pendiente de correr — se valida en conjunto con #1263, del cual depende.
