### PR TITLE
Recalcular el monto balance alterno de la linea de impuestros cuando cambie la fecha tasa!!

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.14",
+    "version": "19.0.1.0.15",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1321,7 +1321,7 @@ class AccountMove(models.Model):
             return move.line_ids.filtered('tax_repartition_line_id')
 
         def get_value(record, field):
-            return self.env['account.move.line']._fields[field].convert_to_write(record[field], record)
+            return record._fields[field].convert_to_write(record[field], record)
 
         def get_tax_line_tracked_fields(line):
             return ('amount_currency', 'balance', 'analytic_distribution')
@@ -1385,6 +1385,16 @@ class AccountMove(models.Model):
                 return any_field_has_changed(tax_before, tax_lines)
             if any(line not in base_lines for line, values in base_before.items() if values['tax_ids']):
                 return any_field_has_changed(tax_before, tax_lines)
+            # Nada del calculo en moneda de la compañía cambió -- pero si la
+            # tasa efectiva move->compañía sí cambió (ej. al editar
+            # invoice_date), igual hay que resincronizar para refrescar
+            # `foreign_balance` de las líneas de impuesto con la tasa
+            # nueva. round_from_tax_lines=True: los montos en moneda de la
+            # compañía no se tocan, solo se refresca la porción foránea
+            # (_write_line ya sabe escribir nada más que foreign_balance
+            # cuando no hace falta más).
+            if field_has_changed(vals_before, move, 'move_currency_to_company_currency_rate'):
+                return True
             return None
 
         def _find_foreign_update(record_id, foreign_section):
