### PR TITLE
19.0_feat-ta_78876 Restringir edición company_id (rehecho limpio, depende de #1263)

### DIFF
--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -244,14 +244,17 @@ class ProductProduct(models.Model):
 
         MoveLine = self.env['stock.move.line'].with_context(active_test=False)
 
-        # domain_move_in_loc/domain_move_out_loc reference location_final_id, a field
-        # of stock.move that no longer exists on stock.move.line since Odoo 19. Since
-        # these lines are always filtered to state == 'done', the "final destination
-        # of an in-progress chained move" logic does not apply here: it is enough to
-        # filter by the plain location_id/location_dest_id already used for quants.
-        descendant_location_ids = domain_quant_loc.value
-        domain_move_line_in_loc = [('location_dest_id', 'in', descendant_location_ids)]
-        domain_move_line_out_loc = [('location_id', 'in', descendant_location_ids)]
+        # These lines are always filtered to state == 'done', so the "final destination
+        # of an in-progress chained move" branch of _get_domain_locations() does not
+        # apply here. `skip_in_progress=True` makes the core return the plain
+        # done-only in/out domains (each already excluding the other side via `~`,
+        # e.g. `dest_loc_domain_done & ~loc_domain`), instead of the union with the
+        # in-progress branch used for stock.move. Without that exclusion, an internal
+        # transfer (both origin and destination inside the selected locations) would
+        # count as incoming AND outgoing at once, inflating both quantities.
+        _, domain_move_line_in_loc, domain_move_line_out_loc = self.with_context(
+            skip_in_progress=True
+        )._get_domain_locations()
 
         domain_move_line_in = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_line_in_loc
         domain_move_line_out = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_line_out_loc

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -78,6 +78,7 @@ class ProductTemplate(models.Model):
     company_id = fields.Many2one(tracking=True)
 
     can_edit_company_id = fields.Boolean(
+        string="Puede editar la compañía",
         compute="_compute_can_edit_company_id",
         help="Indica si el usuario actual puede modificar la compañía del producto.",
     )
@@ -429,6 +430,7 @@ class ProductTemplate(models.Model):
                     ])
                     rules.unlink()
 
+    @api.depends_context("uid")
     def _compute_can_edit_company_id(self):
         can_edit = self.env.user.has_group("l10n_ve_stock.group_edit_product_company")
         for product in self:

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -75,6 +75,13 @@ class ProductTemplate(models.Model):
         ),
     )
 
+    company_id = fields.Many2one(tracking=True)
+
+    can_edit_company_id = fields.Boolean(
+        compute="_compute_can_edit_company_id",
+        help="Indica si el usuario actual puede modificar la compañía del producto.",
+    )
+
     def button_dummy(self):
         # TDE FIXME: this button is very interesting
         # Maldito Raiver e.e
@@ -412,3 +419,8 @@ class ProductTemplate(models.Model):
                         ('location_out_id', '=', location.id),
                     ])
                     rules.unlink()
+
+    def _compute_can_edit_company_id(self):
+        can_edit = self.env.user.has_group("l10n_ve_stock.group_edit_product_company")
+        for product in self:
+            product.can_edit_company_id = can_edit

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import AccessError, ValidationError
 from collections import defaultdict
 
 _logger = logging.getLogger(__name__)
@@ -98,6 +98,15 @@ class ProductTemplate(models.Model):
                 raise ValidationError(_("Price cannot be negative or zero."))
 
     def write(self, vals):
+        if (
+            "company_id" in vals
+            and not self.env.su
+            and not self.env.user.has_group("l10n_ve_stock.group_edit_product_company")
+        ):
+            raise AccessError(
+                _("No tienes permiso para cambiar la compañía de este producto.")
+            )
+
         # default_code and lock_internal_reference_on_moves are both stored
         # fields with their own inverse (_set_default_code on the core side,
         # _set_lock_internal_reference_on_moves here), so Odoo runs them as

