### PR TITLE
[ADD] l10n_ve_bcv_sync: opcion de token unico para varias companias i…

### DIFF
--- a/l10n_ve_bcv_sync/__manifest__.py
+++ b/l10n_ve_bcv_sync/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.0.0.0",
+    "version": "17.0.0.0.1",
     # Depends on l10n_ve_currency_rate_live only to reuse the
     # `can_update_habil_days` field on res.company. The date-validity
     # decision itself is fully self-contained in this module (see

--- a/l10n_ve_bcv_sync/controllers/bcv_sync.py
+++ b/l10n_ve_bcv_sync/controllers/bcv_sync.py
@@ -64,8 +64,16 @@ class BcvSyncController(http.Controller):
                 400,
             )
 
+        # Normally just this token's own company; if it has
+        # bcv_sync_apply_to_all_companies enabled, every root company in
+        # the database (see res.company._bcv_sync_resolve_target_companies).
+        target_companies = company._bcv_sync_resolve_target_companies()
+
         try:
-            summary = company._bcv_sync_process_tasas(payload["tasas"])
+            results = [
+                (target, target._bcv_sync_process_tasas(payload["tasas"]))
+                for target in target_companies
+            ]
         except Exception:
             _logger.exception(
                 "BCV Sync: unexpected error processing the payload for %s",
@@ -75,14 +83,38 @@ class BcvSyncController(http.Controller):
                 {"ok": False, "error": "internal error processing the payload"}, 500
             )
 
-        _logger.info(
-            "BCV Sync: payload processed for %s -- applied=%s skipped=%s",
-            company.display_name,
-            summary["applied"],
-            summary["skipped"],
-        )
+        for target, summary in results:
+            _logger.info(
+                "BCV Sync: payload processed for %s -- applied=%s skipped=%s",
+                target.display_name,
+                summary["applied"],
+                summary["skipped"],
+            )
+
+        # Single-company response shape unchanged on purpose (matches
+        # ODOO_INTEGRATION.md and keeps the vast majority of tokens, which
+        # don't fan out, on the exact same contract as before). The
+        # per-company breakdown only appears when this token actually
+        # applies to more than one company.
+        if len(results) == 1:
+            _, summary = results[0]
+            return self._json_response(
+                {"ok": True, "applied": summary["applied"], "skipped": summary["skipped"]},
+                200,
+            )
+
         return self._json_response(
-            {"ok": True, "applied": summary["applied"], "skipped": summary["skipped"]},
+            {
+                "ok": True,
+                "companies": [
+                    {
+                        "company": target.display_name,
+                        "applied": summary["applied"],
+                        "skipped": summary["skipped"],
+                    }
+                    for target, summary in results
+                ],
+            },
             200,
         )
 

--- a/l10n_ve_bcv_sync/models/res_company.py
+++ b/l10n_ve_bcv_sync/models/res_company.py
@@ -32,6 +32,22 @@ class ResCompany(models.Model):
             "alli para el cliente/URL de esta compania."
         ),
     )
+    bcv_sync_apply_to_all_companies = fields.Boolean(
+        string="Aplicar a todas las companias",
+        default=False,
+        groups="base.group_system",
+        help=(
+            "Si esta activo, este token deja de aplicar la tasa solo a esta "
+            "compania -- se aplica a TODAS las companias raiz activas de "
+            "esta base de datos (util cuando un mismo cliente de BCV Sync "
+            "administra varias companias independientes y no quiere un "
+            "token/entrada de panel por cada una). Activarlo amplia el "
+            "radio de exposicion de este token: si se filtra, quien lo "
+            "tenga puede escribir la tasa de todas las companias, no solo "
+            "de esta. Tratalo con el mismo cuidado que una credencial de "
+            "administrador global, no como una credencial por cliente."
+        ),
+    )
 
     @api.model
     def _bcv_sync_get_company_by_token(self, token):
@@ -52,6 +68,16 @@ class ResCompany(models.Model):
             if hmac.compare_digest(token, company.bcv_sync_api_key or ""):
                 match = company
         return match
+
+    def _bcv_sync_resolve_target_companies(self):
+        """Returns the companies this token's payload should be applied
+        to: just this company's root by default, or every active root
+        company in the database if ``bcv_sync_apply_to_all_companies`` is
+        enabled (opt-in fan-out, see that field's help text)."""
+        self.ensure_one()
+        if self.bcv_sync_apply_to_all_companies:
+            return self.env["res.company"].sudo().search([("parent_id", "=", False)])
+        return self.root_id
 
     def _bcv_sync_process_tasas(self, tasas):
         """Idempotently applies the ``tasas`` entries received from BCV

--- a/l10n_ve_bcv_sync/models/res_config_settings.py
+++ b/l10n_ve_bcv_sync/models/res_config_settings.py
@@ -9,6 +9,9 @@ class ResConfigSettings(models.TransientModel):
     bcv_sync_api_key = fields.Char(
         related="company_id.bcv_sync_api_key", readonly=False
     )
+    bcv_sync_apply_to_all_companies = fields.Boolean(
+        related="company_id.bcv_sync_apply_to_all_companies", readonly=False
+    )
 
     def action_generate_bcv_sync_api_key(self):
         """Generates a random token, assigns it directly to

--- a/l10n_ve_bcv_sync/tests/test_bcv_sync_controller.py
+++ b/l10n_ve_bcv_sync/tests/test_bcv_sync_controller.py
@@ -129,3 +129,28 @@ class TestBcvSyncController(HttpCase):
         data = response.json()
         self.assertEqual(data["applied"], ["USD"])
         self.assertEqual(data["skipped"], ["XYZ"])
