### PR TITLE
19.0_feat-ta_80063 Tasa fallback matriz - ventas (rehecho, review con Saúl)

### DIFF
--- a/l10n_ve_rate/i18n/es_VE.po
+++ b/l10n_ve_rate/i18n/es_VE.po
@@ -99,3 +99,9 @@ msgstr ""
 msgid ""
 "The currency foreign must be different from the currency of the company"
 msgstr "La moneda alterna debería ser diferente a la moneda base"
+
+#. module: l10n_ve_rate
+#. odoo-python
+#: code:addons/l10n_ve_rate/models/res_currency_rate.py:0
+msgid "There is no rate for that date, please configure one."
+msgstr "No hay tasas en esa fecha, configúrela."

--- a/l10n_ve_rate/models/res_currency_rate.py
+++ b/l10n_ve_rate/models/res_currency_rate.py
@@ -32,6 +32,12 @@ class ResCurrencyRate(models.Model):
             The date of the rate that is gonna be searched for the given currency
             (foreign_currency_id).
 
+        If no rate is found at or before rate_date (e.g. rate_date is older than any
+        recorded rate for this currency/company), falls back to the oldest rate on
+        record instead of returning nothing - callers default a missing rate to 0
+        (see l10n_ve_sale's `_compute_rate`), and a stale-but-real historical rate is
+        always a better result than silently zeroing out the order's foreign amounts.
+
         Returns
         -------
         dict
@@ -45,6 +51,14 @@ class ResCurrencyRate(models.Model):
             ],
             order="name DESC", limit=1,
         )
+        if not rate:
+            rate = self.env["res.currency.rate"].search(
+                [
+                    ("currency_id", "=", foreign_currency_id),
+                    ("company_id", "=", self.env.company.id),
+                ],
+                order="name ASC", limit=1,
+            )
         if not rate:
             return {}
 

--- a/l10n_ve_rate/models/res_currency_rate.py
+++ b/l10n_ve_rate/models/res_currency_rate.py
@@ -9,7 +9,7 @@ class ResCurrencyRate(models.Model):
     _inherit = "res.currency.rate"
 
     @api.model
