### PR TITLE
FIX#14986 l10n_ve_accountant: evitar que se renombren facturas de pro…

### DIFF
--- a/l10n_ve_accountant/__init__.py
+++ b/l10n_ve_accountant/__init__.py
@@ -1,6 +1,3 @@
-from odoo import _
-from odoo.exceptions import UserError
-
 from . import models
 from . import wizard
 from . import report
@@ -9,63 +6,8 @@ old_module = "binaural_accountant"
 new_module = "l10n_ve_accountant"
 
 def pre_init_hook(env):
-    _check_account_move_partner_consistency(env.cr)
     reassign_account_data_ids(env.cr)
     reassign_tax_unit_data_ids(env.cr)
-
-def _check_account_move_partner_consistency(cr):
-    """Aborta la instalación si existen facturas de proveedor posteadas
-    con el mismo nombre para el mismo proveedor/diario/compañía.
-
-    El _auto_init de account_move.py necesita que estos grupos no
-    existan para poder crear el índice único account_move_unique_name_ve
-    sin tocar ningún dato. Si aquí se detectan, casi siempre es porque
-    la migración de datos de proveedores (binaural_accountant ->
-    l10n_ve_accountant) todavía no terminó de asignar el partner_id
-    definitivo -- instalar en ese estado puede hacer que el índice no
-    se cree (queda solo un warning en el log, sin daño a los datos,
-    pero conviene resolverlo antes en vez de dejarlo pasar en silencio).
-    """
-    cr.execute(
-        """
-        SELECT rp.name, am.journal_id, am.name, COUNT(*)
-        FROM account_move am
-        LEFT JOIN res_partner rp ON rp.id = am.partner_id
-        WHERE am.state = 'posted'
-        AND am.name != '/'
-        AND am.move_type IN ('in_invoice', 'in_refund', 'in_receipt')
-        GROUP BY am.partner_id, am.journal_id, am.company_id, am.name, rp.name
-        HAVING COUNT(*) > 1
-        ORDER BY 4 DESC
-        """
-    )
-    collisions = cr.fetchall()
-    if not collisions:
-        return
-
-    detail = "\n".join(
-        "  - Proveedor: %s | Diario: %s | Número: %s | Repeticiones: %s"
-        % (partner_name or "(sin proveedor)", journal_id, name, count)
-        for partner_name, journal_id, name, count in collisions[:20]
-    )
-    more = ""
-    if len(collisions) > 20:
-        more = _("\n  ... y %d grupo(s) más.") % (len(collisions) - 20)
-
-    raise UserError(
-        _(
-            "No se puede instalar l10n_ve_accountant: se detectaron %(count)d "
-            "grupo(s) de facturas de proveedor posteadas con el mismo número "
-            "para el mismo proveedor y diario. Esto puede indicar datos de "
-            "migración sin finalizar (proveedor transitorio) o duplicados "
-            "reales sin resolver.\n\n"
-            "%(detail)s%(more)s\n\n"
-            "Corrija o confirme estos casos antes de continuar. Una vez "
-            "resueltos, vuelva a actualizar el módulo -- el índice único se "
-            "creará automáticamente sin necesidad de ningún paso adicional."
-        )
-        % {"count": len(collisions), "detail": detail, "more": more}
-    )
 
 def reassign_account_data_ids(env):
     execute_script_sql(env, "alternative_")

--- a/l10n_ve_accountant/__init__.py
+++ b/l10n_ve_accountant/__init__.py
@@ -1,3 +1,6 @@
+from odoo import _
+from odoo.exceptions import UserError
+
 from . import models
 from . import wizard
 from . import report
@@ -6,8 +9,63 @@ old_module = "binaural_accountant"
 new_module = "l10n_ve_accountant"
 
 def pre_init_hook(env):
+    _check_account_move_partner_consistency(env.cr)
     reassign_account_data_ids(env.cr)
     reassign_tax_unit_data_ids(env.cr)