--- a/l10n_ve_stock/security/l10n_ve_stock_groups.xml
+++ b/l10n_ve_stock/security/l10n_ve_stock_groups.xml
@@ -68,6 +68,7 @@
         <record id="group_edit_product_company" model="res.groups">
             <field name="name">Puede editar la compañía del producto</field>
             <field name="privilege_id" ref="l10n_ve_stock.edit_product_company_privilege"/>
+            <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
     </data>
 

--- a/l10n_ve_stock/security/l10n_ve_stock_groups.xml
+++ b/l10n_ve_stock/security/l10n_ve_stock_groups.xml
@@ -61,6 +61,14 @@
             <field name="name">Binaural - Editar Ubicaciones Físicas Alternas</field>
             <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
+        <record id="edit_product_company_privilege" model="res.groups.privilege">
+            <field name="name">Editar compañía del producto</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
+        <record id="group_edit_product_company" model="res.groups">
+            <field name="name">Puede editar la compañía del producto</field>
+            <field name="privilege_id" ref="l10n_ve_stock.edit_product_company_privilege"/>
+        </record>
     </data>
 
 </odoo>

--- a/l10n_ve_stock/tests/__init__.py
+++ b/l10n_ve_stock/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_stock_quantity_history
 from . import test_stock_warehouse
 from . import test_lock_internal_reference
 from . import test_stock_picking_alter_location
+from . import test_product_company_edit_restriction

--- a/l10n_ve_stock/tests/test_product_company_edit_restriction.py
+++ b/l10n_ve_stock/tests/test_product_company_edit_restriction.py
@@ -30,12 +30,11 @@ class TestProductCompanyEditRestriction(TransactionCase):
         })
         # Odoo's mail.thread.create() discards pending write-tracking for the
         # new record right after logging its creation message, but only
-        # finalizes that discard on a real DB flush/commit. Flush here so
-        # creation-time bookkeeping doesn't leak into a later write() within
-        # this same test transaction (this has no effect outside tests,
-        # where each request is its own transaction).
-        self.env.flush_all()
-        self.cr.flush()
+        # finalizes that discard on a real DB commit's precommit hooks.
+        # Run those here so creation-time bookkeeping doesn't leak into a
+        # later write() within this same test transaction (this has no
+        # effect outside tests, where each request is its own transaction).
+        self.env.cr.precommit.run()
 
     def test_can_edit_company_id_false_without_group(self):
         template = self.template.with_user(self.user)
@@ -53,13 +52,12 @@ class TestProductCompanyEditRestriction(TransactionCase):
         # Odoo defers tracking-message creation to a cr.precommit hook, which
         # only runs on a real DB commit. Force it here so the assertions
         # below see the tracking message within this test's transaction.
-        self.env.flush_all()
-        self.cr.flush()
-        tracking_values = self.template.message_ids[0].tracking_value_ids
+        self.env.cr.precommit.run()
         self.assertGreater(
             len(self.template.message_ids), message_count_before,
             "Changing company_id should post a tracking message to the chatter.",
         )
+        tracking_values = self.template.message_ids[0].tracking_value_ids
         self.assertTrue(
             any(tv.field_id.name == "company_id" for tv in tracking_values),
             "The tracking message should include a tracking value for company_id.",

--- a/l10n_ve_stock/tests/test_product_company_edit_restriction.py
+++ b/l10n_ve_stock/tests/test_product_company_edit_restriction.py
@@ -15,6 +15,14 @@ class TestProductCompanyEditRestriction(TransactionCase):
             "name": "Product Company Edit Restriction",
             "type": "consu",
         })
+        # Odoo's mail.thread.create() discards pending write-tracking for the
+        # new record right after logging its creation message, but only
+        # finalizes that discard on a real DB flush/commit. Flush here so
+        # creation-time bookkeeping doesn't leak into a later write() within
+        # this same test transaction (this has no effect outside tests,
+        # where each request is its own transaction).
+        self.env.flush_all()
+        self.cr.flush()
 
     def test_can_edit_company_id_false_without_group(self):
         template = self.template.with_user(self.user)
@@ -24,3 +32,22 @@ class TestProductCompanyEditRestriction(TransactionCase):
         self.user.group_ids = [(4, self.group.id)]
         template = self.template.with_user(self.user)
         self.assertTrue(template.can_edit_company_id)