-    def compute_rate(self, foreign_currency_id, rate_date):
+    def compute_rate(self, foreign_currency_id, rate_date, raise_if_not_found=True):
         """
         Compute the rate and inverse rate for the given currency and date.
 
@@ -32,6 +32,17 @@ class ResCurrencyRate(models.Model):
         rate_date : date
             The date of the rate that is gonna be searched for the given currency
             (foreign_currency_id).
+        raise_if_not_found : bool
+            Whether the absence of a usable rate should raise UserError (default) or
+            return {} instead. Callers that only recompute a rate as a side effect of
+            an unrelated operation - e.g. a record's default value on create(), or a
+            create()-time chatter comparison against the current rate - must pass
+            False here: raising there would block that unrelated operation (creating
+            a sale/purchase order) entirely, for every user, whenever nobody has
+            loaded today's rate yet. Reserve the True default for paths where the
+            user is explicitly asking for the rate to be (re)computed and can act on
+            the error (e.g. sale.order._compute_rate(), triggered by a manual change
+            of date_order or foreign_currency_id).
 
         The search only ever looks backwards in time: it filters rates with
         name <= rate_date and takes the closest one (name DESC, limit 1). If there
@@ -42,17 +53,18 @@ class ResCurrencyRate(models.Model):
         Raises
         ------
         UserError
-            If there is no rate at or before rate_date for this currency/company -
-            i.e. rate_date is older than every recorded rate (or none exist at all).
-            This does not happen just because there is no rate for that exact date;
-            it only happens when there is no earlier rate to fall back to either. The
-            caller must configure one instead of silently operating with a missing/
-            zeroed rate.
+            If raise_if_not_found is True and there is no rate at or before rate_date
+            for this currency/company - i.e. rate_date is older than every recorded
+            rate (or none exist at all). This does not happen just because there is
+            no rate for that exact date; it only happens when there is no earlier
+            rate to fall back to either. The caller must configure one instead of
+            silently operating with a missing/zeroed rate.
 
         Returns
         -------
         dict
-            A dictionary with the rate and inverse rate for the given currency and date.
+            A dictionary with the rate and inverse rate for the given currency and
+            date, or {} if no rate was found and raise_if_not_found is False.
         """
         rate = self.env["res.currency.rate"].search(
             [
@@ -63,7 +75,9 @@ class ResCurrencyRate(models.Model):
             order="name DESC", limit=1,
         )
         if not rate:
-            raise UserError(_("There is no rate for that date, please configure one."))
+            if raise_if_not_found:
+                raise UserError(_("There is no rate for that date, please configure one."))
+            return {}
 
         vef_id = self.env.company.currency_id.id
         if vef_id == foreign_currency_id:

--- a/l10n_ve_rate/models/res_currency_rate.py
+++ b/l10n_ve_rate/models/res_currency_rate.py
@@ -1,4 +1,5 @@
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -32,11 +33,21 @@ class ResCurrencyRate(models.Model):
             The date of the rate that is gonna be searched for the given currency
             (foreign_currency_id).
 
-        If no rate is found at or before rate_date (e.g. rate_date is older than any
-        recorded rate for this currency/company), falls back to the oldest rate on
-        record instead of returning nothing - callers default a missing rate to 0
-        (see l10n_ve_sale's `_compute_rate`), and a stale-but-real historical rate is
-        always a better result than silently zeroing out the order's foreign amounts.
+        The search only ever looks backwards in time: it filters rates with
+        name <= rate_date and takes the closest one (name DESC, limit 1). If there
+        is no rate for rate_date itself but there are rates both before and after it,
+        the closest one *before* it is used - rates dated after rate_date are excluded
+        by the domain itself and never considered, regardless of how close they are.
+
+        Raises
+        ------
+        UserError
+            If there is no rate at or before rate_date for this currency/company -
+            i.e. rate_date is older than every recorded rate (or none exist at all).
+            This does not happen just because there is no rate for that exact date;
+            it only happens when there is no earlier rate to fall back to either. The
+            caller must configure one instead of silently operating with a missing/
+            zeroed rate.
 
         Returns
         -------
@@ -52,15 +63,7 @@ class ResCurrencyRate(models.Model):
             order="name DESC", limit=1,
         )
         if not rate:
-            rate = self.env["res.currency.rate"].search(
-                [
-                    ("currency_id", "=", foreign_currency_id),
-                    ("company_id", "=", self.env.company.id),
-                ],
-                order="name ASC", limit=1,
-            )
-        if not rate:
-            return {}
+            raise UserError(_("There is no rate for that date, please configure one."))
 
         vef_id = self.env.company.currency_id.id
         if vef_id == foreign_currency_id:

--- a/l10n_ve_rate/models/res_currency_rate.py
+++ b/l10n_ve_rate/models/res_currency_rate.py
@@ -9,7 +9,7 @@ class ResCurrencyRate(models.Model):
     _inherit = "res.currency.rate"
 
     @api.model
-    def compute_rate(self, foreign_currency_id, rate_date, raise_if_not_found=True):
+    def compute_rate(self, foreign_currency_id, rate_date, raise_if_not_found=False):
         """
         Compute the rate and inverse rate for the given currency and date.
 
@@ -33,16 +33,23 @@ class ResCurrencyRate(models.Model):
             The date of the rate that is gonna be searched for the given currency
             (foreign_currency_id).
         raise_if_not_found : bool
-            Whether the absence of a usable rate should raise UserError (default) or
-            return {} instead. Callers that only recompute a rate as a side effect of
-            an unrelated operation - e.g. a record's default value on create(), or a
-            create()-time chatter comparison against the current rate - must pass
-            False here: raising there would block that unrelated operation (creating
-            a sale/purchase order) entirely, for every user, whenever nobody has
-            loaded today's rate yet. Reserve the True default for paths where the
-            user is explicitly asking for the rate to be (re)computed and can act on
-            the error (e.g. sale.order._compute_rate(), triggered by a manual change
-            of date_order or foreign_currency_id).
+            Whether the absence of a usable rate should raise UserError, instead of
+            returning {}. Defaults to False: this method is reached from many
+            "automatic" paths that are not a deliberate user request for a rate -
+            record defaults on create(), a create()-time chatter comparison against
+            the current rate, and even the plain @api.depends compute for
+            foreign_rate/foreign_inverse_rate, which the ORM can re-trigger from
+            unrelated code simply reading that field (e.g. sale.order._prepare_invoice()
+            reading self.foreign_rate). None of those call sites can meaningfully
+            react to a hard error, so raising there would block unrelated operations
+            (creating an order, preparing an invoice) entirely, for every user,
+            whenever nobody has loaded today's rate yet.
+
+            raise_if_not_found=True only makes sense from a call site built
+            specifically to let the user act on the error in place (e.g. a
+            dedicated "recalculate rate" button or onchange) - no such call site
+            exists yet in this codebase; the parameter is kept available for one to
+            opt into deliberately, rather than baked into the shared compute chain.
 
         The search only ever looks backwards in time: it filters rates with
         name <= rate_date and takes the closest one (name DESC, limit 1). If there
@@ -57,8 +64,7 @@ class ResCurrencyRate(models.Model):
             for this currency/company - i.e. rate_date is older than every recorded
             rate (or none exist at all). This does not happen just because there is
             no rate for that exact date; it only happens when there is no earlier
-            rate to fall back to either. The caller must configure one instead of
-            silently operating with a missing/zeroed rate.
+            rate to fall back to either.
 
         Returns
         -------

--- a/l10n_ve_rate/tests/__init__.py
+++ b/l10n_ve_rate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_currency_rate

--- a/l10n_ve_rate/tests/test_res_currency_rate.py
+++ b/l10n_ve_rate/tests/test_res_currency_rate.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from odoo.exceptions import UserError
 from odoo.tests import TransactionCase, tagged
 
 
@@ -20,40 +21,35 @@ class TestComputeRateFallback(TransactionCase):
             "rate": rate_value,
         })
 
-    def test_compute_rate_returns_oldest_rate_when_date_predates_all_rates(self):
-        """If rate_date is older than any recorded rate for this currency/company,
-        compute_rate must fall back to the oldest rate on record instead of
-        returning {} - a stale rate is safer than the 0 that callers default to
-        when the dict comes back empty.
-        """
-        oldest = self._create_rate(date(2023, 1, 1), 40.0)
-        self._create_rate(date(2023, 6, 1), 45.0)
-
-        result = self.Rate.compute_rate(self.foreign_currency.id, date(2020, 1, 1))
-
-        self.assertTrue(result, "compute_rate should not return an empty dict.")
-        self.assertEqual(
-            result["foreign_rate"], oldest.inverse_company_rate,
-            "Should fall back to the oldest rate on record (USD uses inverse_company_rate).",
-        )
-
-    def test_compute_rate_still_prefers_closest_rate_at_or_before_date(self):
-        """The fallback must not interfere with the normal path: a date that
-        does have a matching rate at-or-before it should still resolve to the
-        closest one, not the oldest.
+    def test_compute_rate_raises_when_date_predates_all_rates(self):
+        """If rate_date is older than every recorded rate for this currency/
+        company, there is no earlier rate to fall back to, so compute_rate
+        must raise UserError instead of silently returning {} (which callers
+        default to a rate of 0).
         """
         self._create_rate(date(2023, 1, 1), 40.0)
-        closest = self._create_rate(date(2023, 6, 1), 45.0)
+        self._create_rate(date(2023, 6, 1), 45.0)
+
+        with self.assertRaises(UserError):
+            self.Rate.compute_rate(self.foreign_currency.id, date(2020, 1, 1))
+
+    def test_compute_rate_uses_closest_earlier_rate_ignoring_later_ones(self):
+        """With no rate for rate_date itself but rates both before and after
+        it, compute_rate must use the closest one *before* it - rates dated
+        after rate_date are excluded by the domain and must never be picked,
+        no matter how close they are.
+        """
+        self._create_rate(date(2023, 1, 1), 40.0)
+        closest_before = self._create_rate(date(2023, 6, 1), 45.0)
         self._create_rate(date(2023, 12, 1), 50.0)
 
         result = self.Rate.compute_rate(self.foreign_currency.id, date(2023, 8, 1))
 
-        self.assertEqual(result["foreign_rate"], closest.inverse_company_rate)
+        self.assertEqual(result["foreign_rate"], closest_before.inverse_company_rate)
 
-    def test_compute_rate_returns_empty_when_no_rate_exists_at_all(self):
-        """With no rate at all for this currency/company, both the primary
-        search and the fallback search find nothing, so compute_rate still
-        returns {} - this is not a case the fallback is meant to cover.
+    def test_compute_rate_raises_when_no_rate_exists_at_all(self):
+        """With no rate at all for this currency/company, there is nothing
+        at or before rate_date to use, so compute_rate must raise UserError.
         """
-        result = self.Rate.compute_rate(self.foreign_currency.id, date(2023, 1, 1))
-        self.assertEqual(result, {})
+        with self.assertRaises(UserError):
+            self.Rate.compute_rate(self.foreign_currency.id, date(2023, 1, 1))

--- a/l10n_ve_rate/tests/test_res_currency_rate.py
+++ b/l10n_ve_rate/tests/test_res_currency_rate.py
@@ -1,0 +1,59 @@
+from datetime import date
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "l10n_ve_rate")
+class TestComputeRateFallback(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.company
+        self.company.currency_id = self.env.ref("base.VEF")
+        self.foreign_currency = self.env.ref("base.USD")
+        self.Rate = self.env["res.currency.rate"]
+
+    def _create_rate(self, day, rate_value):
+        return self.Rate.create({
+            "currency_id": self.foreign_currency.id,
+            "company_id": self.company.id,
+            "name": day,
+            "rate": rate_value,
+        })
+
+    def test_compute_rate_returns_oldest_rate_when_date_predates_all_rates(self):
+        """If rate_date is older than any recorded rate for this currency/company,
+        compute_rate must fall back to the oldest rate on record instead of
+        returning {} - a stale rate is safer than the 0 that callers default to
+        when the dict comes back empty.
+        """
+        oldest = self._create_rate(date(2023, 1, 1), 40.0)
+        self._create_rate(date(2023, 6, 1), 45.0)
+
+        result = self.Rate.compute_rate(self.foreign_currency.id, date(2020, 1, 1))
+
+        self.assertTrue(result, "compute_rate should not return an empty dict.")
+        self.assertEqual(
+            result["foreign_rate"], oldest.inverse_company_rate,
+            "Should fall back to the oldest rate on record (USD uses inverse_company_rate).",
+        )
+
+    def test_compute_rate_still_prefers_closest_rate_at_or_before_date(self):
+        """The fallback must not interfere with the normal path: a date that
+        does have a matching rate at-or-before it should still resolve to the
+        closest one, not the oldest.
+        """
+        self._create_rate(date(2023, 1, 1), 40.0)
+        closest = self._create_rate(date(2023, 6, 1), 45.0)
+        self._create_rate(date(2023, 12, 1), 50.0)
+
+        result = self.Rate.compute_rate(self.foreign_currency.id, date(2023, 8, 1))
+
+        self.assertEqual(result["foreign_rate"], closest.inverse_company_rate)
+
+    def test_compute_rate_returns_empty_when_no_rate_exists_at_all(self):
+        """With no rate at all for this currency/company, both the primary
+        search and the fallback search find nothing, so compute_rate still
+        returns {} - this is not a case the fallback is meant to cover.
+        """
+        result = self.Rate.compute_rate(self.foreign_currency.id, date(2023, 1, 1))
+        self.assertEqual(result, {})

--- a/l10n_ve_rate/tests/test_res_currency_rate.py
+++ b/l10n_ve_rate/tests/test_res_currency_rate.py
@@ -21,17 +21,33 @@ class TestComputeRateFallback(TransactionCase):
             "rate": rate_value,
         })
 
-    def test_compute_rate_raises_when_date_predates_all_rates(self):
-        """If rate_date is older than every recorded rate for this currency/
-        company, there is no earlier rate to fall back to, so compute_rate
-        must raise UserError instead of silently returning {} (which callers
-        default to a rate of 0).
+    def test_compute_rate_returns_empty_by_default_when_date_predates_all_rates(self):
+        """By default (raise_if_not_found=False), if rate_date is older than
+        every recorded rate for this currency/company, compute_rate returns
+        {} instead of raising - this is the path taken by automatic callers
+        (record defaults, create()-time comparisons, and the ORM re-triggering
+        a compute simply because something read the field), none of which can
+        meaningfully react to a hard error.
+        """
+        self._create_rate(date(2023, 1, 1), 40.0)
+        self._create_rate(date(2023, 6, 1), 45.0)
+
+        result = self.Rate.compute_rate(self.foreign_currency.id, date(2020, 1, 1))
+
+        self.assertEqual(result, {})
+
+    def test_compute_rate_raises_when_explicitly_requested_and_date_predates_all_rates(self):
+        """With raise_if_not_found=True, the same case above must raise
+        UserError instead - reserved for a future call site built
+        specifically to let the user act on the error in place.
         """
         self._create_rate(date(2023, 1, 1), 40.0)
         self._create_rate(date(2023, 6, 1), 45.0)
 
         with self.assertRaises(UserError):
-            self.Rate.compute_rate(self.foreign_currency.id, date(2020, 1, 1))
+            self.Rate.compute_rate(
+                self.foreign_currency.id, date(2020, 1, 1), raise_if_not_found=True,
+            )
 
     def test_compute_rate_uses_closest_earlier_rate_ignoring_later_ones(self):
         """With no rate for rate_date itself but rates both before and after
@@ -47,9 +63,9 @@ class TestComputeRateFallback(TransactionCase):
 
         self.assertEqual(result["foreign_rate"], closest_before.inverse_company_rate)
 
-    def test_compute_rate_raises_when_no_rate_exists_at_all(self):
+    def test_compute_rate_returns_empty_by_default_when_no_rate_exists_at_all(self):
         """With no rate at all for this currency/company, there is nothing
-        at or before rate_date to use, so compute_rate must raise UserError.
+        at or before rate_date to use; by default compute_rate returns {}.
         """
-        with self.assertRaises(UserError):
-            self.Rate.compute_rate(self.foreign_currency.id, date(2023, 1, 1))
+        result = self.Rate.compute_rate(self.foreign_currency.id, date(2023, 1, 1))
+        self.assertEqual(result, {})

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -50,7 +50,6 @@ class SaleOrder(models.Model):
         rate_values = self.env["res.currency.rate"].compute_rate(
             self.env.company.foreign_currency_id.id or self.env.ref("base.VEF").id,
             self.date_order or fields.Date.today(),
-            raise_if_not_found=False,
         )
         return rate_values.get("foreign_rate", 0)
 
@@ -66,7 +65,6 @@ class SaleOrder(models.Model):
         rate_values = self.env["res.currency.rate"].compute_rate(
             self.env.company.foreign_currency_id.id or self.env.ref("base.VEF").id,
             self.date_order or fields.Date.today(),
-            raise_if_not_found=False,
         )
         return rate_values.get("foreign_inverse_rate", 0)
 
@@ -532,7 +530,6 @@ class SaleOrder(models.Model):
             rate_values = Rate.compute_rate(
                 sale.foreign_currency_id.id,
                 sale.date_order or fields.Date.today(),
-                raise_if_not_found=False,
             )
             last_foreign_rate = rate_values.get("foreign_rate", 0)
             if sale.manually_set_rate and sale.foreign_rate != last_foreign_rate:

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -50,6 +50,7 @@ class SaleOrder(models.Model):
         rate_values = self.env["res.currency.rate"].compute_rate(
             self.env.company.foreign_currency_id.id or self.env.ref("base.VEF").id,
             self.date_order or fields.Date.today(),
+            raise_if_not_found=False,
         )
         return rate_values.get("foreign_rate", 0)
 
@@ -65,6 +66,7 @@ class SaleOrder(models.Model):
         rate_values = self.env["res.currency.rate"].compute_rate(
             self.env.company.foreign_currency_id.id or self.env.ref("base.VEF").id,
             self.date_order or fields.Date.today(),
+            raise_if_not_found=False,
         )
         return rate_values.get("foreign_inverse_rate", 0)
 
@@ -528,7 +530,9 @@ class SaleOrder(models.Model):
         for sale in res:
             Rate = self.env["res.currency.rate"]
             rate_values = Rate.compute_rate(
-                sale.foreign_currency_id.id, sale.date_order or fields.Date.today()
+                sale.foreign_currency_id.id,
+                sale.date_order or fields.Date.today(),
+                raise_if_not_found=False,
             )
             last_foreign_rate = rate_values.get("foreign_rate", 0)
             if sale.manually_set_rate and sale.foreign_rate != last_foreign_rate:

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -413,6 +413,11 @@ class SaleOrder(models.Model):
             # de llegar al or, asi que se comprueba primero.
             rate_date = sale.date_order.date() if sale.date_order else fields.Date.today()
 
+            # TODO(website): confirmar con el responsable de la vertical de
+            # website/e-commerce si esta condicion sigue siendo necesaria y si
+            # el comportamiento (congelar la tasa de ordenes con website_id)
+            # es el correcto. No se toca en la tarea 80063; queda como
+            # oportunidad de analisis para otro momento.
             if (
                 sale.manually_set_rate
                 or "website_id" in sale._fields

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -692,6 +692,20 @@ class SaleOrder(models.Model):
 
                     order._block_valid_confirm()
 
+            # A la confirmacion (accion explicita del usuario, no un compute
+            # automatico) le corresponde reaccionar de una vez a la falta de
+            # tasa, en vez de dejar pasar la orden con foreign_rate en 0 en
+            # silencio -- exactamente el punto de entrada que el docstring de
+            # compute_rate() reserva para raise_if_not_found=True.
+            if (
+                order.foreign_currency_id
+                and not order.manually_set_rate
+                and float_is_zero(order.foreign_rate, precision_rounding=order.currency_id.rounding)
+            ):
+                rate_date = order.date_order.date() if order.date_order else fields.Date.today()
+                self.env["res.currency.rate"].compute_rate(
+                    order.foreign_currency_id.id, rate_date, raise_if_not_found=True
+                )
 
         res = super().action_confirm()
         for sale in self:

--- a/l10n_ve_sale/tests/__init__.py
+++ b/l10n_ve_sale/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_action_confirm
 from . import test_ta74966_currency
 from . import test_ta80647_invoice_currency
 from . import test_documented_behaviour
+from . import test_action_confirm_requires_rate

--- a/l10n_ve_sale/tests/test_action_confirm_requires_rate.py
+++ b/l10n_ve_sale/tests/test_action_confirm_requires_rate.py
@@ -1,0 +1,71 @@
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+from odoo import fields
+
+
+@tagged("post_install", "-at_install", "l10n_ve_sale")
+class TestActionConfirmRequiresRate(TransactionCase):
+    """action_confirm() is a user-triggered action (not an automatic
+    default/compute path), so it's the one place where compute_rate()'s
+    raise_if_not_found=True is safe to use - see the docstring of
+    compute_rate() for why every automatic caller passes False instead.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.company
+        self.ves = self.env.ref("base.VEF")
+        self.usd = self.env.ref("base.USD")
+        self.company.currency_id = self.ves
+        self.company.foreign_currency_id = self.usd
+        self.partner = self.env["res.partner"].create({"name": "Test Partner"})
+        self.product = self.env["product.product"].create({
+            "name": "Test Product",
+            "list_price": 100.0,
+        })
+
+    def _create_order(self, date_order):
+        so = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+            "date_order": date_order,
+        })
+        self.env["sale.order.line"].create({
+            "order_id": so.id,
+            "product_id": self.product.id,
+            "product_uom_qty": 1,
+            "price_unit": 100.0,
+        })
+        return so
+
+    def test_confirm_without_rate_raises(self):
+        """No USD rate exists for any date - the order is created with
+        foreign_rate at 0 (compute_rate() stays silent, as always), but
+        confirming it must raise instead of letting it through silently."""
+        so = self._create_order(fields.Date.today())
+        self.assertEqual(so.foreign_rate, 0.0)
+
+        with self.assertRaises(UserError):
+            so.action_confirm()
+
+    def test_confirm_with_rate_is_allowed(self):
+        self.env["res.currency.rate"].create({
+            "currency_id": self.usd.id,
+            "company_id": self.company.id,
+            "name": fields.Date.today(),
+            "rate": 1.0 / 380.0,
+        })
+        so = self._create_order(fields.Date.today())
+        self.assertNotEqual(so.foreign_rate, 0.0)
+
+        so.action_confirm()
+        self.assertEqual(so.state, "sale")
+
+    def test_confirm_with_manually_set_rate_is_allowed(self):
+        """manually_set_rate freezes the rate from outside compute_rate()
+        entirely, so a missing currency-rate record must not block
+        confirmation in that case."""
+        so = self._create_order(fields.Date.today())
+        so.write({"manually_set_rate": True, "foreign_rate": 123.0})
+
+        so.action_confirm()
+        self.assertEqual(so.state, "sale")

