### PR TITLE
[FIX] l10n_ve_sale: chequeo de límite de crédito independiente de not_allow_sell_products

### DIFF
--- a/l10n_ve_sale/__manifest__.py
+++ b/l10n_ve_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Sales/Sales",
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.9",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_sale/i18n/es_VE.po
+++ b/l10n_ve_sale/i18n/es_VE.po
@@ -365,11 +365,16 @@ msgstr "Teléfono"
 #: code:addons/l10n_ve_sale/models/sale_order.py:0
 msgid ""
 "No se ha confirmado el presupuesto. Límite de crédito excedido. La cuenta "
-"por cobrar del cliente es de %s más %s en presupuesto da un total de %s "
-"superando el límite de ventas de %s. Por favor cancele el presupuesto o "
-"comuníquese con el administrador para aumentar el límite de crédito del "
-"cliente."
+"por cobrar del cliente es de %(debt)s más %(amount)s en presupuesto da un "
+"total de %(total)s superando el límite de ventas de %(limit)s. Por favor "
+"cancele el presupuesto o comuníquese con el administrador para aumentar el "
+"límite de crédito del cliente."
 msgstr ""
+"No se ha confirmado el presupuesto. Límite de crédito excedido. La cuenta "
+"por cobrar del cliente es de %(debt)s más %(amount)s en presupuesto da un "
+"total de %(total)s superando el límite de ventas de %(limit)s. Por favor "
+"cancele el presupuesto o comuníquese con el administrador para aumentar el "
+"límite de crédito del cliente."
 
 #. module: l10n_ve_sale
 #. odoo-python
@@ -489,17 +494,17 @@ msgstr "Subtotal"
 #. odoo-python
 #: code:addons/l10n_ve_sale/models/sale_order.py:0
 msgid ""
-"The budget cannot be confirmed. Has an overdue amount of (%.2f) that cannot "
-"be greater than %.2f %s."
+"The budget cannot be confirmed. Has an overdue amount of (%(amount).2f) "
+"that cannot be greater than %(limit).2f %(currency)s."
 msgstr ""
-"No se puede confirmar el presupuesto. Tiene un monto vencido de (%.2f) que "
-"no puede ser mayor a %.2f %s."
+"No se puede confirmar el presupuesto. Tiene un monto vencido de "
+"(%(amount).2f) que no puede ser mayor a %(limit).2f %(currency)s."
 
 #. module: l10n_ve_sale
 #. odoo-python
 #: code:addons/l10n_ve_sale/models/sale_order.py:0
-msgid "The budget cannot be confirmed. You have %s Invoices (%s)."
-msgstr "No se puede confirmar el presupuesto. Tiene %s Facturas (%s)."
+msgid "The budget cannot be confirmed. You have %(count)s Invoices (%(state)s)."
+msgstr "No se puede confirmar el presupuesto. Tiene %(count)s Facturas (%(state)s)."
 
 #. module: l10n_ve_sale
 #. odoo-python

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -660,12 +660,15 @@ class SaleOrder(models.Model):
         skip_not_allow_sell_products_validation = self.env.context.get(
             "skip_not_allow_sell_products_validation", False
         )
+        skip_credit_limit_check = self.env.context.get(
+            "skip_credit_limit_check", False
+        )
         for order in self:
             # Validación de líneas de producto
             if not order.order_line or all(line.display_type for line in order.order_line):
                 raise UserError(_("Before confirming an order, you need to add a product."))
 
-            # Validación de productos no permitidos para la venta y límite de crédito
+            # Validación de productos no permitidos para la venta
             if self.env.company.not_allow_sell_products and not skip_not_allow_sell_products_validation:
                 for line in order.order_line:
                     if (
@@ -680,27 +683,29 @@ class SaleOrder(models.Model):
                             line.product_uom_qty,
                         )
                         raise ValidationError(msg)
-            
 