+
+    def test_company_id_change_is_tracked_in_chatter(self):
+        other_company = self.env["res.company"].create({"name": "Other Company"})
+        message_count_before = len(self.template.message_ids)
+        self.template.write({"company_id": other_company.id})
+        # Odoo defers tracking-message creation to a cr.precommit hook, which
+        # only runs on a real DB commit. Force it here so the assertions
+        # below see the tracking message within this test's transaction.
+        self.env.flush_all()
+        self.cr.flush()
+        tracking_values = self.template.message_ids[0].tracking_value_ids
+        self.assertGreater(
+            len(self.template.message_ids), message_count_before,
+            "Changing company_id should post a tracking message to the chatter.",
+        )
+        self.assertTrue(
+            any(tv.field_id.name == "company_id" for tv in tracking_values),
+            "The tracking message should include a tracking value for company_id.",
+        )

--- a/l10n_ve_stock/tests/test_product_company_edit_restriction.py
+++ b/l10n_ve_stock/tests/test_product_company_edit_restriction.py
@@ -1,3 +1,4 @@
+from odoo.exceptions import AccessError
 from odoo.tests import TransactionCase, tagged
 
 
@@ -10,6 +11,18 @@ class TestProductCompanyEditRestriction(TransactionCase):
             "name": "Test User Company Edit",
             "login": "test_user_company_edit",
             "email": "test_user_company_edit@example.com",
+            # Passing group_ids explicitly skips res.users' own default
+            # (base.group_user + implied groups), so it has to be listed here
+            # too - otherwise the user lacks even base internal-user access
+            # (e.g. to res.company) and every write() fails before it ever
+            # reaches the company_id guard being tested.
+            "group_ids": [(6, 0, [
+                self.env.ref("base.group_user").id,
+                # Base write access to product.template (Products/Create), so
+                # the write()-level tests below exercise the company_id guard
+                # itself instead of failing earlier on the base ACL.
+                self.env.ref("product.group_product_manager").id,
+            ])],
         })
         self.template = self.env["product.template"].create({
             "name": "Product Company Edit Restriction",
@@ -51,3 +64,21 @@ class TestProductCompanyEditRestriction(TransactionCase):
             any(tv.field_id.name == "company_id" for tv in tracking_values),
             "The tracking message should include a tracking value for company_id.",
         )
+
+    def test_write_company_id_without_group_raises_access_error(self):
+        other_company = self.env["res.company"].create({"name": "Other Company"})
+        template = self.template.with_user(self.user)
+        with self.assertRaises(AccessError):
+            template.write({"company_id": other_company.id})
+
+    def test_write_company_id_with_group_is_allowed(self):
+        other_company = self.env["res.company"].create({"name": "Other Company"})
+        self.user.group_ids = [(4, self.group.id)]
+        template = self.template.with_user(self.user)
+        template.write({"company_id": other_company.id})
+        self.assertEqual(self.template.company_id, other_company)
+
+    def test_write_without_company_id_is_allowed_without_group(self):
+        template = self.template.with_user(self.user)
+        template.write({"name": "Renamed by unprivileged user"})
+        self.assertEqual(self.template.name, "Renamed by unprivileged user")

--- a/l10n_ve_stock/tests/test_product_company_edit_restriction.py
+++ b/l10n_ve_stock/tests/test_product_company_edit_restriction.py
@@ -1,0 +1,26 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "l10n_ve_stock")
+class TestProductCompanyEditRestriction(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.group = self.env.ref("l10n_ve_stock.group_edit_product_company")
+        self.user = self.env["res.users"].create({
+            "name": "Test User Company Edit",
+            "login": "test_user_company_edit",
+            "email": "test_user_company_edit@example.com",
+        })
+        self.template = self.env["product.template"].create({
+            "name": "Product Company Edit Restriction",
+            "type": "consu",
+        })
+
+    def test_can_edit_company_id_false_without_group(self):
+        template = self.template.with_user(self.user)
+        self.assertFalse(template.can_edit_company_id)
+
+    def test_can_edit_company_id_true_with_group(self):
+        self.user.group_ids = [(4, self.group.id)]
+        template = self.template.with_user(self.user)
+        self.assertTrue(template.can_edit_company_id)

--- a/l10n_ve_stock/tests/test_product_product.py
+++ b/l10n_ve_stock/tests/test_product_product.py
@@ -201,9 +201,55 @@ class TestProductProductComputeQuantitiesForReport(TransactionCase):
             "is_storable": True,
         })
 