--- a/openspec/specs/l10n_ve_rate/spec.md
+++ b/openspec/specs/l10n_ve_rate/spec.md
@@ -40,17 +40,24 @@ El sistema DEBE (MUST) impedir modificar `foreign_currency_id` de una compañía
 
 ### Requirement: Cálculo de tasa y tasa inversa por fecha
 
-El método `compute_rate(foreign_currency_id, rate_date)` de `res.currency.rate` DEBE (MUST) devolver la tasa (`foreign_rate`) y la tasa inversa (`foreign_inverse_rate`) tomando el registro de tasa más reciente cuya fecha sea menor o igual a `rate_date` para esa moneda y la compañía activa. Si la moneda solicitada es la moneda principal de la compañía, ambos valores son `company_rate`; en caso contrario `foreign_rate` es `inverse_company_rate` y `foreign_inverse_rate` es `company_rate`. La tasa inversa es el factor por el que se multiplican los montos para obtener su equivalente en moneda alterna.
+El método `compute_rate(foreign_currency_id, rate_date, raise_if_not_found=False)` de `res.currency.rate` DEBE (MUST) devolver la tasa (`foreign_rate`) y la tasa inversa (`foreign_inverse_rate`) tomando el registro de tasa más reciente cuya fecha sea menor o igual a `rate_date` para esa moneda y la compañía activa. Si la moneda solicitada es la moneda principal de la compañía, ambos valores son `company_rate`; en caso contrario `foreign_rate` es `inverse_company_rate` y `foreign_inverse_rate` es `company_rate`. La tasa inversa es el factor por el que se multiplican los montos para obtener su equivalente en moneda alterna. Solo considera tasas con fecha `<=` `rate_date`: si existe una tasa exacta para esa fecha o una anterior, se usa la más cercana hacia atrás; las tasas con fecha posterior a `rate_date` quedan excluidas y nunca se consideran, sin importar qué tan cercanas estén.
 
 #### Scenario: Moneda alterna distinta a la de la compañía
 
 - **WHEN** se invoca `compute_rate` con una moneda distinta a la moneda principal de la compañía y existe una tasa registrada en o antes de la fecha dada
 - **THEN** devuelve `foreign_rate = inverse_company_rate` y `foreign_inverse_rate = company_rate` de la tasa más reciente aplicable
 