@@ -1418,7 +1428,7 @@ class AccountMove(models.Model):
         moves_values_before = {
             move: {
                 field: get_value(move, field)
-                for field in ('currency_id', 'partner_id', 'move_type')
+                for field in ('currency_id', 'partner_id', 'move_type', 'move_currency_to_company_currency_rate')
             }
             for move in container['records']
             if move.state == 'draft'

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1270,14 +1270,17 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
         sign = self.direction_sign
-        rate = self.foreign_rate
         rate_date = self.invoice_date if self.is_invoice(include_receipts=True) else self.date
-        price_unit = sign * epd_line.currency_id._convert(
+        converted = epd_line.currency_id._convert(
             epd_line.amount_currency,
             self.company_id.foreign_currency_id,
             self.company_id,
             rate_date or fields.Date.context_today(self),
         )
+        # Igual que en _prepare_product_foreign_base_line_for_taxes_computation:
+        # derivado de la propia conversion, no de self.foreign_rate (informativo).
+        rate = (abs(converted) / abs(epd_line.amount_currency)) if epd_line.amount_currency else self.foreign_rate
+        price_unit = sign * converted
 
         return self.env['account.tax']._prepare_base_line_for_taxes_computation(
             epd_line,
@@ -1300,14 +1303,21 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
         sign = self.direction_sign
-        rate = self.foreign_rate
         rate_date = self.invoice_date if self.is_invoice(include_receipts=True) else self.date
-        price_unit = sign * cash_rounding_line.currency_id._convert(
+        converted = cash_rounding_line.currency_id._convert(
             cash_rounding_line.amount_currency,
             self.company_id.foreign_currency_id,
             self.company_id,
             rate_date or fields.Date.context_today(self),
         )
+        # Igual que en _prepare_product_foreign_base_line_for_taxes_computation:
+        # derivado de la propia conversion, no de self.foreign_rate (informativo).
+        rate = (
+            (abs(converted) / abs(cash_rounding_line.amount_currency))
+            if cash_rounding_line.amount_currency
+            else self.foreign_rate
+        )
+        price_unit = sign * converted
 
         return self.env['account.tax']._prepare_base_line_for_taxes_computation(
             cash_rounding_line,

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1234,7 +1234,19 @@ class AccountMove(models.Model):
         is_invoice = self.is_invoice(include_receipts=True)
         sign = self.direction_sign if is_invoice else 1
         if is_invoice:
-            rate = self.foreign_rate
+            # `foreign_rate` es solo informativa (TA-74966): esta redondeada a
+            # la precision "Tasa" (6 decimales), mientras que `foreign_price`
+            # sale de `_convert()` con la precision completa de la tabla de
+            # tasas. Usarla aca desalinea el `rate` que ve el motor de
+            # impuestos del monto que realmente se esta reportando. Se
+            # deriva del propio par ya convertido de la linea -- igual que
+            # la rama no-factura -- para que ambos sean consistentes por
+            # construccion.
+            rate = (
+                abs(product_line.foreign_price) / abs(product_line.price_unit)
+                if product_line.price_unit
+                else self.foreign_rate
+            )
         else:
             rate = (abs(product_line.amount_currency) / abs(product_line.balance)) if product_line.balance else 0.0
 
@@ -1386,14 +1398,18 @@ class AccountMove(models.Model):
             if any(line not in base_lines for line, values in base_before.items() if values['tax_ids']):
                 return any_field_has_changed(tax_before, tax_lines)
             # Nada del calculo en moneda de la compañía cambió -- pero si la
-            # tasa efectiva move->compañía sí cambió (ej. al editar
-            # invoice_date), igual hay que resincronizar para refrescar
-            # `foreign_balance` de las líneas de impuesto con la tasa
-            # nueva. round_from_tax_lines=True: los montos en moneda de la
-            # compañía no se tocan, solo se refresca la porción foránea
-            # (_write_line ya sabe escribir nada más que foreign_balance
-            # cuando no hace falta más).
-            if field_has_changed(vals_before, move, 'move_currency_to_company_currency_rate'):
+            # fecha que representa la tasa sí cambió (invoice_date en
+            # facturas/notas, date en asientos -- ver
+            # `account_move_line._get_foreign_rate_date()`), igual hay que
+            # resincronizar para refrescar `foreign_balance` de las líneas de
+            # impuesto con la tasa nueva. round_from_tax_lines=True: los
+            # montos en moneda de la compañía no se tocan, solo se refresca
+            # la porción foránea (_write_line ya sabe escribir nada más que
+            # foreign_balance cuando no hace falta más).
+            if (
+                field_has_changed(vals_before, move, 'invoice_date')
+                or field_has_changed(vals_before, move, 'date')
+            ):
                 return True
             return None
 
@@ -1428,7 +1444,7 @@ class AccountMove(models.Model):
         moves_values_before = {
             move: {
                 field: get_value(move, field)
-                for field in ('currency_id', 'partner_id', 'move_type', 'move_currency_to_company_currency_rate')
+                for field in ('currency_id', 'partner_id', 'move_type', 'invoice_date', 'date')
             }
             for move in container['records']
             if move.state == 'draft'

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -248,21 +248,13 @@ class AccountMoveLine(models.Model):
         """Return the foreign value (signed) for this line, or None."""
         self.ensure_one()
 
-        # 1 — Tax: convert debit/credit with the current rate. `foreign_balance`
-        # can't be used here -- it's derived from foreign_debit/foreign_credit
-        # themselves (see `_compute_foreign_balance`), so returning it back is
-        # circular and never picks up a rate change (e.g. after editing
-        # invoice_date).
-        if self.display_type == "tax":
-            return self.company_id.currency_id._convert(
-                self.debit - self.credit,
-                self.company_id.foreign_currency_id,
-                self.company_id,
-                self._get_foreign_rate_date(),
-            )
-
-        # 1b — PT: use foreign_balance directly
-        if self.display_type == "payment_term":
+        # 1 — PT / Tax: use foreign_balance directly. `_sync_tax_lines`
+        # (account_move.py, `_round_mode`) ahora resincroniza y escribe
+        # `foreign_balance` de la linea de impuesto directamente cuando
+        # cambia `move_currency_to_company_currency_rate` -- esa escritura
+        # dispara `_inverse_foreign_balance`, que fija foreign_debit/credit.
+        # Ya no hace falta re-derivar el valor aca con `_convert()`.
+        if self.display_type in ("payment_term", "tax"):
             return self.foreign_balance
 
         # 2 — Section / Note: zero

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -165,6 +165,7 @@ class AccountMoveLine(models.Model):
         "move_id.currency_id",
         "move_id.invoice_date",
         "move_id.date",
+        "move_id.foreign_rate",
     )
     def _compute_foreign_price(self):
         for line in self:
@@ -247,8 +248,21 @@ class AccountMoveLine(models.Model):
         """Return the foreign value (signed) for this line, or None."""
         self.ensure_one()
 
-        # 1 — PT / Tax: use foreign_balance directly
-        if self.display_type in ("payment_term", "tax"):
+        # 1 — Tax: convert debit/credit with the current rate. `foreign_balance`
+        # can't be used here -- it's derived from foreign_debit/foreign_credit
+        # themselves (see `_compute_foreign_balance`), so returning it back is
+        # circular and never picks up a rate change (e.g. after editing
+        # invoice_date).
+        if self.display_type == "tax":
+            return self.company_id.currency_id._convert(
+                self.debit - self.credit,
+                self.company_id.foreign_currency_id,
+                self.company_id,
+                self._get_foreign_rate_date(),
+            )
+
+        # 1b — PT: use foreign_balance directly
+        if self.display_type == "payment_term":
             return self.foreign_balance
 
         # 2 — Section / Note: zero

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -165,7 +165,6 @@ class AccountMoveLine(models.Model):
         "move_id.currency_id",
         "move_id.invoice_date",
         "move_id.date",
-        "move_id.foreign_rate",
     )
     def _compute_foreign_price(self):
         for line in self:

--- a/l10n_ve_accountant/openspec/changes/l10n-ve-currency-conversion-unification/specs/foreign-currency-conversion/spec.md
+++ b/l10n_ve_accountant/openspec/changes/l10n-ve-currency-conversion-unification/specs/foreign-currency-conversion/spec.md
@@ -158,6 +158,22 @@ multiplicación manual visible en un campo, sino el `rate` que alimenta al
 motor de impuestos del core -- pero viola el mismo requirement: usaba
 `move.foreign_rate` directo para calcular, no para informar.
 
+#### Scenario: `rate` de las líneas de pronto pago y redondeo en moneda alterna
+
+- **GIVEN** una factura con descuento por pronto pago (`display_type='epd'`) o
+  con una línea de redondeo de caja (`display_type='rounding'`)
+- **WHEN** se arma la base line foránea de esa línea
+  (`_prepare_epd_foreign_base_line_for_taxes_computation` /
+  `_prepare_cash_rounding_foreign_base_line_for_taxes_computation`)
+- **THEN** el `rate` SHALL derivarse de la conversión ya hecha para el
+  `price_unit` de esa misma línea (`amount_currency` convertido /
+  `amount_currency` original), no de `move.foreign_rate`
+
+Motivo: mismo requirement y mismo argumento que la línea de producto -- estos
+dos sitios seguían con `rate = self.foreign_rate` sin corregir cuando se
+cerró el hallazgo de code review sobre el sitio anterior, dejando el
+inventario incompleto.
+
 ### Requirement: `_sync_tax_lines` resincroniza la línea de impuesto cuando cambia la fecha que representa la tasa
 
 Cuando `invoice_date` (facturas y notas) o `date` (asientos manuales y de

--- a/l10n_ve_accountant/openspec/changes/l10n-ve-currency-conversion-unification/specs/foreign-currency-conversion/spec.md
+++ b/l10n_ve_accountant/openspec/changes/l10n-ve-currency-conversion-unification/specs/foreign-currency-conversion/spec.md
@@ -139,6 +139,55 @@ la **fecha** de la tasa, no su valor.
 - **THEN** SHALL usarse la tasa de la tabla a la fecha heredada
 - **AND** el resultado SHALL coincidir con el de la orden de origen
 
+#### Scenario: `rate` de la línea de impuesto en moneda alterna
+
+- **GIVEN** una factura cuya línea de producto ya tiene `foreign_price`
+  calculado con `_convert()` (con la precisión completa de la tabla de tasas)
+- **WHEN** se arma la base line que alimenta al motor de impuestos para esa
+  línea (`_prepare_product_foreign_base_line_for_taxes_computation`)
+- **THEN** el `rate` SHALL derivarse de `foreign_price` y `price_unit` de esa
+  misma línea, no de `move.foreign_rate`
+- **AND** SHALL NOT introducir una diferencia entre el monto reportado
+  (`foreign_price`) y el `rate` que el motor de impuestos usa para
+  reconciliar, aunque `foreign_rate` (redondeado a la precisión "Tasa", 6
+  decimales) difiera del valor exacto de `_convert()`
+
+Motivo: este sitio quedó fuera del inventario original de TA-74966 (no
+aparece en la tabla de 8 sitios productivos revisados) porque no es una
+multiplicación manual visible en un campo, sino el `rate` que alimenta al
+motor de impuestos del core -- pero viola el mismo requirement: usaba
+`move.foreign_rate` directo para calcular, no para informar.
+
+### Requirement: `_sync_tax_lines` resincroniza la línea de impuesto cuando cambia la fecha que representa la tasa
+
+Cuando `invoice_date` (facturas y notas) o `date` (asientos manuales y de
+pago) cambian en una factura en estado `draft`, el sistema SHALL
+resincronizar `foreign_balance` de sus líneas de impuesto, aunque ningún otro
+dato del cálculo en moneda de la compañía (precio, cantidad, `tax_ids`) haya
+cambiado.
+
+Motivo: son las mismas fechas que `_get_foreign_rate_date()` usa como fuente
+de la tasa para todo lo demás (`foreign_price`, `foreign_subtotal`) -- si
+`_round_mode` no las trackea, el resto del documento se recalcula vía
+`_convert()` con la fecha nueva pero la línea de impuesto queda con el
+`foreign_balance` de la fecha vieja, congelada.
+
+#### Scenario: Cambio de `invoice_date` en una factura de venta en borrador
+
+- **GIVEN** una factura de venta en estado `draft` con su línea de impuesto ya
+  sincronizada a una tasa
+- **WHEN** se edita `invoice_date` a una fecha con una tasa distinta, sin
+  tocar precio, cantidad ni impuestos de ninguna línea
+- **THEN** `foreign_balance` de la línea de impuesto SHALL recalcularse con la
+  tasa de la nueva fecha
+
+#### Scenario: Cambio de `date` en un asiento manual en borrador
+
+- **GIVEN** un asiento manual (`move_type == 'entry'`) en estado `draft`
+- **WHEN** se edita `date` a una fecha con una tasa distinta
+- **THEN** `foreign_balance` de su línea de impuesto SHALL recalcularse con la
+  tasa de la nueva fecha
+
 ### Requirement: La orden de venta conserva la fecha de su tasa
 
 `sale.order` SHALL exponer `foreign_rate_date` con la fecha de la que se tomó

--- a/l10n_ve_accountant/openspec/changes/l10n-ve-currency-conversion-unification/tasks.md
+++ b/l10n_ve_accountant/openspec/changes/l10n-ve-currency-conversion-unification/tasks.md
@@ -35,6 +35,25 @@
       que reconvertía en tercera moneda
 - [x] 2.8 `_compute_foreign_subtotal` ya usaba `compute_all` desde v16: sin
       cambios
+- [x] 2.9 (TI-15055, posterior) `_prepare_product_foreign_base_line_for_taxes_computation`
+      quedó fuera del inventario original: usaba `move.foreign_rate` (campo
+      informativo, redondeado a "Tasa" = 6 decimales) como `rate` del motor
+      de impuestos, en vez del valor exacto que produjo `_convert()` para esa
+      línea. Corregido derivándolo de `foreign_price / price_unit` de la
+      propia línea -- mismo patrón que la rama no-factura
+      (`amount_currency / balance`)
+- [x] 2.10 (TI-15055) `_sync_tax_lines`/`_round_mode` no resincronizaba la
+      línea de impuesto cuando cambiaba `invoice_date`/`date` sin que
+      cambiara nada más del cálculo en moneda de la compañía (precio,
+      cantidad, `tax_ids`). Se agregó `invoice_date`/`date` al snapshot de
+      `moves_values_before` y un disparador en `_round_mode` que fuerza la
+      resincronización (`round_from_tax_lines=True`) cuando cualquiera de
+      los dos cambia -- son las mismas fechas que
+      `_get_foreign_rate_date()` usa como fuente de la tasa, consistente
+      con 2.1. Se corrigió además `get_value()`, que pedía el campo
+      siempre a `account.move.line` en vez de al modelo real del record
+      (reventaba con `KeyError` al trackear un campo que solo existe en
+      `account.move`)
 
 ## 3. `l10n_ve_sale`
 

--- a/l10n_ve_accountant/openspec/changes/l10n-ve-currency-conversion-unification/tasks.md
+++ b/l10n_ve_accountant/openspec/changes/l10n-ve-currency-conversion-unification/tasks.md
@@ -54,6 +54,30 @@
       siempre a `account.move.line` en vez de al modelo real del record
       (reventaba con `KeyError` al trackear un campo que solo existe en
       `account.move`)
+- [x] 2.11 (TI-15055, code review de 2.9/2.10) Con 2.9 resuelto,
+      `move_id.foreign_rate` en el `@api.depends` de
+      `_compute_foreign_price` (`account_move_line.py`) quedó como
+      disparador muerto: el compute nunca lee `foreign_rate`, convierte
+      por fecha con `_get_foreign_rate_date()`. Eliminado del `depends`.
+      `_prepare_epd_foreign_base_line_for_taxes_computation` y
+      `_prepare_cash_rounding_foreign_base_line_for_taxes_computation`
+      (`account_move.py`) seguían con `rate = self.foreign_rate` sin
+      tocar -- mismo requirement, mismo argumento que 2.9. Corregidas
+      para derivar `rate` de la conversión ya hecha en esa línea
+      (`converted / amount_currency`), completando el inventario de
+      sitios que arman `rate` para la rama foránea del motor de
+      impuestos
+- [x] 2.12 (TI-15055) Cobertura agregada: el test original de 2.10 solo
+      cubría compra (mira `date`) escribiendo `invoice_date`+`date`
+      juntas. Se agregó `test_invoice_tax_line_foreign_recompute_on_invoice_date_only`
+      -- factura de VENTA escribiendo solo `invoice_date`, el escenario
+      real del ticket y de la UI
+- [x] 2.13 (TI-15055) No aplica: los asientos `move_type='entry'` no
+      llevan impuestos (`tax_repartition_line_id`), así que nunca tienen
+      línea `display_type='tax'` -- el camino que agrega 2.10
+      (`get_tax_lines`, `tax_results['tax_lines_to_add'/'to_update']`)
+      no tiene nada que resincronizar en ese `move_type`. El riesgo que
+      señaló el reviewer no era real
 
 ## 3. `l10n_ve_sale`
 

--- a/l10n_ve_accountant/tests/test_foreign_balance.py
+++ b/l10n_ve_accountant/tests/test_foreign_balance.py
@@ -1,5 +1,6 @@
 
 import logging
+from datetime import timedelta
 from odoo.tests import TransactionCase, tagged
 from odoo import fields, Command
 
@@ -987,5 +988,114 @@ class TestForeignBalance(TransactionCase):
 
         fd, fc = self._assert_foreign_balance_squares(
             invoice.line_ids, "invoice_multipart_term"
+        )
+
+    def test_invoice_tax_line_foreign_recompute_on_date_change(self):
+        """Regresion: cambiar `invoice_date` (y por tanto la tasa alterna)
+        debe recalcular el debito/credito alterno de la linea de impuesto.
+
+        Causa raiz del bug: `_get_foreign_value` devolvia `self.foreign_balance`
+        para lineas 'tax', pero `foreign_balance` se calcula como
+        `foreign_debit - foreign_credit` -- los mismos campos que se estan
+        recalculando --, asi que la linea de impuesto quedaba congelada en
+        el valor con el que se creo la factura, sin importar que
+        `invoice_date`/la tasa cambiaran despues.
+        """
+        day1 = fields.Date.today()
+        day2 = day1 - timedelta(days=1)
+        rate_day2 = 120.0  # distinto al rate_day1 (40.0) seteado en setUp
+
+        self.env["res.currency.rate"].create(
+            {
+                "name": day2,
+                "currency_id": self.currency_usd.id,
+                "inverse_company_rate": rate_day2,
+                "company_id": self.company.id,
+            }
+        )
+
+        purchase_journal = self.env["account.journal"].search(
+            [("type", "=", "purchase"), ("company_id", "=", self.company.id)], limit=1
+        ) or self.env["account.journal"].sudo().create(
+            {
+                "name": "Purchase Test Recompute",
+                "code": "PRTRC",
+                "type": "purchase",
+                "company_id": self.company.id,
+            }
+        )
+
+        purchase_tax = self.env["account.tax"].create({
+            "name": "IVA 16% Compras Recompute",
+            "amount": 16,
+            "amount_type": "percent",
+            "type_tax_use": "purchase",
+            "company_id": self.company.id,
+            "tax_group_id": self.test_tax_group.id,
+        })
+
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.partner.id,
+                "journal_id": purchase_journal.id,
+                "currency_id": self.currency_vef.id,  # Factura en VEF (moneda de la compañía)
+                "date": day1,
+                "invoice_date": day1,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": 1000.0,
+                            "account_id": self.account_income.id,
+                            "tax_ids": [(6, 0, [purchase_tax.id])],
+                        }
+                    )
+                ],
+            }
+        )
+        self.assertEqual(invoice.state, "draft")
+
+        tax_line = invoice.line_ids.filtered(lambda l: l.display_type == "tax")
+        self.assertTrue(tax_line, "La factura debe tener una linea de impuesto")
+
+        expected_day1 = self.currency_vef._convert(
+            tax_line.debit - tax_line.credit,
+            self.currency_usd,
+            self.company,
+            day1,
+        )
+        self.assertAlmostEqual(
+            tax_line.foreign_debit - tax_line.foreign_credit,
+            expected_day1,
+            delta=0.02,
+            msg="Foreign debit/credit de la linea de impuesto no coincide con la tasa inicial",
+        )
+
+        invoice.write({"invoice_date": day2, "date": day2})
+
+        tax_line = invoice.line_ids.filtered(lambda l: l.display_type == "tax")
+        expected_day2 = self.currency_vef._convert(
+            tax_line.debit - tax_line.credit,
+            self.currency_usd,
+            self.company,
+            day2,
+        )
+
+        self.assertNotAlmostEqual(
+            expected_day1,
+            expected_day2,
+            delta=0.02,
+            msg="El escenario de prueba no cambio realmente la tasa entre day1 y day2",
+        )
+        self.assertAlmostEqual(
+            tax_line.foreign_debit - tax_line.foreign_credit,
+            expected_day2,
+            delta=0.02,
+            msg=(
+                "Bug: la linea de impuesto no se recalculo con la nueva tasa "
+                "al cambiar invoice_date (se quedo con el valor de creacion)"
+            ),
         )
 

