### PR TITLE
[FIX] l10n_ve_payment_extension: importes del reporte de retenciones con su moneda

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.27",
+    "version": "19.0.2.0.28",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/report/retention_line_report.py
+++ b/l10n_ve_payment_extension/report/retention_line_report.py
@@ -20,11 +20,18 @@ class RetentionLineReport(models.Model):
     retention_date_accounting = fields.Date()
     raw_aliquot = fields.Char()
     aliquot = fields.Char(compute="_compute_percentages")
-    iva_amount = fields.Float()
-    invoice_amount = fields.Float()
+    # Importes monetarios anclados a `currency_id`, que la consulta rellena
+    # con la moneda en la que efectivamente vienen. Eran `fields.Float()`
+    # pelados, sin `digits` y sin moneda, y la MISMA columna traia importes en
+    # moneda de compania o en divisa segun `use_foreign_currency`: un numero en
+    # pantalla que no decia en que moneda estaba, y que cambiaba de moneda
+    # segun la compania desde la que se mirara.
+    currency_id = fields.Many2one("res.currency", string="Currency", readonly=True)
+    iva_amount = fields.Monetary(currency_field="currency_id")
+    invoice_amount = fields.Monetary(currency_field="currency_id")
     raw_retention_percentage = fields.Char()
     retention_percentage = fields.Char(compute="_compute_percentages")
-    retention_amount = fields.Float()
+    retention_amount = fields.Monetary(currency_field="currency_id")
     state = fields.Char()
     state_show = fields.Char(string="State")
     type = fields.Char()
@@ -46,16 +53,21 @@ class RetentionLineReport(models.Model):
             "base.VEF", raise_if_not_found=False
         )
         use_foreign_currency = self.env.company.currency_id.id != base_vef_id
+        # La moneda viaja junto a los importes: si la consulta cambia de
+        # columnas, cambia tambien de moneda, y las dos cosas tienen que
+        # decidirse en el mismo sitio o vuelven a divergir.
         amounts_query = """
             rl.iva_amount AS iva_amount,
             rl.invoice_amount AS invoice_amount,
             rl.retention_amount AS retention_amount,
+            r.company_currency_id AS currency_id,
         """
         if use_foreign_currency:
             amounts_query = """
                 rl.foreign_iva_amount AS iva_amount,
                 rl.foreign_invoice_amount AS invoice_amount,
                 rl.foreign_retention_amount AS retention_amount,
+                r.foreign_currency_id AS currency_id,
             """
 
         return (

--- a/l10n_ve_payment_extension/tests/__init__.py
+++ b/l10n_ve_payment_extension/tests/__init__.py
@@ -30,3 +30,4 @@ from . import test_data_files
 from . import test_allowed_lines_move_ids
 from . import test_retention_line_compute_amounts
 from . import test_retention_payment_move_date
+from . import test_retention_report_currency

--- a/l10n_ve_payment_extension/tests/test_retention_report_currency.py
+++ b/l10n_ve_payment_extension/tests/test_retention_report_currency.py
@@ -1,0 +1,42 @@
+from odoo import fields
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "retention_report_currency")
+class TestRetentionLineReportCurrency(TransactionCase):
+    """Los importes del reporte dicen en que moneda estan.
+
+    La vista SQL mete en las MISMAS columnas los importes en moneda de
+    compania o los de divisa segun `use_foreign_currency`, y los campos eran
+    `Float` pelados. Un usuario leia un numero sin saber su moneda, y la
+    moneda cambiaba segun la compania desde la que se mirara.
+    """
+
+    def test_amount_fields_are_monetary_and_anchored(self):
+        fields_def = self.env["retention.line.report"]._fields
+        self.assertIn("currency_id", fields_def)
+        for name in ("iva_amount", "invoice_amount", "retention_amount"):
+            self.assertEqual(
+                fields_def[name].type, "monetary",
+                "%s es un importe monetario del reporte" % name,
+            )
+            self.assertEqual(fields_def[name].currency_field, "currency_id")
+
+    def test_query_selects_a_currency_next_to_the_amounts(self):
+        """La moneda y los importes se deciden en el mismo sitio.
+
+        Si alguien cambia las columnas de importe sin tocar la moneda, la
+        vista volveria a mostrar cifras sin moneda o con la equivocada.
+        """
+        select = self.env["retention.line.report"]._select()
+        self.assertIn("AS currency_id", select)
+        # Las dos ramas -compañía y divisa- tienen que traer su moneda.
+        self.assertEqual(select.count("AS currency_id"), 1)
+
+    def test_report_rows_carry_a_currency(self):
+        rows = self.env["retention.line.report"].search([], limit=5)
+        for row in rows:
+            self.assertTrue(
+                row.currency_id,
+                "una fila del reporte no puede venir sin moneda",
+            )


### PR DESCRIPTION
## Qué corrige

`retention.line.report` mostraba importes **sin decir en qué moneda están**, y la moneda cambiaba según quién mirara.

Los tres importes del reporte —`iva_amount`, `invoice_amount`, `retention_amount`— eran `fields.Float()` pelados, sin `digits` y sin `currency_field`. Y `_select()` mete en **esas mismas columnas** los importes en moneda de compañía o los importes en divisa según `use_foreign_currency`.

Resultado: la misma columna del Retention Analysis Report cambia de moneda según la compañía desde la que se mire, y nada en pantalla lo indica.

## Cómo

`Monetary` anclados a un `currency_id` que la propia consulta rellena, **en el mismo bloque donde elige las columnas**. Si alguien cambia los importes sin tocar la moneda, las dos cosas ya no pueden divergir porque se deciden juntas.

## Contexto: sustituye a un intento anterior

Este PR reemplaza a uno que anclaba a su moneda tres campos de `account.retention.line` (`amount_tax_ret`, `base_ret`, `imp_ret`). Aquel iba a un sitio equivocado por dos razones, ambas destapadas en revisión:

1. **Esos tres campos están muertos** — no hay una sola escritura en ningún repo, y su único formulario no se abre desde ninguna acción.
2. Pasarlos a `Monetary` habría **empeorado** el redondeo: su `currency_field` es un `related` no almacenado que puede venir vacío, y `Monetary` no redondea sin moneda, mientras `Float(digits=(16,2))` redondeaba siempre.

Retirar esos campos muertos es un `[REM]` aparte, y conviene confirmarlo contra producción y no contra un grep local.

## Verificación

`0 failed, 0 error(s) of 3 tests`, y 32 corriendo junto al resto del ticket.

## Colisión previsible

Sube `l10n_ve_payment_extension` a `19.0.2.0.28`, igual que los otros dos PRs del ticket en este repo.

References:
- Ticket: #15069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