-#### Scenario: Sin tasa registrada
+#### Scenario: Sin tasa registrada (comportamiento por defecto)
 
-- **WHEN** se invoca `compute_rate` y no existe ninguna tasa registrada en o antes de la fecha dada para esa moneda y compañía
+- **WHEN** se invoca `compute_rate` sin `raise_if_not_found` (o con `raise_if_not_found=False`) y no existe ninguna tasa registrada en o antes de la fecha dada para esa moneda y compañía
 - **THEN** devuelve un diccionario vacío
+
+#### Scenario: Sin tasa registrada, con `raise_if_not_found=True`
+
+- **WHEN** se invoca `compute_rate` con `raise_if_not_found=True` y no existe ninguna tasa registrada en o antes de la fecha dada para esa moneda y compañía
+- **THEN** lanza `UserError` indicando que no hay tasa configurada para esa fecha
+
+`raise_if_not_found=True` está reservado para un punto de entrada que se construya específicamente para que el usuario reaccione al error en el momento (por ejemplo, un botón dedicado de recálculo). Ningún llamador actual del código pasa `True`: los `default` de creación, las comparaciones de `create()` para el chatter, y el propio compute explícito de `foreign_rate`/`foreign_inverse_rate` (que el ORM puede disparar por su cuenta con solo leer el campo) usan el valor por defecto (`False`), porque ninguno de esos puntos puede reaccionar de forma útil a un error duro sin bloquear una operación no relacionada (crear la orden, preparar la factura).
 
 ### Requirement: Inversión de tasa solo con moneda alterna USD
 