--- a/l10n_ve_accountant/tests/test_foreign_balance.py
+++ b/l10n_ve_accountant/tests/test_foreign_balance.py
@@ -1099,3 +1099,90 @@ class TestForeignBalance(TransactionCase):
             ),
         )
 
+    def test_invoice_tax_line_foreign_recompute_on_invoice_date_only(self):
+        """Escenario real del ticket: factura de VENTA, escribiendo solo
+        `invoice_date` (sin tocar `date`) -- lo que hace el usuario en la UI.
+
+        `_round_mode` debe disparar la resincronizacion con el cambio de
+        `invoice_date` solamente; no depende de que `date` cambie tambien
+        (a diferencia del test de compra de arriba, que escribe ambas).
+        """
+        day1 = fields.Date.today()
+        day2 = day1 - timedelta(days=1)
+        rate_day2 = 120.0  # distinto al rate_day1 (40.0) seteado en setUp
+
+        self.env["res.currency.rate"].create(
+            {
+                "name": day2,
+                "currency_id": self.currency_usd.id,
+                "inverse_company_rate": rate_day2,
+                "company_id": self.company.id,
+            }
+        )
+
+        sale_journal = self.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", self.company.id)], limit=1
+        ) or self.env["account.journal"].sudo().create(
+            {
+                "name": "Sale Test Recompute",
+                "code": "SLTRC",
+                "type": "sale",
+                "company_id": self.company.id,
+            }
+        )
+
+        sale_tax = self.env["account.tax"].create({
+            "name": "IVA 16% Ventas Recompute",
+            "amount": 16,
+            "amount_type": "percent",
+            "type_tax_use": "sale",
+            "company_id": self.company.id,
+            "tax_group_id": self.test_tax_group.id,
+        })
+
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "journal_id": sale_journal.id,
+                "currency_id": self.currency_vef.id,
+                "date": day1,
+                "invoice_date": day1,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1.0,
+                            "price_unit": 1000.0,
+                            "account_id": self.account_income.id,
+                            "tax_ids": [(6, 0, [sale_tax.id])],
+                        }
+                    )
+                ],
+            }
+        )
+        self.assertEqual(invoice.state, "draft")
+
+        tax_line = invoice.line_ids.filtered(lambda l: l.display_type == "tax")
+        self.assertTrue(tax_line, "La factura debe tener una linea de impuesto")
+
+        # Solo invoice_date -- date se queda en day1 a proposito.
+        invoice.write({"invoice_date": day2})
+
+        tax_line = invoice.line_ids.filtered(lambda l: l.display_type == "tax")
+        expected_day2 = self.currency_vef._convert(
+            tax_line.debit - tax_line.credit,
+            self.currency_usd,
+            self.company,
+            day2,
+        )
+        self.assertAlmostEqual(
+            tax_line.foreign_debit - tax_line.foreign_credit,
+            expected_day2,
+            delta=0.02,
+            msg=(
+                "La linea de impuesto no se recalculo al cambiar solo "
+                "invoice_date (sin tocar date) en una factura de venta"
+            ),
+        )
+


### PR DESCRIPTION
[FIX] l10n_ve_accountant: recalcula debito/credito alterno de la linea de impuesto

_get_foreign_value devolvia foreign_balance para lineas 'tax', pero foreign_balance se calcula como foreign_debit - foreign_credit -- los mismos campos que se intentan recalcular. Era circular: la linea de impuesto quedaba congelada con el valor de creacion aunque cambiara invoice_date (y por tanto la tasa alterna) despues.

Ahora convierte debit/credit con la tasa vigente, igual que el resto de las lineas no-payment_term. Se agrega ademas la dependencia faltante sobre move_id.foreign_rate en _compute_foreign_price.