-    @unittest.skip("_compute_quantities_dict_for_report depends on location_final_id removed in Odoo 19")
     def test_compute_quantities_dict_for_report_basic(self):
-        pass
+        self.env["stock.quant"].create({
+            "product_id": self.product.id,
+            "location_id": self.location.id,
+            "quantity": 10,
+        })
+        res = self.product._compute_quantities_dict_for_report(
+            lot_id=False, owner_id=False, package_id=False, location=self.location,
+        )
+        self.assertEqual(res[self.product.id]["qty_available"], 10.0)
+
+    def test_compute_quantities_dict_for_report_internal_transfer_does_not_inflate(self):
+        """A move.line whose origin and destination are both inside the
+        selected locations (e.g. WH/Stock -> WH/Output) must not be counted
+        as incoming AND outgoing at once, or the report's totals get
+        inflated for every internal transfer.
+        """
+        other_internal_location = self.env["stock.location"].create({
+            "name": "Internal Transfer Target",
+            "location_id": self.location.location_id.id,
+            "usage": "internal",
+        })
+        picking = self.env["stock.picking"].create({
+            "picking_type_id": self.warehouse.int_type_id.id,
+            "location_id": self.location.id,
+            "location_dest_id": other_internal_location.id,
+            "move_ids": [(0, 0, {
+                "product_id": self.product.id,
+                "product_uom_qty": 5,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.location.id,
+                "location_dest_id": other_internal_location.id,
+            })],
+        })
+        picking.action_confirm()
+        picking.move_ids.quantity = 5
+        picking.button_validate()
+
+        res = self.product._compute_quantities_dict_for_report(
+            lot_id=False, owner_id=False, package_id=False,
+        )
+        self.assertEqual(
+            res[self.product.id]["incoming_qty"], 0.0,
+            "An internal transfer between two selected locations must not count as incoming.",
+        )
+        self.assertEqual(
+            res[self.product.id]["outgoing_qty"], 0.0,
+            "An internal transfer between two selected locations must not count as outgoing.",
+        )
 
     @unittest.skip("_compute_quantities_dict_for_report depends on location_final_id removed in Odoo 19")
     def test_compute_quantities_dict_for_report_with_lot(self):

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -67,6 +67,12 @@
                         invisible="not show_physical_locations"/>
                 </group>
             </xpath>
+            <xpath expr="//field[@name='company_id'][@options]" position="before">
+                <field name="can_edit_company_id" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='company_id'][@options]" position="attributes">
+                <attribute name="readonly">not can_edit_company_id</attribute>
+            </xpath>
         </field>
     </record>
     <record id="product_template_form_view" model="ir.ui.view">

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -67,10 +67,10 @@
                         invisible="not show_physical_locations"/>
                 </group>
             </xpath>
-            <xpath expr="//field[@name='company_id'][@options]" position="before">
+            <xpath expr="//field[@name='categ_id']/following-sibling::field[@name='company_id']" position="before">
                 <field name="can_edit_company_id" invisible="1"/>
             </xpath>
-            <xpath expr="//field[@name='company_id'][@options]" position="attributes">
+            <xpath expr="//field[@name='categ_id']/following-sibling::field[@name='company_id']" position="attributes">
                 <attribute name="readonly">not can_edit_company_id</attribute>
             </xpath>
         </field>


### PR DESCRIPTION
Reemplaza al PR #1199, cerrado por el mismo problema de fondo que #1196/#1197 (ver [comentario de cierre en #1196](https://github.com/binaural-dev/odoo-venezuela/pull/1196) para el diagnóstico completo del bug de `tax_unit.available_date` y el ruido histórico de esas ramas — esta rama tenía 127 commits acumulados de meses de merges cruzados con `19.0`).