--- a/openspec/specs/l10n_ve_sale/spec.md
+++ b/openspec/specs/l10n_ve_sale/spec.md
@@ -159,6 +159,20 @@ La acción `action_confirm` DEBE (MUST) rechazar con error la confirmación de u
 - **WHEN** se confirma una orden que solo tiene secciones o notas
 - **THEN** se lanza un error indicando que debe agregarse un producto
 
+### Requirement: Confirmación requiere tasa de moneda alterna
+
+Al confirmar (`action_confirm`), si la orden tiene moneda alterna (`foreign_currency_id`), no tiene `manually_set_rate` activo, y `foreign_rate` es cero, el sistema DEBE (MUST) invocar `compute_rate` con `raise_if_not_found=True`, bloqueando la confirmación con un `UserError` en vez de dejar pasar la orden con `foreign_rate` en cero. Es el único punto del módulo donde se usa `raise_if_not_found=True`: a diferencia de los defaults y del propio `_compute_rate`, `action_confirm` es una acción explícita del usuario, no un camino automático que un error ahí pueda romper.
+
+#### Scenario: Confirmación sin tasa configurada
+
+- **WHEN** se confirma una orden con moneda alterna, sin `manually_set_rate`, y no existe ninguna tasa registrada para su fecha
+- **THEN** se lanza un `UserError` y la orden no se confirma
+
+#### Scenario: Confirmación con tasa manual en cero
+
+- **WHEN** se confirma una orden con `manually_set_rate` activo, aunque `foreign_rate` sea cero
+- **THEN** la confirmación no se bloquea por este requirement — la tasa es responsabilidad explícita del usuario
+
 ### Requirement: Bloqueo de venta sin existencias
 
 Cuando la compañía tiene activo `not_allow_sell_products` (configurable desde ajustes) y no se pasa el contexto `skip_not_allow_sell_products_validation`, `action_confirm` DEBE (MUST) impedir confirmar órdenes con líneas de productos almacenables de tipo `consu` cuya cantidad demandada supere `qty_available`.