-                if (
-                    order.company_id.account_use_credit_limit
-                    and order.partner_id.use_partner_credit_limit_order
-                ):
-                    total_pay = order.partner_id.credit + order.amount_total
-                    if total_pay > order.partner_id.credit_limit:
-                        decimal_places = order.currency_id.decimal_places
-                        raise ValidationError(
-                            _(
-                                "No se ha confirmado el presupuesto. Límite de crédito excedido. La cuenta por cobrar del cliente es de %s más %s en presupuesto da un total de %s superando el límite de ventas de %s. Por favor cancele el presupuesto o comuníquese con el administrador para aumentar el límite de crédito del cliente.",
-                                round(order.partner_id.credit, decimal_places),
-                                round(order.amount_total, decimal_places),
-                                round(total_pay, decimal_places),
-                                round(order.partner_id.credit_limit, decimal_places),
-                            )
+            # Validación de límite de crédito — independiente de not_allow_sell_products,
+            # antes corría solo cuando esa opción estaba activa y por lo tanto nunca
+            # se ejecutaba con la configuración por defecto de la compañía.
+            if (
+                not skip_credit_limit_check
+                and order.company_id.account_use_credit_limit
+                and order.partner_id.use_partner_credit_limit_order
+            ):
+                total_pay = order.partner_id.credit + order.amount_total
+                if total_pay > order.partner_id.credit_limit:
+                    decimal_places = order.currency_id.decimal_places
+                    raise ValidationError(
+                        _(
+                            "No se ha confirmado el presupuesto. Límite de crédito excedido. La cuenta por cobrar del cliente es de %s más %s en presupuesto da un total de %s superando el límite de ventas de %s. Por favor cancele el presupuesto o comuníquese con el administrador para aumentar el límite de crédito del cliente.",
+                            round(order.partner_id.credit, decimal_places),
+                            round(order.amount_total, decimal_places),
+                            round(total_pay, decimal_places),
+                            round(order.partner_id.credit_limit, decimal_places),
                         )
+                    )
 
-                    order._block_valid_confirm()
-
+                order._block_valid_confirm()
 
         res = super().action_confirm()
         for sale in self:

--- a/l10n_ve_sale/models/sale_order.py
+++ b/l10n_ve_sale/models/sale_order.py
@@ -636,10 +636,11 @@ class SaleOrder(models.Model):
             }
 
             raise UserError(
-                _("The budget cannot be confirmed. You have %s Invoices (%s).")
-                % (
-                    invoice_count_payment_state,
-                    payment_state_labels[block_order_invoice_payment_state],
+                _(
+                    "The budget cannot be confirmed. You have %(count)s "
+                    "Invoices (%(state)s).",
+                    count=invoice_count_payment_state,
+                    state=payment_state_labels[block_order_invoice_payment_state],
                 )
             )
 
@@ -647,12 +648,12 @@ class SaleOrder(models.Model):
             if amount_total_not_pay > block_order_invoice_total_amount_overdue:
                 raise UserError(
                     _(
-                        "The budget cannot be confirmed. Has an overdue amount of (%.2f) that cannot be greater than %.2f %s."
-                    )
-                    % (
-                        amount_total_not_pay,
-                        block_order_invoice_total_amount_overdue,
-                        invoice_id.currency_id.name,
+                        "The budget cannot be confirmed. Has an overdue amount "
+                        "of (%(amount).2f) that cannot be greater than "
+                        "%(limit).2f %(currency)s.",
+                        amount=amount_total_not_pay,
+                        limit=block_order_invoice_total_amount_overdue,
+                        currency=invoice_id.currency_id.name,
                     )
                 )
 
@@ -697,11 +698,17 @@ class SaleOrder(models.Model):
                     decimal_places = order.currency_id.decimal_places
                     raise ValidationError(
                         _(
-                            "No se ha confirmado el presupuesto. Límite de crédito excedido. La cuenta por cobrar del cliente es de %s más %s en presupuesto da un total de %s superando el límite de ventas de %s. Por favor cancele el presupuesto o comuníquese con el administrador para aumentar el límite de crédito del cliente.",
-                            round(order.partner_id.credit, decimal_places),
-                            round(order.amount_total, decimal_places),
-                            round(total_pay, decimal_places),
-                            round(order.partner_id.credit_limit, decimal_places),
+                            "No se ha confirmado el presupuesto. Límite de crédito "
+                            "excedido. La cuenta por cobrar del cliente es de "
+                            "%(debt)s más %(amount)s en presupuesto da un total de "
+                            "%(total)s superando el límite de ventas de %(limit)s. "
+                            "Por favor cancele el presupuesto o comuníquese con el "
+                            "administrador para aumentar el límite de crédito del "
+                            "cliente.",
+                            debt=round(order.partner_id.credit, decimal_places),
+                            amount=round(order.amount_total, decimal_places),
+                            total=round(total_pay, decimal_places),
+                            limit=round(order.partner_id.credit_limit, decimal_places),
                         )
                     )
 

--- a/l10n_ve_sale/openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix/design.md
+++ b/l10n_ve_sale/openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`l10n_ve_sale.action_confirm()` reescribe el `action_confirm` nativo de
+`sale.order` para dos validaciones propias de la localización venezolana:
+disponibilidad de stock (gateada por `not_allow_sell_products`) y límite de
+crédito (gateada por `account_use_credit_limit` +
+`use_partner_credit_limit_order`). Las dos viven en el mismo método, y la
+segunda quedó anidada dentro del `if` de la primera en algún punto de su
+historia — no hay ningún commit que documente la intención de acoplarlas.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Que el chequeo de crédito en `action_confirm` corra siempre que sus
+  propios gates lo indiquen, sin depender de una opción de stock sin
+  relación.
+- Dar un mecanismo de bypass explícito y nombrado igual al que ya existe en
+  `l10n_ve_accountant`, para consistencia entre los dos puntos de chequeo
+  del producto.
+
+**Non-Goals:**
+- No se resuelve aquí la falta de conversión de moneda en la comparación —
+  eso es explícitamente el trabajo de `integra-addons/binaural_credit_limit`,
+  que depende de este fix.
+- No se audita el resto del módulo en busca de acoplamientos similares.
+
+## Decisions
+
+- **Sacar el bloque de crédito del `if`, no envolver el `if` en una
+  condición más grande.** La opción más simple y la que menos superficie de
+  cambio introduce: el bloque de crédito pasa a ser un `if` hermano al de
+  stock, ambos dentro del mismo `for order in self:`.
+- **Nombrar el flag `skip_credit_limit_check`, no uno nuevo.** Ya existe ese
+  nombre exacto en `l10n_ve_accountant._is_subject_to_credit_limit()` con la
+  misma semántica (bypass explícito, nunca activado por defecto) — reusar el
+  nombre evita que quien integra ambos módulos tenga que aprender dos flags
+  para el mismo concepto.
+- **No fusionar `skip_credit_limit_check` con
+  `skip_not_allow_sell_products_validation`.** Son conceptos distintos; un
+  flujo que necesita saltar el chequeo de crédito (una orden ya aprobada
+  manualmente, por ejemplo) no debería tener que saltar también la
+  validación de stock como efecto colateral.
+
+## Risks / Trade-offs
+
+- **Este es un cambio de comportamiento real, no un refactor.** Cualquier
+  compañía VE con `account_use_credit_limit=True` y
+  `not_allow_sell_products=False` (la config por defecto) empezará a
+  bloquear presupuestos que hoy pasan sin aviso. Requiere sign-off de
+  Producto antes de mergear, con aviso explícito de que este es un fix de un
+  bug preexistente y no parte de la feature de moneda alterna en curso.
+- Sin test de regresión previo a este cambio — el que se agrega en este
+  mismo proposal es la primera cobertura que existe para este chequeo.
+
+## Migration Plan
+
+Sin migración de datos — es lógica de validación en memoria, no hay campos
+ni tablas involucradas. Requiere comunicar el cambio de comportamiento a los
+clientes VE con crédito activo antes del release (ver Risks).

--- a/l10n_ve_sale/openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix/proposal.md
+++ b/l10n_ve_sale/openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix/proposal.md
@@ -1,0 +1,65 @@
+# Ejecutar el chequeo de límite de crédito en `action_confirm` sin depender de `not_allow_sell_products`
+
+Tarea: [TA-81707](https://www.binauraldev.com/odoo/action-341/81707) — asociado como fix descubierto durante esa tarea, no un ticket de soporte separado.
+
+## Why
+
+`action_confirm()` (`l10n_ve_sale/models/sale_order.py`) tiene el bloque que
+valida el límite de crédito del cliente (`account_use_credit_limit` +
+`use_partner_credit_limit_order`) anidado **dentro** de
+`if self.env.company.not_allow_sell_products:`. Esa opción de compañía
+controla si se valida el stock disponible antes de confirmar un presupuesto
+— un concepto sin relación con crédito — y su valor por defecto es `False`.
+
+Consecuencia real: en cualquier compañía VE con `account_use_credit_limit`
+activo pero `not_allow_sell_products` desactivado (la configuración estándar
+para la enorme mayoría de instalaciones), **el chequeo de límite de crédito
+en presupuestos/pedidos nunca se ejecuta**. El equivalente en facturación
+(`l10n_ve_accountant.action_post`) sí es independiente y sí bloquea — hoy es
+posible confirmar un presupuesto muy por encima del límite del cliente sin
+ningún aviso, y solo enterarse al intentar postear la factura resultante.
+
+No hay ningún test que cubra el chequeo de crédito en este módulo — el bug
+pasó varias versiones (hasta la actual `19.0.1.0.6`) sin detectarse.
+
+Encontrado durante la investigación de la elevación a producto de "límite de
+crédito en moneda alterna" (ver
+`integra-addons/binaural_credit_limit/openspec/changes/binaural-credit-limit-foreign-currency/`),
+que necesita que este chequeo corra de verdad para poder hacerlo
+currency-aware — hoy estaría escribiendo una fórmula que en la práctica
+nunca se ejecuta.
+
+## What Changes
+
+- El bloque de límite de crédito se saca de adentro del `if
+  not_allow_sell_products` y pasa a evaluarse siempre (sujeto a sus propios
+  gates: `account_use_credit_limit` y `use_partner_credit_limit_order`),
+  igual que ya ocurre en `l10n_ve_accountant.action_post`.
+- Se agrega un context flag propio, `skip_credit_limit_check` — mismo
+  nombre y semántica que el que ya usa `l10n_ve_accountant` — para que un
+  flujo con autorización explícita pueda saltear el chequeo sin tener que
+  reutilizar `skip_not_allow_sell_products_validation` (que salta también
+  la validación de stock, sin relación).
+- `skip_not_allow_sell_products_validation` sigue existiendo tal cual, sin
+  cambios de comportamiento para la validación de stock.
+
+## Non-goals
+
+- No se toca la fórmula de comparación en sí (`partner.credit +
+  order.amount_total > partner.credit_limit`, sin conversión de moneda) —
+  eso es alcance de la elevación a producto en
+  `integra-addons/binaural_credit_limit`, que consume este fix como
+  prerequisito.
+- No se corrige aquí el mismo tipo de problema si aparece en otro lado del
+  código VE — este proposal cubre únicamente `l10n_ve_sale.action_confirm`.
+
+## Impact
+
+- **Módulo**: `l10n_ve_sale` (`models/sale_order.py`).
+- **Cambio de comportamiento real** para cualquier cliente VE con
+  `account_use_credit_limit=True` y `not_allow_sell_products=False`: el
+  chequeo de crédito en presupuestos, que hoy nunca corre, empieza a correr.
+  Requiere aviso explícito a Producto antes de mergear — no es un cambio
+  cosmético.
+- Sin cambios de modelo, vista ni seguridad.
+- Manifest: bump de versión pendiente de definir junto con el ID de ticket.

--- a/l10n_ve_sale/openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix/specs/credit-limit-blocking/spec.md
+++ b/l10n_ve_sale/openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix/specs/credit-limit-blocking/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: El límite de crédito se valida en toda confirmación de presupuesto
+
+Cuando `company.account_use_credit_limit` y
+`partner.use_partner_credit_limit_order` están activos,
+`sale.order.action_confirm()` SHALL bloquear la confirmación de cualquier
+presupuesto cuya deuda total proyectada (`partner.credit +
+order.amount_total`) supere `partner.credit_limit`, lanzando
+`ValidationError`.
+
+Esta validación SHALL ejecutarse independientemente del valor de
+`company.not_allow_sell_products` — esa opción gobierna únicamente la
+validación de disponibilidad de stock y no debe condicionar el chequeo de
+crédito.
+
+Un contexto con `skip_credit_limit_check=True` SHALL saltear esta
+validación por completo, para flujos con autorización explícita.
+
+#### Scenario: Bloqueo con la configuración estándar de compañía
+- **GIVEN** una compañía con `account_use_credit_limit=True` y
+  `not_allow_sell_products=False` (configuración por defecto)
+- **AND** un cliente con `use_partner_credit_limit_order=True` cuya deuda
+  más el presupuesto supera su límite
+- **WHEN** se confirma el presupuesto
+- **THEN** se lanza `ValidationError` y el presupuesto no se confirma
+
+#### Scenario: La validación de stock no afecta al chequeo de crédito
+- **GIVEN** la misma compañía y cliente del escenario anterior, con
+  `not_allow_sell_products` en `True` o en `False`
+- **THEN** el resultado del chequeo de crédito es el mismo en ambos casos
+
+#### Scenario: Bypass explícito
+- **GIVEN** un cliente sobre su límite de crédito
+- **WHEN** se confirma el presupuesto con `skip_credit_limit_check=True` en
+  el contexto
+- **THEN** el presupuesto se confirma sin lanzar `ValidationError`
+
+#### Scenario: Compañía sin el gate activo
+- **GIVEN** `company.account_use_credit_limit=False`
+- **THEN** el presupuesto se confirma sin ninguna validación de crédito, sin
+  importar el monto o el límite del cliente
+
+## Implementation
+
+| Component | Path |
+|---|---|
+| Modelo | `l10n_ve_sale/models/sale_order.py` |
+| Tests | `l10n_ve_sale/tests/test_action_confirm.py` |
+
+## Notes
+
+- Antes de este cambio, el bloque de crédito estaba anidado dentro de `if
+  company.not_allow_sell_products`, por lo que nunca se ejecutaba con la
+  configuración por defecto de compañía (`not_allow_sell_products=False`).
+- No hay conversión de moneda en esta comparación — `credit`/`credit_limit`
+  están en moneda de la compañía, `order.amount_total` en la moneda del
+  pedido. La versión currency-aware es responsabilidad de
+  `integra-addons/binaural_credit_limit`, que consume `action_confirm` una
+  vez corregido su alcance.

--- a/l10n_ve_sale/openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix/tasks.md
+++ b/l10n_ve_sale/openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix/tasks.md
@@ -1,0 +1,52 @@
+## 1. Diagnóstico
+
+- [x] 1.1 Confirmado leyendo el código real (no memoria) que el bloque de
+      crédito está anidado dentro de `if
+      self.env.company.not_allow_sell_products` en
+      `l10n_ve_sale/models/sale_order.py`.
+- [x] 1.2 Confirmado que `not_allow_sell_products` es `False` por default
+      (`l10n_ve_sale/models/res_company.py`).
+- [x] 1.3 Confirmado que no existe ningún test que cubra el chequeo de
+      crédito en `l10n_ve_sale` (`grep -rn "credit_limit"
+      l10n_ve_sale/tests/` vacío).
+- [x] 1.4 Confirmado que `l10n_ve_accountant.action_post` sí es
+      independiente y sí soporta `skip_credit_limit_check`.
+
+## 2. Fix
+
+- [x] 2.1 Sacar el bloque de crédito de adentro del `if
+      not_allow_sell_products`, como `if` hermano en el mismo `for order`.
+- [x] 2.2 Agregar `skip_credit_limit_check = self.env.context.get(
+      "skip_credit_limit_check", False)` y usarlo como primer gate del
+      bloque.
+- [x] 2.3 Bump de versión del manifest (`19.0.1.0.6` → `19.0.1.0.7`).
+
+## 3. Verificación
+
+- [ ] 3.1 Confirmar un presupuesto con `not_allow_sell_products=False`,
+      `account_use_credit_limit=True`, `use_partner_credit_limit_order=True`
+      y el cliente sobre el límite → antes del fix pasa (bug), después se
+      bloquea con `ValidationError`.
+- [ ] 3.2 Confirmar el mismo caso con `not_allow_sell_products=True` → se
+      comporta igual antes y después del fix (no regresión del caso que sí
+      funcionaba).
+- [ ] 3.3 Confirmar con `skip_credit_limit_check=True` en el contexto → no
+      bloquea, sin importar el resto de los gates.
+- [ ] 3.4 Confirmar que la validación de stock (`not_allow_sell_products`)
+      no cambia de comportamiento en ningún escenario.
+- [ ] 3.5 Agregar los tests automatizados descritos en
+      `specs/credit-limit-blocking/spec.md`.
+
+## 4. Pendiente de Producto
+
+- [ ] 4.1 Aviso explícito a Producto: este fix cambia comportamiento real
+      para clientes VE con crédito activo y `not_allow_sell_products`
+      desactivado. Sign-off requerido antes de mergear.
+- [x] 4.2 Asociado a TA-81707 y rama creada:
+      `19.0-fix-ta-81707-l10n-ve-sale-credit-limit-scope`.
+
+## 5. OpenSpec
+
+- [x] `proposal.md` + `design.md` + `tasks.md`
+- [x] Spec delta — `credit-limit-blocking` (ADDED)
+- [ ] `openspec validate --changes`

--- a/l10n_ve_sale/openspec/config.yaml
+++ b/l10n_ve_sale/openspec/config.yaml
@@ -1,0 +1,10 @@
+schema: spec-driven
+context: |
+  Módulo: l10n_ve_sale (src/odoo-venezuela, rama 19.0)
+  Tech stack: Odoo 19.0, Python, PostgreSQL
+  Dominio: Localización venezolana de Ventas — presupuestos/pedidos,
+    reglas de stock y límite de crédito específicas de VE sobre `sale.order`.
+  Dependencias: base, l10n_ve_base, sale, l10n_ve_rate, l10n_ve_contact,
+    l10n_ve_invoice, l10n_ve_filter_partner, l10n_ve_stock.
+  Core Odoo 19: sale.order.action_confirm en
+    /usr/lib/python3/dist-packages/odoo/addons/sale/models/sale_order.py

--- a/l10n_ve_sale/tests/test_action_confirm.py
+++ b/l10n_ve_sale/tests/test_action_confirm.py
@@ -1,3 +1,5 @@
+from odoo import fields
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 from odoo.tests import tagged
 
@@ -91,3 +93,76 @@ class TestActionConfirmServiceProducts(TransactionCase):
         sale_order.action_confirm()
         self.assertEqual(sale_order.state, 'sale')
         self.assertEqual(len(sale_order.picking_ids), 1)
+
+
+@tagged('post_install', '-at_install')
+class TestActionConfirmCreditLimit(TransactionCase):
+    """Cobertura del fix de alcance: el chequeo de crédito estaba anidado
+    dentro de `if not_allow_sell_products`, así que con la configuración
+    por defecto de compañía (`not_allow_sell_products=False`) nunca corría.
+    Ver openspec/changes/l10n-ve-sale-credit-limit-block-scope-fix.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.company
+        self.company.account_use_credit_limit = True
+        # l10n_ve_accountant calcula siempre un total en "moneda alterna"
+        # (`_get_tax_totals_summary`) al leer `order.amount_total`, y esa
+        # ruta revienta si la compañía no tiene `foreign_currency_id` con
+        # una tasa activa. En cualquier compañía VE real esto ya está
+        # configurado (es lo que usa `l10n_ve_rate`); acá se replica esa
+        # condición para no depender de un bug ajeno a este fix.
+        foreign_currency = self.env.ref('base.EUR')
+        foreign_currency.active = True
+        self.company.foreign_currency_id = foreign_currency
+        self.env['res.currency.rate'].create({
+            'currency_id': foreign_currency.id,
+            'company_id': self.company.id,
+            'name': fields.Date.today(),
+            'rate': 1.1,
+        })
+        self.partner = self.env['res.partner'].create({
+            'name': 'Credit Limit Partner',
+            'use_partner_credit_limit_order': True,
+            'credit_limit': 100.0,
+        })
+        self.product = self.env['product.product'].create({
+            'name': 'Expensive Product',
+            'type': 'service',
+            'list_price': 500.0,
+        })
+
+    def _create_order(self):
+        return self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product.id,
+                'product_uom_qty': 1,
+                'price_unit': 500.0,
+            })],
+        })
+
+    def test_blocks_over_limit_with_default_company_settings(self):
+        self.company.not_allow_sell_products = False
+        order = self._create_order()
+        with self.assertRaises(ValidationError):
+            order.action_confirm()
+
+    def test_stock_setting_does_not_change_credit_result(self):
+        self.company.not_allow_sell_products = True
+        order = self._create_order()
+        with self.assertRaises(ValidationError):
+            order.action_confirm()
+
+    def test_skip_credit_limit_check_bypasses_block(self):
+        self.company.not_allow_sell_products = False
+        order = self._create_order()
+        order.with_context(skip_credit_limit_check=True).action_confirm()
+        self.assertEqual(order.state, 'sale')
+
+    def test_company_flag_off_never_blocks(self):
+        self.company.account_use_credit_limit = False
+        order = self._create_order()
+        order.action_confirm()
+        self.assertEqual(order.state, 'sale')


### PR DESCRIPTION
## Resumen

El chequeo de límite de crédito en `action_confirm` estaba anidado dentro de `if not_allow_sell_products` (una opción que solo gobierna disponibilidad de stock, sin relación con crédito). Con la configuración por defecto de compañía (`not_allow_sell_products=False`), el chequeo de crédito en presupuestos **nunca se ejecutaba**.

- Se saca el bloque de crédito a un `if` hermano, evaluado siempre según sus propios gates (`account_use_credit_limit` + `use_partner_credit_limit_order`).
- Se agrega `skip_credit_limit_check` (mismo nombre que ya usa `l10n_ve_accountant`), para no depender de `skip_not_allow_sell_products_validation`.

**Prerequisito** de la elevación a producto del límite de crédito en moneda alterna (`integra-addons/binaural_credit_limit`, PR asociado): sin este fix, el chequeo currency-aware de esa elevación quedaría montado sobre un chequeo que en la práctica nunca corre.

⚠️ **Cambio de comportamiento real**: cualquier compañía VE con `account_use_credit_limit=True` y `not_allow_sell_products=False` empezará a bloquear presupuestos que hoy pasan sin aviso. Requiere sign-off de Producto antes de mergear.

## Test plan
- [x] 68/68 tests OK (`l10n_ve_sale`, base efímera nueva) — incluye 4 tests nuevos cubriendo el fix.
- [ ] Sign-off de Producto sobre el cambio de comportamiento.

## Referencias
- Tarea: https://www.binauraldev.com/odoo/action-341/81707