### PR TITLE
[FIX] l10n_ve_payment_extension: excluir facturas sin retención IVA previa

### DIFF
--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -218,6 +218,12 @@ class AccountRetention(models.Model):
                         # Match the criterion in #1005: a credit note's residual is negative,
                         # so '>' 0 excluded it, making its lines unreachable from this dropdown.
                         ('amount_residual', '!=', 0),
+                        # NOTE: negated field-traversal domains on empty o2m's produce a
+                        # LEFT JOIN with NULL, so "NOT (NULL IN (...))" is falsy in SQL and
+                        # invoices with no retention_iva_line_ids at all were wrongly
+                        # excluded. Explicitly include invoices without any lines.
+                        '|',
+                        ('retention_iva_line_ids', '=', False),
                         '!',
                         ('retention_iva_line_ids.state', 'in', ('draft', 'emitted')),
                     ]

--- a/l10n_ve_payment_extension/tests/test_iva_eligible_partners.py
+++ b/l10n_ve_payment_extension/tests/test_iva_eligible_partners.py
@@ -240,6 +240,17 @@ class TestIvaEligiblePartners(TransactionCase):
         eligible = self._get_iva_eligible_partners("iva", "in_invoice")
         self.assertNotIn(self.partner, eligible)
 
+    def test_supplier_no_retention_lines_is_eligible(self):
+        # Regression for #15015: an invoice with an empty retention_iva_line_ids
+        # o2m produces a LEFT JOIN with NULL state, so "NOT (NULL IN (...))" was
+        # falsy in SQL and the invoice was wrongly excluded even though it has
+        # never had any IVA retention line at all.
+        invoice = self._create_invoice("in_invoice", self.tax_purchase, self.purchase_journal)
+        self.assertFalse(invoice.retention_iva_line_ids)
+        self.assertNotEqual(invoice.amount_residual, 0)
+        eligible = self._get_iva_eligible_partners("iva", "in_invoice")
+        self.assertIn(self.partner, eligible)
+
     def test_supplier_negative_residual_is_eligible(self):
         # Aligned with #1005: a credit note's residual is negative, so it must stay
         # eligible here or its lines become unreachable from this dropdown.


### PR DESCRIPTION
## Resumen

- `_compute_iva_type_eligible_partner_ids` excluía por error toda factura que **nunca** ha tenido una línea de retención IVA (o2m `retention_iva_line_ids` vacío). Al negar `retention_iva_line_ids.state in (draft, emitted)` sobre un o2m vacío, el ORM arma un `LEFT JOIN` que deja `state` en `NULL`, y `NOT (NULL IN (...))` es falso en SQL — el caso más común (primera retención de una factura) quedaba oculto del dropdown de partners elegibles.
- Fix: se agrega `('retention_iva_line_ids', '=', False)` explícito al dominio (con `OR`) antes de la negación, para cubrir el caso de o2m vacío.
- Se agrega test de regresión `test_supplier_no_retention_lines_is_eligible`.

Diagnosticado en una instancia real (caso concreto: partner AVPHARMA, C.A., factura 180002005) confirmando con `psql` y con `env['account.move'].search(...)` en shell de Odoo que la condición negada excluía la factura pese a cumplir el resto de criterios.

## Test plan

- [ ] CI: `test_iva_eligible_partners.py` (incluye el nuevo `test_supplier_no_retention_lines_is_eligible`) pasa en `l10n_ve_payment_extension`.
- [ ] Confirmar que no hay regresión en el resto de tests del archivo.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/92/tickets/15015