+
+def _check_account_move_partner_consistency(cr):
+    """Aborta la instalación si existen facturas de proveedor posteadas
+    con el mismo nombre para el mismo proveedor/diario/compañía.
+
+    El _auto_init de account_move.py necesita que estos grupos no
+    existan para poder crear el índice único account_move_unique_name_ve
+    sin tocar ningún dato. Si aquí se detectan, casi siempre es porque
+    la migración de datos de proveedores (binaural_accountant ->
+    l10n_ve_accountant) todavía no terminó de asignar el partner_id
+    definitivo -- instalar en ese estado puede hacer que el índice no
+    se cree (queda solo un warning en el log, sin daño a los datos,
+    pero conviene resolverlo antes en vez de dejarlo pasar en silencio).
+    """
+    cr.execute(
+        """
+        SELECT rp.name, am.journal_id, am.name, COUNT(*)
+        FROM account_move am
+        LEFT JOIN res_partner rp ON rp.id = am.partner_id
+        WHERE am.state = 'posted'
+        AND am.name != '/'
+        AND am.move_type IN ('in_invoice', 'in_refund', 'in_receipt')
+        GROUP BY am.partner_id, am.journal_id, am.company_id, am.name, rp.name
+        HAVING COUNT(*) > 1
+        ORDER BY 4 DESC
+        """
+    )
+    collisions = cr.fetchall()
+    if not collisions:
+        return
+
+    detail = "\n".join(
+        "  - Proveedor: %s | Diario: %s | Número: %s | Repeticiones: %s"
+        % (partner_name or "(sin proveedor)", journal_id, name, count)
+        for partner_name, journal_id, name, count in collisions[:20]
+    )
+    more = ""
+    if len(collisions) > 20:
+        more = _("\n  ... y %d grupo(s) más.") % (len(collisions) - 20)
+
+    raise UserError(
+        _(
+            "No se puede instalar l10n_ve_accountant: se detectaron %(count)d "
+            "grupo(s) de facturas de proveedor posteadas con el mismo número "
+            "para el mismo proveedor y diario. Esto puede indicar datos de "
+            "migración sin finalizar (proveedor transitorio) o duplicados "
+            "reales sin resolver.\n\n"
+            "%(detail)s%(more)s\n\n"
+            "Corrija o confirme estos casos antes de continuar. Una vez "
+            "resueltos, vuelva a actualizar el módulo -- el índice único se "
+            "creará automáticamente sin necesidad de ningún paso adicional."
+        )
+        % {"count": len(collisions), "detail": detail, "more": more}
+    )
 
 def reassign_account_data_ids(env):
     execute_script_sql(env, "alternative_")

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -3,8 +3,6 @@ import math
 from collections import defaultdict
 from contextlib import contextmanager
 
-from psycopg2 import IntegrityError
-
 from lxml import etree
 from odoo import _, api, fields, models, Command
 from odoo.exceptions import UserError, ValidationError
@@ -32,43 +30,56 @@ class AccountMove(models.Model):
     ]
 
     def _auto_init(self):
-        res = super()._auto_init()
+        # Se ejecuta ANTES de super()._auto_init(): el _auto_init de core
+        # (account/models/account_move.py) intenta crear su propio índice
+        # account_move_unique_name (name, journal_id) de forma incondicional,
+        # sin protección alguna. Si ya existe un índice con ese nombre --el
+        # nuestro, más amplio-- core detecta que ya existe y se salta su
+        # propio intento, evitando que la instalación truene por facturas de
+        # distintos proveedores que comparten número en el mismo diario.
         if not index_exists(self.env.cr, "account_move_unique_name_ve"):