### PR DESCRIPTION
@SaulOrte

Reemplaza al PR #1198, cerrado (ver comentario de cierre ahí para el detalle). Rehecho limpio desde `maintenance-19.0`, con los cambios quirúrgicos que Saúl indicó tras revisar el código junto a él — sin el resto de la lógica que traía la rama vieja del PR original (fallback por compañía padre/matriz, y los conflictos con la tarea TA-74966), que se descarta por completo: `maintenance-19.0` ya resuelve lo necesario, solo faltaba este ajuste puntual.

## Tarea

project.task 80063 — "3. Tasa fallback matriz" (lado ventas). Ver PR hermano en compras: `integra-addons` (ver link abajo, ya mergeado).

References: https://binaural.odoo.com/odoo/action-341/80063

## Cambio (actualizado tras la review de Pastor)

**Nota**: la sección "Cambio" original de este body describía un fallback ("devuelve la tasa más antigua registrada") que ya no existe en el código — quedó de una versión intermedia del historial de commits, antes de que Saúl pidiera reemplazarlo por `UserError` y luego eso se volviera opcional. Pastor lo señaló como bloqueante ("el body describe una implementación que no está en el diff"). Esta sección reemplaza esa descripción por el comportamiento real.

`l10n_ve_rate/models/res_currency_rate.py::compute_rate(foreign_currency_id, rate_date, raise_if_not_found=False)` — cuando no existe ninguna tasa con fecha `<=` `rate_date`:
- Por defecto (`raise_if_not_found=False`, todos los caminos automáticos: defaults de creación, comparación de `create()` para el chatter, y el propio `@api.depends` de `foreign_rate`/`foreign_inverse_rate`) devuelve `{}`, silenciosamente — ninguno de esos caminos puede reaccionar de forma útil a un error duro sin bloquear una operación no relacionada.
- Con `raise_if_not_found=True`, lanza `UserError("No hay tasas en esa fecha, configúrela.")`.