## Dependencia real con #1263 — a diferencia de #1265

A diferencia del PR #2 (#1265, tarea 79469), que resultó **independiente** de la tarea 79483, este PR **sí depende funcionalmente** de #1263: el commit propio `f03eb2aa8` (ahora `709f65c10` en esta rama) modifica directamente el método `_compute_quantities_dict_for_report` en `l10n_ve_stock/models/product_product.py`, reemplazando el hack `domain_quant_loc.value` que el commit de compatibilidad Odoo 19 de la tarea 79483 (`ca9e4bc90`, ya en #1263) había dejado. No es una dependencia de "necesitan estar ambos módulos instalados" — es una edición literal sobre líneas que solo existen porque #1263 las escribió primero.

Por eso la base de este PR es la rama de **#1263** (`maint-19.0_feat-ta_79483_block_referencia_interna`), no `maintenance-19.0` directamente. El diff mostrado acá son solo los 7 commits propios de la tarea 78876; cuando #1263 se mergee a `maintenance-19.0`, GitHub retarget-ea este PR automáticamente sin intervención manual.

## Tarea

project.task 78876 — "4. Trazabilidad en el cambio de sucursales de los productos V19": restringir quién puede cambiar la sucursal/compañía (`company_id`) del producto, y dejar trazabilidad del cambio.

References: https://binaural.odoo.com/odoo/action-341/78876

## Puntos cubiertos de las reviews de Christopher (#1199)

Verificado y confirmado directamente por el propio Christopher en su review de seguimiento (2026-09-01 20:54, tras los commits `f03eb2aa8`, `1265a0e0b`, `417e14925`, `826294c00`):

| Hallazgo | Severidad | Archivo | Estado |
|---|---|---|---|
| Dominio de reemplazo pierde exclusión origen/destino → infla `incoming_qty`/`outgoing_qty` | 🔴 | `models/product_product.py:211-218` | ✅ Corregido — `skip_in_progress=True` en `_get_domain_locations()` + test de transferencia interna |
| Restricción solo de UI, `write()` sin protección server-side | 🔴 | `models/product_template.py` `write()` | ✅ Corregido — guard con `AccessError` + `has_group()`, 3 tests (sin permiso / con permiso / sin `company_id`) |
| Compute sin `@api.depends_context('uid')` → caché compartida entre usuarios | 🟠 | `models/product_template.py:185` | ✅ Corregido |
| XPath frágil (usaba `options` como discriminador) | 🟡 | `views/products_views.xml:70` | ✅ Corregido — anclado a `categ_id/following-sibling` en vez de `[@options]` |
| Test con doble `flush` (pelea con el framework) | 🟡 | `tests/test_product_company_edit_restriction.py:19` | ✅ Corregido — `env.cr.precommit.run()` |
| Grupo `group_edit_product_company` sin string / campo sin `string=` | 🟡 | `models/product_template.py:65` | ✅ Corregido (parcial, ver pendiente #1 abajo) |

## Pendiente — no resuelto todavía en este PR

- 🟡 **Strings nuevos sin traducción `es_VE`** — `l10n_ve_stock/i18n/es_VE.po` no incluye los `msgid` nuevos (`can_edit_company_id`, el `name` del grupo `group_edit_product_company`, ni el mensaje de `AccessError` "No tienes permiso para cambiar la compañía de este producto"). Recomendación de Christopher: exportar/agregar esas entradas al `.po`.
- 🟡 **Grupo otorgado solo a `root`+`admin`, sin roles de negocio definidos** — `security/l10n_ve_stock_groups.xml:64-66`. El `user_ids` con `base.user_root`/`base.user_admin` evita que el fix quede "muerto" tras instalar, pero no define quién en el negocio (¿gerentes? ¿encargados de sucursal?) debería tener el permiso. Nota de diseño de Christopher, no bloqueante — requiere que alguien con acceso a la tarea 78876 confirme el alcance esperado.

## CI

Pendiente de correr — se valida en conjunto con #1263, del cual depende.