-            drop_index(self.env.cr, "account_move_unique_name", self._table)
-            try:
-                with self.env.cr.savepoint():
-                    self.env.cr.execute(
-                        """
-                        CREATE UNIQUE INDEX account_move_unique_name_ve
-                            ON account_move(
-                                name, partner_id, company_id, journal_id
-                            )
-                        WHERE state = 'posted' AND name != '/';
-                        """
-                    )
-            except IntegrityError:
-                self.env.cr.execute(
-                    """
-                    SELECT partner_id, journal_id, name, COUNT(*)
-                    FROM account_move
-                    WHERE state = 'posted'
-                    AND name != '/'
-                    AND move_type IN ('in_invoice', 'in_refund', 'in_receipt')
-                    GROUP BY partner_id, journal_id, company_id, name
-                    HAVING COUNT(*) > 1
-                    """
-                )
-                collisions = self.env.cr.fetchall()
+            groups = self.env["account.move"]._read_group(
+                domain=[
+                    ("state", "=", "posted"),
+                    ("name", "!=", "/"),
+                    ("partner_id", "!=", False),
+                ],
+                groupby=["partner_id", "journal_id", "company_id", "name"],
+                aggregates=["__count"],
+            )
+            collisions = [group for group in groups if group[-1] > 1]
+            if collisions:
                 _logger.warning(
-                    "l10n_ve_accountant: no se pudo crear el índice único "
-                    "account_move_unique_name_ve porque existen %d grupo(s) de "
-                    "account.move (facturas de proveedor) con el mismo nombre "
-                    "para el mismo proveedor/diario/compañía. No se modificó "
-                    "ningún dato -- revisar manualmente si son duplicados "
-                    "reales antes de forzar la unicidad. Grupos: %s",
+                    "l10n_ve_accountant: no se reemplazó el índice único "
+                    "account_move_unique_name por account_move_unique_name_ve "
+                    "porque existen %d grupo(s) de account.move con el mismo "
+                    "nombre para el mismo proveedor/diario/compañía. No se "
+                    "modificó ningún dato -- revisar manualmente si son "
+                    "duplicados reales antes de forzar la unicidad. Grupos: %s",
                     len(collisions), collisions,
                 )
-        return res
+            else:
+                # Solo se descarta el índice de core (name, journal_id) una vez
+                # confirmado que es seguro reemplazarlo por uno más permisivo
+                # (incluye partner_id/company_id): en Venezuela distintos
+                # proveedores pueden repetir el mismo número de factura en el
+                # mismo diario.
+                drop_index(self.env.cr, "account_move_unique_name", self._table)
+                self.env.cr.execute(
+                    """
+                    CREATE UNIQUE INDEX account_move_unique_name
+                        ON account_move(
+                            name, partner_id, company_id, journal_id
+                        )
+                    WHERE state = 'posted' AND name != '/';
+                    CREATE UNIQUE INDEX account_move_unique_name_ve
+                        ON account_move(
+                            name, partner_id, company_id, journal_id
+                        )
+                    WHERE state = 'posted' AND name != '/';
+                    """
+                )
+        return super()._auto_init()
 
     def _get_fields_to_compute_lines(self):
         return ["invoice_line_ids", "line_ids", "foreign_inverse_rate", "foreign_rate"]

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -3,6 +3,8 @@ import math
 from collections import defaultdict
 from contextlib import contextmanager
 
+from psycopg2 import IntegrityError
+
 from lxml import etree
 from odoo import _, api, fields, models, Command
 from odoo.exceptions import UserError, ValidationError
@@ -33,58 +35,39 @@ class AccountMove(models.Model):
         res = super()._auto_init()
         if not index_exists(self.env.cr, "account_move_unique_name_ve"):
             drop_index(self.env.cr, "account_move_unique_name", self._table)