**El problema real que señaló Pastor**: hasta este commit, ningún llamador de la organización pasaba `raise_if_not_found=True` — el parámetro existía pero no tenía efecto, y el bug que motivó la tarea (orden confirmada con `foreign_rate` en 0) seguía intacto.

## Fix: `action_confirm` ahora exige la tasa

Se agrega la validación en `sale.order.action_confirm()` (commit nuevo): si la orden tiene moneda alterna, no tiene `manually_set_rate` activo, y `foreign_rate` sigue en cero al momento de confirmar, se invoca `compute_rate(..., raise_if_not_found=True)`, bloqueando la confirmación con el `UserError` en vez de dejarla pasar en silencio.

**Por qué acá y no en otro lado**: `action_confirm` es una acción explícita del usuario (un clic en "Confirmar"), no un camino automático — es exactamente el tipo de punto de entrada que el docstring de `compute_rate` reserva para `raise_if_not_found=True`. No se toca `_compute_rate()`, los defaults, ni `_prepare_invoice()`: todos esos siguen siendo silenciosos, tal como deben serlo (un error ahí bloquearía crear la orden o facturar por una causa no relacionada).

Con esto, el parámetro deja de ser código muerto y el bug real (tasa en 0 al confirmar) queda resuelto con el mínimo cambio posible: ~10 líneas en un método que ya existía, sin botones ni vistas nuevas.

## Documentación pendiente (no se toca en este PR)

`l10n_ve_sale/models/sale_order.py::_compute_rate` tiene una condición que congela el recálculo de tasa para órdenes con `website_id` (e-commerce). No es parte del alcance de esta tarea — se deja como comentario `TODO` para que el responsable de la vertical de website confirme si sigue siendo necesaria y si el comportamiento es el correcto.

## Trazabilidad

- PR anterior (cerrado, no aplican sus correcciones porque el PR fue cerrado): #1198
- PR hermano (compras, integra-addons, ya mergeado): https://github.com/binaural-dev/integra-addons/pull/2725

@pastor-binaural
