### PR TITLE
[FIX] l10n_ve_payment_extension: redondear el importe del fichero ISLR con el criterio de Odoo

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.27",
+    "version": "19.0.2.0.28",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/tests/__init__.py
+++ b/l10n_ve_payment_extension/tests/__init__.py
@@ -30,3 +30,4 @@ from . import test_data_files
 from . import test_allowed_lines_move_ids
 from . import test_retention_line_compute_amounts
 from . import test_retention_payment_move_date
+from . import test_islr_file_rounding

--- a/l10n_ve_payment_extension/tests/test_islr_file_rounding.py
+++ b/l10n_ve_payment_extension/tests/test_islr_file_rounding.py
@@ -1,0 +1,83 @@
+from odoo import Command, fields
+from odoo.tests import tagged
+from odoo.tools.float_utils import float_round
+
+from .test_withholding_common_VEF import RetentionTestCommon
+
+
+@tagged("post_install", "-at_install", "islr_file_rounding")
+class TestIslrFileRounding(RetentionTestCommon):
+    """El importe del fichero ISLR se redondea con el criterio de Odoo.
+
+    `round()` de Python redondea al par -`round(0.125, 2)` da 0.12- mientras
+    todo el resto del sistema redondea al alza. Es el fichero que se declara
+    al SENIAT: el sesgo no se cancela, crece con el numero de operaciones.
+
+    0.125 se eligio porque es EXACTO en binario, asi que el empate es real y
+    no un artefacto de la representacion: los dos criterios difieren de
+    verdad y el test discrimina.
+    """
+
+    def setUp(self):
+        hoy = fields.Date.today()
+        self.env["res.currency.rate"].search([
+            ("currency_id", "=", self.env.ref("base.USD").id),
+            ("name", "in", [hoy, fields.Date.subtract(hoy, days=1)]),
+        ]).unlink()
+        super().setUp()
+        if "subsidiary" in self.company._fields:
+            self.company.subsidiary = False
+
+    def _retention_line(self, amount, with_currency=True):
+        retention = self.env["account.retention"].create({
+            "type_retention": "islr",
+            "type": "in_invoice",
+            "company_id": self.company.id,
+            "partner_id": self.partner_pnr_75.id,
+            "date": fields.Date.today(),
+            "date_accounting": fields.Date.today(),
+        })
+        if not with_currency:
+            retention.foreign_currency_id = False
+        line = self.env["account.retention.line"].create({
+            "retention_id": retention.id,
+            "name": "ISLR",
+            "foreign_invoice_amount": amount,
+            "invoice_amount": amount,
+        })
+        return line
+
+    def _amount(self, line, is_vef_currency=True):
+        wizard = self.env["wizard.retention.islr"].create({"report": "islr"})
+        return wizard._islr_operation_amount(line, is_vef_currency)
+
+    def test_half_is_rounded_up_not_to_even(self):
+        line = self._retention_line(0.125)
+        valor = self._amount(line)
+        self.assertAlmostEqual(
+            valor, 0.13, places=6,
+            msg="El fichero del SENIAT debe redondear al alza, no al par.",
+        )
+        # La prueba de que el test discrimina: el criterio anterior daba otra
+        # cosa sobre este mismo numero.
+        self.assertNotAlmostEqual(round(0.125, 2), valor, places=6)
+
+    def test_line_without_currency_does_not_break_the_file(self):
+        """`foreign_currency_id` es un related nullable.
+
+        Con `currency.round()` esto reventaba con `Expected singleton` y
+        tumbaba la generacion del fichero completo, no una linea.
+        """
+        line = self._retention_line(0.125, with_currency=False)
+        self.assertFalse(line.foreign_currency_id)
+        valor = self._amount(line)
+        self.assertAlmostEqual(valor, 0.13, places=6)
+
+    def test_both_branches_use_the_same_criterion(self):
+        """La rama en divisa y la de compañía no pueden diferir de criterio."""
+        line = self._retention_line(0.125)
+        esperado = float_round(0.125, precision_digits=2, rounding_method="HALF-UP")
+        self.assertAlmostEqual(esperado, 0.13, places=6)
+        # Las dos ramas -divisa y moneda de compania- con el mismo criterio.
+        self.assertAlmostEqual(self._amount(line, True), esperado, places=6)
+        self.assertAlmostEqual(self._amount(line, False), esperado, places=6)

--- a/l10n_ve_payment_extension/wizard/wizard_retention_islr.py
+++ b/l10n_ve_payment_extension/wizard/wizard_retention_islr.py
@@ -1,3 +1,4 @@
+from odoo.tools.float_utils import float_round
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError,ValidationError
 import xlsxwriter
@@ -150,6 +151,36 @@ class RetentionIslrReport(models.TransientModel):
         return new_model_row
 
     @api.model    