-            # Make all values of `name` different (naming them `name (1)`, `name (2)`...) so that
-            # we can add the following UNIQUE INDEX
-            self.env.cr.execute(
-                """
-                WITH duplicated_sequence AS (
-                    SELECT name, partner_id, state, journal_id
+            try:
+                with self.env.cr.savepoint():
+                    self.env.cr.execute(
+                        """
+                        CREATE UNIQUE INDEX account_move_unique_name_ve
+                            ON account_move(
+                                name, partner_id, company_id, journal_id
+                            )
+                        WHERE state = 'posted' AND name != '/';
+                        """
+                    )
+            except IntegrityError:
+                self.env.cr.execute(
+                    """
+                    SELECT partner_id, journal_id, name, COUNT(*)
                     FROM account_move
                     WHERE state = 'posted'
                     AND name != '/'
                     AND move_type IN ('in_invoice', 'in_refund', 'in_receipt')
-                GROUP BY partner_id, journal_id, name, state
+                    GROUP BY partner_id, journal_id, company_id, name
                     HAVING COUNT(*) > 1
-                ),
-                to_update AS (
-                    SELECT move.id,
-                        move.name,
-                        move.state,
-                        move.date,
-                        row_number() OVER(PARTITION BY move.name, move.partner_id, move.partner_id, move.date) AS row_seq
-                        FROM duplicated_sequence
-                        JOIN account_move move ON move.name = duplicated_sequence.name
-                                            AND move.partner_id = duplicated_sequence.partner_id
-                                            AND move.state = duplicated_sequence.state
-                                            AND move.journal_id = duplicated_sequence.journal_id
-                ),
-                new_vals AS (
-                    SELECT id,
-                            name || ' (' || (row_seq-1)::text || ')' AS name
-                        FROM to_update
-                        WHERE row_seq > 1
+                    """
                 )
-                UPDATE account_move
-                SET name = new_vals.name
-                FROM new_vals
-                WHERE account_move.id = new_vals.id;
-            """
-            )
-
-            self.env.cr.execute(
-                """
-                CREATE UNIQUE INDEX account_move_unique_name
-                    ON account_move(
-                        name, partner_id, company_id, journal_id
-                    )
-                WHERE state = 'posted' AND name != '/';
-                CREATE UNIQUE INDEX account_move_unique_name_ve
-                    ON account_move(
-                        name, partner_id, company_id, journal_id
-                    )
-                WHERE state = 'posted' AND name != '/';
-            """
-            )
+                collisions = self.env.cr.fetchall()
+                _logger.warning(
+                    "l10n_ve_accountant: no se pudo crear el índice único "
+                    "account_move_unique_name_ve porque existen %d grupo(s) de "
+                    "account.move (facturas de proveedor) con el mismo nombre "
+                    "para el mismo proveedor/diario/compañía. No se modificó "
+                    "ningún dato -- revisar manualmente si son duplicados "
+                    "reales antes de forzar la unicidad. Grupos: %s",
+                    len(collisions), collisions,
+                )
         return res
 
     def _get_fields_to_compute_lines(self):

--- a/l10n_ve_accountant/tests/__init__.py
+++ b/l10n_ve_accountant/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_form_account_move
 from . import test_accountant
 from . import test_coverage_gaps
 from . import test_migration_rounding
+from . import test_account_move_unique_name_index

