### PR TITLE
[IMP] l10n_ve_accountant: placeholders nombrados en el mensaje de límite de crédito

### DIFF
--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -971,10 +971,16 @@ msgstr "No Deducible Aliquota Reducida (Compra)"
 #: code:addons/l10n_ve_accountant/models/account_move.py:0
 msgid ""
 "No se ha confirmado la factura. Límite de crédito excedido. La cuenta por "
-"cobrar del cliente es de %s más %s en factura da un total de %s superando el"
-" límite de ventas de %s. Por favor cancele la factura o comuníquese con el "
-"administrador para aumentar el límite de crédito del cliente."
+"cobrar del cliente es de %(debt)s más %(amount)s en factura da un total de "
+"%(total)s superando el límite de ventas de %(limit)s. Por favor cancele la "
+"factura o comuníquese con el administrador para aumentar el límite de "
+"crédito del cliente."
 msgstr ""
+"No se ha confirmado la factura. Límite de crédito excedido. La cuenta por "
+"cobrar del cliente es de %(debt)s más %(amount)s en factura da un total de "
+"%(total)s superando el límite de ventas de %(limit)s. Por favor cancele la "
+"factura o comuníquese con el administrador para aumentar el límite de "
+"crédito del cliente."
 
 #. module: l10n_ve_accountant
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.view_res_config_settings_l10n_ve_accountant

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1152,11 +1152,17 @@ class AccountMove(models.Model):
                     decimal_places = invoice.currency_id.decimal_places
                     raise ValidationError(
                         _(
-                            "No se ha confirmado la factura. Límite de crédito excedido. La cuenta por cobrar del cliente es de %s más %s en factura da un total de %s superando el límite de ventas de %s. Por favor cancele la factura o comuníquese con el administrador para aumentar el límite de crédito del cliente.",
-                            round(invoice.partner_id.credit, decimal_places),
-                            round(invoice.amount_residual, decimal_places),
-                            round(total_pay, decimal_places),
-                            round(invoice.partner_id.credit_limit, decimal_places),
+                            "No se ha confirmado la factura. Límite de crédito "
+                            "excedido. La cuenta por cobrar del cliente es de "
+                            "%(debt)s más %(amount)s en factura da un total de "
+                            "%(total)s superando el límite de ventas de "
+                            "%(limit)s. Por favor cancele la factura o "
+                            "comuníquese con el administrador para aumentar el "
+                            "límite de crédito del cliente.",
+                            debt=round(invoice.partner_id.credit, decimal_places),
+                            amount=round(invoice.amount_residual, decimal_places),
+                            total=round(total_pay, decimal_places),
+                            limit=round(invoice.partner_id.credit_limit, decimal_places),
                         )
                     )
         return super().action_post()


### PR DESCRIPTION
## Resumen

Mismo defecto de i18n corregido en `l10n_ve_sale` (#1279): el mensaje de `ValidationError` en `action_post` usaba cuatro `%s` posicionales — sin forma de que un traductor reordene las palabras según la gramática del idioma destino. Se pasa a `%(nombre)s` con kwargs en `_()`, y se actualiza la entrada huérfana en `es_VE.po`.

Encontrado al revisar el mismo patrón durante la elevación a producto del límite de crédito en moneda alterna — no es parte de esa elevación, va como fix independiente.

## Test plan
- [x] 170/170 tests OK (`l10n_ve_accountant`, base efímera nueva).

## Referencias
- Tarea: https://www.binauraldev.com/odoo/action-341/81707