+
+    def test_fan_out_token_returns_a_per_company_breakdown(self):
+        other_company = self.env["res.company"].create(
+            {"name": "Other Co", "currency_id": self.vef.id}
+        )
+        self.company.sudo().bcv_sync_apply_to_all_companies = True
+        today = fields.Date.context_today(self.company)
+
+        response = self._post(
+            {
+                "tasas": [
+                    {"moneda": "USD", "valor": "791.6667", "fecha_valor": str(today)}
+                ]
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["ok"])
+        self.assertNotIn("applied", data)
+        companies_in_response = {entry["company"] for entry in data["companies"]}
+        self.assertIn(self.company.display_name, companies_in_response)
+        self.assertIn(other_company.display_name, companies_in_response)
+        for entry in data["companies"]:
+            self.assertEqual(entry["applied"], ["USD"])

--- a/l10n_ve_bcv_sync/tests/test_res_company_bcv_sync.py
+++ b/l10n_ve_bcv_sync/tests/test_res_company_bcv_sync.py
@@ -346,3 +346,45 @@ class TestBcvSyncResCompany(TransactionCase):
         self.assertEqual(found, self.company)
         self.assertFalse(not_found)
         self.assertFalse(empty)
+
+    def test_resolve_target_companies_defaults_to_self_only(self):
+        other_company = self.env["res.company"].create({"name": "Other Co"})
+
+        targets = self.company._bcv_sync_resolve_target_companies()
+
+        self.assertEqual(targets, self.company)
+        self.assertNotIn(other_company, targets)
+
+    def test_resolve_target_companies_fans_out_when_enabled(self):
+        # Independent companies (no parent/child relation) -- the real
+        # case this flag exists for: one client of BCV Sync administers
+        # several unrelated companies in the same database.
+        other_company = self.env["res.company"].create({"name": "Other Co"})
+        self.company.bcv_sync_apply_to_all_companies = True
+
+        targets = self.company._bcv_sync_resolve_target_companies()
+
+        self.assertIn(self.company, targets)
+        self.assertIn(other_company, targets)
+
+    def test_fan_out_applies_the_payload_to_every_root_company(self):
+        other_company = self.env["res.company"].create(
+            {"name": "Other Co", "currency_id": self.vef.id}
+        )
+        self.company.bcv_sync_apply_to_all_companies = True
+        today = fields.Date.context_today(self.company)
+        tasas = [{"moneda": "USD", "valor": "791.6667", "fecha_valor": str(today)}]
+
+        for target in self.company._bcv_sync_resolve_target_companies():
+            summary = target._bcv_sync_process_tasas(tasas)
+            self.assertEqual(summary["applied"], ["USD"])
+
+        for company in (self.company, other_company):
+            rate = self.Rate.search(
+                [
+                    ("currency_id", "=", self.usd.id),
+                    ("company_id", "=", company.id),
+                    ("name", "=", today),
+                ]
+            )
+            self.assertEqual(len(rate), 1)

--- a/l10n_ve_bcv_sync/views/res_config_settings.xml
+++ b/l10n_ve_bcv_sync/views/res_config_settings.xml
@@ -26,6 +26,17 @@
                                 string="Generar Token"
                             />
                         </div>
+                        <div class="mt-2">
+                            <field name="bcv_sync_apply_to_all_companies" class="oe_inline" />
+                            <label for="bcv_sync_apply_to_all_companies" string="Aplicar este token a todas las compañías" />
+                            <div class="alert alert-warning mt-1" role="alert">
+                                Amplía el alcance de este token a TODAS las compañías raíz
+                                activas de esta base de datos, no solo esta. Úsalo solo si
+                                administrás varias compañías independientes con un mismo
+                                cliente de BCV Sync y tratás este token con el mismo cuidado
+                                que una credencial de administrador global.
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
…ndependientes

Un cliente con varias companias independientes (sin relacion padre/hijo) en la misma base de datos necesitaba un token y una entrada de panel de BCV Sync por cada una -- tedioso a partir de 3-4 companias.

Se agrega el campo opt-in bcv_sync_apply_to_all_companies (default False, groups=base.group_system). Cuando esta activo, ese token deja de resolver solo a su propia compania: _bcv_sync_resolve_target_companies() devuelve todas las companias raiz activas de la base de datos, y el controller aplica el payload a cada una por separado, agregando el resumen de aplicadas/omitidas por compania.

El shape de la respuesta para el caso normal (token de una sola compania, la inmensa mayoria) no cambia -- sigue siendo {"applied": [...], "skipped": [...]} tal cual. Solo cuando el token efectivamente resuelve a mas de una compania la respuesta pasa a {"companies": [{"company": ..., "applied": [...], "skipped": [...]}, ...]}. ODOO_INTEGRATION.md no necesito cambios porque ya documenta que el body de respuesta no tiene schema exigido.

Trade-off de seguridad deliberado, documentado en el help del campo y en la vista: activar esto amplia el radio de exposicion de ese token a todas las companias, no solo una -- por eso queda desactivado por default y restringido a group_system, no es el comportamiento por defecto de ningun token nuevo.

3 tests nuevos: default (solo la propia compania), fan-out cuando se activa el flag, y que efectivamente aplica el payload contra cada compania raiz (creando una segunda compania de verdad y verificando que ambas terminan con la tasa guardada). Mas un test HTTP del nuevo shape de respuesta con el desglose por compania.

https://binaural.odoo.com/odoo/action-341/80569