--- a/l10n_ve_accountant/tests/test_account_move_unique_name_index.py
+++ b/l10n_ve_accountant/tests/test_account_move_unique_name_index.py
@@ -1,0 +1,123 @@
+from collections import deque
+
+from psycopg2 import IntegrityError
+
+from odoo import fields
+from odoo.tests import TransactionCase, tagged
+from odoo.tools import drop_index, index_exists
+
+
+@tagged("post_install", "-at_install", "l10n_ve_accountant", "unique_name_index")
+class TestAccountMoveUniqueNameIndex(TransactionCase):
+    """Cubre el ticket #14986: ante nombres de account.move duplicados,
+    _auto_init no debe renombrar registros ni crashear -- solo debe omitir
+    la creación del índice único y loguear un warning."""
+
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.ref("base.main_company")
+        self.partner_a = self.env["res.partner"].create({"name": "Proveedor A"})
+        self.journal = self.env["account.journal"].search(
+            [("type", "=", "purchase"), ("company_id", "=", self.company.id)], limit=1
+        ) or self.env["account.journal"].create({
+            "name": "Compras Test 14986", "code": "T14986",
+            "type": "purchase", "company_id": self.company.id,
+        })
+        drop_index(self.env.cr, "account_move_unique_name_ve", "account_move")
+        drop_index(self.env.cr, "account_move_unique_name", "account_move")
+
+    def _create_move(self, name, partner):
+        """Crea un account.move y fuerza name/state directo en BD, simulando
+        datos ya migrados/duplicados (el escenario real del bug)."""
+        move = self.env["account.move"].with_context(check_move_validity=False).create({
+            "move_type": "in_invoice",
+            "partner_id": partner.id if partner else False,
+            "journal_id": self.journal.id,
+            "date": fields.Date.today(),
+        })
+        self.env.cr.execute(
+            "UPDATE account_move SET state = 'posted', name = %s WHERE id = %s",
+            (name, move.id),
+        )
+        move.invalidate_recordset()
+        return move
+
+    def _run_auto_init(self):
+        """Reproduce el contexto transitorio que Registry.init_models() arma
+        alrededor de model._auto_init() (post_init_queue, etc.) -- necesario
+        porque estos atributos no existen fuera del ciclo de carga de módulos."""
+        registry = self.env.registry
+        registry._post_init_queue = deque()
+        registry._foreign_keys = {}
+        registry._is_install = False
+        try:
+            self.env["account.move"]._auto_init()
+            while registry._post_init_queue:
+                registry._post_init_queue.popleft()()
+        finally:
+            del registry._post_init_queue
+            del registry._foreign_keys
+            del registry._is_install
+
+    def test_duplicate_names_are_not_renamed_but_real_duplicates_still_block_install(self):
+        """Duplicados reales (mismo proveedor+diario+número): nuestro código
+        no renombra nada y loguea el warning, pero la instalación igual se
+        detiene -- Odoo core tampoco puede crear su propio índice sobre datos
+        genuinamente duplicados. Es el comportamiento deseado: un problema de
+        datos real debe frenar la migración para revisión manual, no
+        ocultarse silenciosamente."""
+        move_1 = self._create_move("FAC-DUP-001", self.partner_a)
+        move_2 = self._create_move("FAC-DUP-001", self.partner_a)
+
+        with self.assertLogs(
+            "odoo.addons.l10n_ve_accountant.models.account_move", level="WARNING"
+        ) as log_ctx:
+            with self.assertRaises(IntegrityError):
+                with self.env.cr.savepoint():
+                    self._run_auto_init()
+
+        self.assertTrue(
+            any("account_move_unique_name_ve" in msg for msg in log_ctx.output),
+            "Se esperaba un warning indicando que el índice no se reemplazó por duplicados",
+        )
+        move_1.invalidate_recordset()
+        move_2.invalidate_recordset()
+        self.assertEqual(
+            move_1.name, "FAC-DUP-001",
+            "El nombre no debe modificarse -- no debe agregarse ningún sufijo",
+        )
+        self.assertEqual(
+            move_2.name, "FAC-DUP-001",
+            "El nombre no debe modificarse -- no debe agregarse ningún sufijo",
+        )
+        self.assertFalse(
+            index_exists(self.env.cr, "account_move_unique_name_ve"),
+            "El índice único no debe crearse mientras existan duplicados",
+        )
+
+    def test_no_duplicates_creates_index(self):
+        self._create_move("FAC-OK-001", self.partner_a)
+        self._create_move("FAC-OK-002", self.partner_a)
+
+        self._run_auto_init()
+
+        self.assertTrue(
+            index_exists(self.env.cr, "account_move_unique_name_ve"),
+            "El índice único debe crearse cuando no hay duplicados",
+        )
+        self.assertTrue(
+            index_exists(self.env.cr, "account_move_unique_name"),
+            "El índice de core también debe recrearse con la definición ampliada",
+        )
+
+    def test_null_partner_id_is_not_a_false_positive(self):
+        self._create_move("FAC-NULL-001", None)
+        self._create_move("FAC-NULL-001", None)
+
+        self._run_auto_init()
+
+        self.assertTrue(
+            index_exists(self.env.cr, "account_move_unique_name_ve"),
+            "Registros con partner_id NULL no deben considerarse duplicados entre sí "
+            "(replica el comportamiento real del índice único de postgres)",
+        )


### PR DESCRIPTION
…veedor al instalar el módulo

Antes, si el módulo encontraba facturas de proveedor con el mismo número (por ejemplo durante una migración de datos), las renombraba solo agregándoles un sufijo como (39) para poder crear una validación interna. Esto causó que facturas correctas terminaran con un número distinto al real.

Ahora, si el módulo detecta ese caso, no toca ninguna factura: directamente avisa cuáles son (proveedor, diario y número) y detiene la instalación hasta que se revise. Si no hay ningún caso problemático, todo sigue funcionando exactamente igual que antes.

Ticket: https://binaural.odoo.com/odoo/my-tickets/14986