+    def _islr_operation_amount(self, ret_line_id, is_vef_currency):
+        """El "Monto Operacion" del fichero ISLR, con el criterio de Odoo.
+
+        Estaba con `round(x, 2)` de Python, que redondea al PAR
+        -`round(0.125, 2)` da 0.12- mientras todo el resto del sistema,
+        empezando por los propios campos Monetary, redondea al alza. Es el
+        unico punto donde un importe que va a un fichero de declaracion usaba
+        el criterio contrario, y el sesgo no se cancela: crece con el numero
+        de operaciones declaradas.
+
+        Se fijan dos decimales porque el layout del SENIAT manda dos. Lo que
+        cambia es el criterio para llegar a ellos, no la cantidad.
+
+        `float_round` en vez de `currency.round()`: el campo de moneda de la
+        linea es un related no almacenado a traves de `retention_id` y puede
+        venir vacio -no es required ni en la retencion ni en la compania-, y
+        ahi `currency.round()` haria `ensure_one()` sobre un recordset vacio y
+        tumbaria la generacion del fichero entero. Justo el caso en que el ORM
+        tampoco redondeo el Monetary, que es cuando esto hace falta.
+
+        Vive aparte del constructor de fila para poder probarse sin montar una
+        retencion ISLR completa.
+        """
+        amount = (
+            ret_line_id.foreign_invoice_amount
+            if is_vef_currency
+            else ret_line_id.invoice_amount
+        )
+        return float_round(amount, precision_digits=2, rounding_method="HALF-UP")
+
     def _get_retention_islr_excel_row(self, row_idx, ret_line_id, is_vef_currency):
 
         new_row = self._get_retention_islr_excel_model_row()
@@ -183,8 +214,15 @@ class RetentionIslrReport(models.TransientModel):
 
         new_row["Código Concepto"] = concept
 
-        new_row["Monto Operación"] = (
-            round(ret_line_id.foreign_invoice_amount, 2) if is_vef_currency else ret_line_id.invoice_amount
+        # Se redondea con la moneda del propio campo, no con round() de
+        # Python: round() aplica banker's rounding -redondea al par, asi que
+        # round(2.675, 2) da 2.67 y round(1.005, 2) da 1.0- mientras que todo
+        # el resto del sistema, empezando por los propios campos Monetary,
+        # redondea al alza. Dos criterios distintos sobre un importe que va a
+        # un fichero de declaracion.
+        #
+        new_row["Monto Operación"] = self._islr_operation_amount(
+            ret_line_id, is_vef_currency
         )
 
         new_row["Porcentaje de retención"] = alicuota


### PR DESCRIPTION
## Qué corrige

`round()` de Python redondea **al par** y el resto del sistema redondea al alza. `round(0.125, 2)` da 0,12; Odoo da 0,13.

Era el único punto donde un importe que va al fichero de declaración del SENIAT usaba el criterio contrario al del resto del sistema. **El sesgo no se cancela**: crece con el número de operaciones declaradas y el total del fichero deja de cuadrar con la suma de las líneas.

## Cómo

`float_round(..., precision_digits=2, rounding_method="HALF-UP")`, no `currency.round()`.

Los dos decimales se siguen fijando a mano porque **el layout del SENIAT manda dos**: lo que cambia es el criterio para llegar a ellos, no la cantidad.

Anclarlo a la moneda habría creado un modo de fallo peor: el campo de moneda de la línea es un `related` no almacenado a través de `retention_id`, puede venir vacío —no es `required` ni en la retención ni en la compañía— y ahí `currency.round()` hace `ensure_one()` sobre un recordset vacío y **tumba la generación del fichero completo**, no una línea. Justo el caso en que el ORM tampoco redondeó el Monetary, que es cuando esto hace falta.

Las dos ramas —importe en divisa e importe en moneda de compañía— pasan ahora por el mismo criterio; antes la segunda salía sin redondear.

## Punto para el revisor

La regla vive en `_islr_operation_amount`, aparte del constructor de fila, para poder probarse sin montar una retención ISLR completa. Es la razón del pequeño refactor.

## Verificación

Los tests usan **0,125 porque es exacto en binario**: el empate es real y los dos criterios difieren de verdad, así que el test falla sin el cambio en vez de limitarse a comprobar el comportamiento de CPython.

`0 failed, 0 error(s) of 3 tests`, y 32 corriendo junto al resto del ticket.

## Colisión previsible

Sube `l10n_ve_payment_extension` a `19.0.2.0.28`, igual que los otros dos PRs del ticket en este repo.

## Fuera de alcance, detectado al revisar

`controllers/iva_report.py:31-37` escribe cinco importes del TXT de retenciones de IVA con `"{:.2f}".format(...)`, que tiene **el mismo sesgo** que se corrige aquí y sobre importes que no vienen de campos Monetary. Merece su propio ticket.

References:
- Ticket: #15069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
