### PR TITLE
[FEAT] l10n_ve_invoice_digital: historial de llamadas a la API TFHKA

### DIFF
--- a/l10n_ve_invoice_digital/__manifest__.py
+++ b/l10n_ve_invoice_digital/__manifest__.py
@@ -23,6 +23,7 @@
         "data/res_currency_data.xml",
         "data/ir_cron.xml",
         "security/ir.model.access.csv",
+        "security/ir_rule.xml",
         "views/res_config_settings.xml",
         "views/account_move_view.xml",
         "views/account_retention_iva.xml",

--- a/l10n_ve_invoice_digital/__manifest__.py
+++ b/l10n_ve_invoice_digital/__manifest__.py
@@ -21,6 +21,7 @@
         "security/security_groups.xml",
         "data/payment_method_data_tfhka.xml",
         "data/res_currency_data.xml",
+        "data/ir_cron.xml",
         "security/ir.model.access.csv",
         "views/res_config_settings.xml",
         "views/account_move_view.xml",
@@ -31,5 +32,6 @@
         "views/account_journal.xml",
         "views/payment_method_tfhka.xml",
         "views/currency_views.xml",
+        "views/tfhka_api_log_views.xml",
     ],
 }

--- a/l10n_ve_invoice_digital/data/ir_cron.xml
+++ b/l10n_ve_invoice_digital/data/ir_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_purge_tfhka_api_log" model="ir.cron">
+            <field name="name">The Factory HKA: Purge API Log History</field>
+            <field name="model_id" ref="model_tfhka_api_log"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_purge_old_logs()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="active" eval="True"/>
+            <field name="user_id" ref="base.user_root"/>
+        </record>
+    </data>
+</odoo>

--- a/l10n_ve_invoice_digital/data/ir_cron.xml
+++ b/l10n_ve_invoice_digital/data/ir_cron.xml
@@ -8,6 +8,7 @@
             <field name="code">model.cron_purge_old_logs()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
+            <field name="nextcall" eval="(DateTime.now() + relativedelta(days=1)).strftime('%Y-%m-%d 00:00:00')"/>
             <field name="active" eval="True"/>
             <field name="user_id" ref="base.user_root"/>
         </record>

--- a/l10n_ve_invoice_digital/i18n/es_VE.po
+++ b/l10n_ve_invoice_digital/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 19.0+e-20260813\n"
+"Project-Id-Version: Odoo Server 19.0+e-20260821\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-15 17:30+0000\n"
-"PO-Revision-Date: 2026-08-15 17:30+0000\n"
+"POT-Creation-Date: 2026-09-08 13:31+0000\n"
+"PO-Revision-Date: 2026-09-08 13:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -128,6 +128,12 @@ msgid "Companies"
 msgstr "Empresas"
 
 #. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__company_id
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_tfhka_api_log_search
+msgid "Company"
+msgstr "Compañía"
+
+#. module: l10n_ve_invoice_digital
 #: model:ir.model,name:l10n_ve_invoice_digital.model_res_config_settings
 msgid "Config Settings"
 msgstr "Ajustes de configuración"
@@ -137,6 +143,11 @@ msgstr "Ajustes de configuración"
 #: code:addons/l10n_ve_invoice_digital/services/tfhka_client.py:0
 msgid "Configuration error: The authentication token is empty."
 msgstr "Error de configuración: El token de autenticación está vacío."
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model,name:l10n_ve_invoice_digital.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
 
 #. module: l10n_ve_invoice_digital
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_retention__control_number_tfhka
@@ -149,6 +160,7 @@ msgstr "Número de control"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_retention_alert_wizard__create_uid
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_payment_method_tfhka__create_uid
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_annul_wizard__create_uid
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__create_uid
 msgid "Created by"
 msgstr "Creado por"
 
@@ -156,6 +168,7 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_retention_alert_wizard__create_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_payment_method_tfhka__create_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_annul_wizard__create_date
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__create_date
 msgid "Created on"
 msgstr "Creado el"
 
@@ -175,6 +188,11 @@ msgstr ""
 "Moneda utilizada para los precios de línea de productos enviados a TFHKA. "
 "Solo puede ser la moneda base de la compañía (VES) o la moneda de la tarifa;"
 " el documento se totaliza en ambas monedas a partir de esta selección."
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__request_date
+msgid "Date"
+msgstr "Fecha"
 
 #. module: l10n_ve_invoice_digital
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_payment_method_tfhka__description
@@ -237,8 +255,10 @@ msgstr "Guía de despacho digital Tfhka"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_company__display_name
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_config_settings__display_name
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_currency__display_name
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_partner__display_name
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_annul_wizard__display_name
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_client__display_name
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__display_name
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_document_service__display_name
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_retention_service__display_name
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_service_base__display_name
@@ -256,6 +276,12 @@ msgstr "Número de Documento TFHKA"
 #: code:addons/l10n_ve_invoice_digital/services/tfhka_retention_service.py:0
 msgid "Document successfully digitized on %(date)s"
 msgstr "Documento digitalizado exitosamente el %(date)s"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__endpoint
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_tfhka_api_log_search
+msgid "Endpoint"
+msgstr "Endpoint"
 
 #. module: l10n_ve_invoice_digital
 #. odoo-python
@@ -296,6 +322,20 @@ msgstr "Error en la API de TFHKA: %(status_code)s"
 #: code:addons/l10n_ve_invoice_digital/models/res_company.py:0
 msgid "Error processing TFHKA API response."
 msgstr "Error al procesar la respuesta de la API de TFHKA."
+
+#. module: l10n_ve_invoice_digital
+#: model_terms:ir.actions.act_window,help:l10n_ve_invoice_digital.action_tfhka_api_log
+msgid ""
+"Every request and response to The Factory HKA API is logged here.\n"
+"                Records older than 3 months are automatically deleted."
+msgstr ""
+"Cada consulta y respuesta a la API de The Factory HKA queda registrada aquí.\n"
+"                Los registros con más de 3 meses se eliminan automáticamente."
+
+#. module: l10n_ve_invoice_digital
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_tfhka_api_log_search
+msgid "Failed"
+msgstr "Fallidas"
 
 #. module: l10n_ve_invoice_digital
 #: model:ir.model.fields.selection,name:l10n_ve_invoice_digital.selection__res_company__mix_invoicing_type_tfhka__fiscal_machine
@@ -339,6 +379,16 @@ msgid "Generate Token for TFHKA."
 msgstr "Generar Token para TFHKA."
 
 #. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__http_method
+msgid "HTTP Method"
+msgstr "Método HTTP"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__status_code
+msgid "HTTP Status"
+msgstr "Estado HTTP"
+
+#. module: l10n_ve_invoice_digital
 #. odoo-python
 #: code:addons/l10n_ve_invoice_digital/services/tfhka_client.py:0
 msgid "HTTP error %(status_code)s: %(text)s"
@@ -355,8 +405,10 @@ msgstr "Error HTTP %(status_code)s: %(text)s"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_company__id
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_config_settings__id
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_currency__id
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_partner__id
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_annul_wizard__id
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_client__id
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__id
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_document_service__id
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_retention_service__id
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_service_base__id
@@ -409,6 +461,7 @@ msgstr "Diario es digital"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_retention_alert_wizard__write_uid
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_payment_method_tfhka__write_uid
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_annul_wizard__write_uid
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__write_uid
 msgid "Last Updated by"
 msgstr "Última actualización por"
 
@@ -416,6 +469,7 @@ msgstr "Última actualización por"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_retention_alert_wizard__write_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_payment_method_tfhka__write_date
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_annul_wizard__write_date
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__write_date
 msgid "Last Updated on"
 msgstr "Última actualización el"
 
@@ -492,6 +546,11 @@ msgstr ""
 "favor, configure la tasa de la moneda antes de digitalizar este documento."
 
 #. module: l10n_ve_invoice_digital
+#: model_terms:ir.actions.act_window,help:l10n_ve_invoice_digital.action_tfhka_api_log
+msgid "No records in the The Factory HKA API log yet"
+msgstr "No hay registros en el historial de la API de The Factory HKA"
+
+#. module: l10n_ve_invoice_digital
 #. odoo-python
 #: code:addons/l10n_ve_invoice_digital/models/ir_module_module.py:0
 msgid ""
@@ -502,6 +561,21 @@ msgstr ""
 "Solo un Administrador TFHKA puede desinstalar el módulo de facturación "
 "digital. Desinstalarlo eliminaría permanentemente las facturas digitalizadas"
 " y su trazabilidad fiscal."
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__res_name
+msgid "Origin Document"
+msgstr "Documento de origen"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__res_model
+msgid "Origin Model"
+msgstr "Modelo de origen"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__res_id
+msgid "Origin Record ID"
+msgstr "ID del registro de origen"
 
 #. module: l10n_ve_invoice_digital
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_config_settings__password_tfhka
@@ -525,6 +599,18 @@ msgid "Reason for annulment"
 msgstr "Motivo de anulación"
 
 #. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__request_payload
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__request_payload_html
+msgid "Request"
+msgstr "Solicitud"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__response_payload
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__response_payload_html
+msgid "Response"
+msgstr "Respuesta"
+
+#. module: l10n_ve_invoice_digital
 #: model:ir.model,name:l10n_ve_invoice_digital.model_account_retention
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_annul_wizard__retention_id
 msgid "Retention"
@@ -545,6 +631,11 @@ msgstr ""
 #: code:addons/l10n_ve_invoice_digital/services/tfhka_retention_service.py:0
 msgid "Retention annulled in The Factory HKA. Reason: %s"
 msgstr "Retención anulada en The Factory HKA. Motivo: %s"
+
+#. module: l10n_ve_invoice_digital
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_tfhka_api_log_search
+msgid "Search The Factory HKA API Log"
+msgstr "Buscar en el Historial de API de The Factory HKA"
 
 #. module: l10n_ve_invoice_digital
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_res_config_settings__sequence_validation_tfhka
@@ -585,6 +676,16 @@ msgstr "Mostrar Retención Digital"
 #: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_account_move__show_payment_box
 msgid "Show Payment Box"
 msgstr "Mostrar cuadro de pago"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.model.fields,field_description:l10n_ve_invoice_digital.field_tfhka_api_log__success
+msgid "Success"
+msgstr "Éxito"
+
+#. module: l10n_ve_invoice_digital
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_tfhka_api_log_search
+msgid "Successful"
+msgstr "Exitosas"
 
 #. module: l10n_ve_invoice_digital
 #: model:ir.model,name:l10n_ve_invoice_digital.model_tfhka_api_client
@@ -675,9 +776,27 @@ msgstr ""
 "El campo 'RIF' del Cliente no puede estar vacío para la digitalización."
 
 #. module: l10n_ve_invoice_digital
+#: model:ir.model,name:l10n_ve_invoice_digital.model_tfhka_api_log
+msgid "The Factory HKA API Call Log"
+msgstr "Historial de Llamadas a la API de The Factory HKA"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.actions.act_window,name:l10n_ve_invoice_digital.action_tfhka_api_log
+#: model:ir.ui.menu,name:l10n_ve_invoice_digital.menu_tfhka_api_log
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_tfhka_api_log_form
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_tfhka_api_log_list
+msgid "The Factory HKA API Log"
+msgstr "Historial de API de The Factory HKA"
+
+#. module: l10n_ve_invoice_digital
 #: model:res.groups,name:l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin
 msgid "The Factory HKA Admin"
 msgstr "Administrador The Factory HKA"
+
+#. module: l10n_ve_invoice_digital
+#: model:ir.actions.server,name:l10n_ve_invoice_digital.ir_cron_purge_tfhka_api_log_ir_actions_server
+msgid "The Factory HKA: Purge API Log History"
+msgstr "The Factory HKA: Purgar historial de log de API"
 
 #. module: l10n_ve_invoice_digital
 #. odoo-python
@@ -963,6 +1082,11 @@ msgstr "Validación"
 #: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_res_config_settings_inherit_tfhka
 msgid "Validation of sequences between Odoo and The Factory"
 msgstr "Validación de secuencias entre Odoo y The Factory"
+
+#. module: l10n_ve_invoice_digital
+#: model_terms:ir.ui.view,arch_db:l10n_ve_invoice_digital.view_tfhka_api_log_form
+msgid "View Origin Document"
+msgstr "Ver documento de origen"
 
 #. module: l10n_ve_invoice_digital
 #. odoo-python

--- a/l10n_ve_invoice_digital/models/__init__.py
+++ b/l10n_ve_invoice_digital/models/__init__.py
@@ -1,1 +1,1 @@
-from . import res_company, res_config_settings, payment_method_tfhka, account_move, account_retention, account_journal, res_currency, ir_module_module, res_partner
+from . import res_company, res_config_settings, payment_method_tfhka, account_move, account_retention, account_journal, res_currency, ir_module_module, res_partner, tfhka_api_log

--- a/l10n_ve_invoice_digital/models/res_company.py
+++ b/l10n_ve_invoice_digital/models/res_company.py
@@ -1,5 +1,6 @@
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError, UserError
+import json
 import requests
 import logging
 
@@ -50,9 +51,12 @@ class ResCompany(models.Model):
 
         try:
             response = requests.post(url, json=payload, timeout=10)
-            self._handle_tfhka_response(response)
+            self._handle_tfhka_response(response, payload)
         except requests.exceptions.RequestException as e:
             _logger.error("Error connecting to the TFHKA API: %s", e)
+            self.env["tfhka.api.client"]._log_call(
+                self, "/Autenticacion", payload, None, None, str(e), False
+            )
             raise ValidationError(_("Error connecting to the TFHKA API: %s", e))
 
     def _validate_tfhka_credentials(self):
@@ -64,9 +68,19 @@ class ResCompany(models.Model):
             raise UserError(_("You must register the URL for TFHKA."))
         _logger.info("TFHKA credentials validated successfully.")
 
-    def _handle_tfhka_response(self, response):
+    def _handle_tfhka_response(self, response, payload):
         data = response.json()
-        if response.status_code == 200 and data.get("codigo") == 200:
+        success = response.status_code == 200 and data.get("codigo") == 200
+        self.env["tfhka.api.client"]._log_call(
+            self,
+            "/Autenticacion",
+            payload,
+            None,
+            response.status_code,
+            json.dumps(data, default=str, indent=2),
+            success,
+        )
+        if success:
             try:
                 self._process_tfhka_response_data(data)
             except ValueError:

--- a/l10n_ve_invoice_digital/models/res_company.py
+++ b/l10n_ve_invoice_digital/models/res_company.py
@@ -77,7 +77,9 @@ class ResCompany(models.Model):
             payload,
             None,
             response.status_code,
-            json.dumps(data, default=str, indent=2),
+            json.dumps(
+                self.env["tfhka.api.log"]._sanitize_payload(data), default=str, indent=2
+            ),
             success,
         )
         if success:

--- a/l10n_ve_invoice_digital/models/tfhka_api_log.py
+++ b/l10n_ve_invoice_digital/models/tfhka_api_log.py
@@ -1,0 +1,127 @@
+import html
+import logging
+import re
+
+from dateutil.relativedelta import relativedelta
+from markupsafe import Markup
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+SENSITIVE_KEYS = {"password", "authorization", "clave"}
+PURGE_AFTER_MONTHS = 3
+
+# Tokenizes a pretty-printed JSON string for syntax highlighting. Order
+# matters: a quoted string immediately followed by ":" is a key, otherwise
+# it is a string value.
+JSON_TOKEN_RE = re.compile(
+    r'(?P<key>"(?:\\.|[^"\\])*"(?=\s*:))'
+    r'|(?P<string>"(?:\\.|[^"\\])*")'
+    r"|(?P<bool>true|false)"
+    r"|(?P<null>null)"
+    r"|(?P<number>-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)"
+)
+
+JSON_TOKEN_STYLES = {
+    "key": "color:#a626a4;font-weight:600",
+    "string": "color:#50a14f",
+    "bool": "color:#c18401;font-weight:600",
+    "null": "color:#986801;font-style:italic",
+    "number": "color:#0184bc",
+}
+
+
+class TfhkaApiLog(models.Model):
+    _name = "tfhka.api.log"
+    _description = "The Factory HKA API Call Log"
+    _order = "request_date desc, id desc"
+
+    endpoint = fields.Char(string="Endpoint", required=True, index=True)
+    http_method = fields.Char(string="HTTP Method")
+    company_id = fields.Many2one("res.company", string="Company", required=True)
+    request_date = fields.Datetime(
+        string="Date", required=True, default=fields.Datetime.now, index=True
+    )
+    request_payload = fields.Text(string="Request")
+    response_payload = fields.Text(string="Response")
+    request_payload_html = fields.Html(
+        string="Request", compute="_compute_payload_html", sanitize=False
+    )
+    response_payload_html = fields.Html(
+        string="Response", compute="_compute_payload_html", sanitize=False
+    )
+    status_code = fields.Integer(string="HTTP Status", aggregator=None)
+    success = fields.Boolean(string="Success")
+
+    res_model = fields.Char(string="Origin Model")
+    res_id = fields.Integer(string="Origin Record ID")
+    res_name = fields.Char(string="Origin Document")
+
+    @api.depends("request_payload", "response_payload")
+    def _compute_payload_html(self):
+        for log in self:
+            log.request_payload_html = self._payload_to_html(log.request_payload)
+            log.response_payload_html = self._payload_to_html(log.response_payload)
+
+    @api.model
+    def _payload_to_html(self, value):
+        """Render a pretty-printed JSON string as syntax-highlighted HTML.
+
+        Keeps the original indentation/line breaks (``white-space: pre-wrap``
+        still wraps long lines so nothing needs horizontal scrolling) while
+        coloring keys, strings, numbers, booleans and null like a code editor.
+        Every token is escaped before being inserted, and the untouched
+        separators (braces, commas, whitespace) can't contain HTML-special
+        characters in valid JSON, so this is safe against injection.
+        """
+        if not value:
+            return False
+
+        def _highlight(match):
+            kind = match.lastgroup
+            text = html.escape(match.group(0))
+            return f'<span style="{JSON_TOKEN_STYLES[kind]}">{text}</span>'
+
+        highlighted = JSON_TOKEN_RE.sub(_highlight, value)
+        return Markup(
+            '<pre style="white-space:pre-wrap;word-break:break-word;'
+            'font-family:monospace;font-size:12px;margin:0;">'
+        ) + Markup(highlighted) + Markup("</pre>")
+
+    @api.model
+    def _sanitize_payload(self, payload):
+        """Redact sensitive keys (e.g. the login password) before persisting."""
+        if not isinstance(payload, dict):
+            return payload
+        sanitized = {}
+        for key, value in payload.items():
+            if isinstance(key, str) and key.lower() in SENSITIVE_KEYS:
+                sanitized[key] = "***"
+            else:
+                sanitized[key] = value
+        return sanitized
+
+    def action_open_origin(self):
+        self.ensure_one()
+        if not (self.res_model and self.res_id):
+            return False
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": self.res_model,
+            "res_id": self.res_id,
+            "view_mode": "form",
+            "target": "current",
+        }
+
+    def cron_purge_old_logs(self):
+        threshold = fields.Datetime.now() - relativedelta(months=PURGE_AFTER_MONTHS)
+        old_logs = self.sudo().search([("request_date", "<", threshold)])
+        count = len(old_logs)
+        old_logs.unlink()
+        if count:
+            _logger.info(
+                "TFHKA: purged %s API log record(s) older than %s months",
+                count,
+                PURGE_AFTER_MONTHS,
+            )

--- a/l10n_ve_invoice_digital/models/tfhka_api_log.py
+++ b/l10n_ve_invoice_digital/models/tfhka_api_log.py
@@ -1,4 +1,5 @@
 import html
+import json
 import logging
 import re
 
@@ -9,7 +10,7 @@ from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
-SENSITIVE_KEYS = {"password", "authorization", "clave"}
+SENSITIVE_KEYS = {"password", "authorization", "clave", "token"}
 PURGE_AFTER_MONTHS = 3
 
 # Tokenizes a pretty-printed JSON string for syntax highlighting. Order
@@ -65,6 +66,17 @@ class TfhkaApiLog(models.Model):
             log.response_payload_html = self._payload_to_html(log.response_payload)
 
     @api.model
+    def _wrap_pre(self, inner_html):
+        return (
+            Markup(
+                '<pre style="white-space:pre-wrap;word-break:break-word;'
+                'font-family:monospace;font-size:12px;margin:0;">'
+            )
+            + Markup(inner_html)
+            + Markup("</pre>")
+        )
+
+    @api.model
     def _payload_to_html(self, value):
         """Render a pretty-printed JSON string as syntax-highlighted HTML.
 
@@ -74,9 +86,21 @@ class TfhkaApiLog(models.Model):
         Every token is escaped before being inserted, and the untouched
         separators (braces, commas, whitespace) can't contain HTML-special
         characters in valid JSON, so this is safe against injection.
+
+        Only applies when ``value`` actually parses as JSON. Some callers
+        persist a raw, non-JSON body here too (e.g. ``response.text`` for an
+        HTTP error from a proxy in front of TFHKA), and the token regex only
+        escapes what it matches — anything else would pass through
+        unescaped. For that case, escape the whole text instead of
+        highlighting it.
         """
         if not value:
             return False
+
+        try:
+            json.loads(value)
+        except (TypeError, ValueError):
+            return self._wrap_pre(html.escape(value))
 
         def _highlight(match):
             kind = match.lastgroup
@@ -84,10 +108,7 @@ class TfhkaApiLog(models.Model):
             return f'<span style="{JSON_TOKEN_STYLES[kind]}">{text}</span>'
 
         highlighted = JSON_TOKEN_RE.sub(_highlight, value)
-        return Markup(
-            '<pre style="white-space:pre-wrap;word-break:break-word;'
-            'font-family:monospace;font-size:12px;margin:0;">'
-        ) + Markup(highlighted) + Markup("</pre>")
+        return self._wrap_pre(highlighted)
 
     @api.model
     def _sanitize_payload(self, payload):

--- a/l10n_ve_invoice_digital/security/ir.model.access.csv
+++ b/l10n_ve_invoice_digital/security/ir.model.access.csv
@@ -3,5 +3,5 @@ account_retention_alert_wizard_access,account_retention_alert_wizard,model_accou
 access_tfhka_annul_wizard_user,tfhka.annul.wizard,model_tfhka_annul_wizard,base.group_user,1,1,1,1
 access_payment_method_tfhka_user,access.payment.method.tfhka.user,model_payment_method_tfhka,base.group_user,1,0,0,0
 access_payment_method_tfhka_admin,access.payment.method.tfhka.admin,model_payment_method_tfhka,l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin,1,1,1,1
-access_tfhka_api_log_admin,tfhka.api.log.admin,model_tfhka_api_log,l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin,1,0,0,1
+access_tfhka_api_log_admin,tfhka.api.log.admin,model_tfhka_api_log,l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin,1,0,0,0
 access_tfhka_api_log_system,tfhka.api.log.system,model_tfhka_api_log,base.group_system,1,1,1,1

--- a/l10n_ve_invoice_digital/security/ir.model.access.csv
+++ b/l10n_ve_invoice_digital/security/ir.model.access.csv
@@ -3,3 +3,5 @@ account_retention_alert_wizard_access,account_retention_alert_wizard,model_accou
 access_tfhka_annul_wizard_user,tfhka.annul.wizard,model_tfhka_annul_wizard,base.group_user,1,1,1,1
 access_payment_method_tfhka_user,access.payment.method.tfhka.user,model_payment_method_tfhka,base.group_user,1,0,0,0
 access_payment_method_tfhka_admin,access.payment.method.tfhka.admin,model_payment_method_tfhka,l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin,1,1,1,1
+access_tfhka_api_log_admin,tfhka.api.log.admin,model_tfhka_api_log,l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin,1,0,0,1
+access_tfhka_api_log_system,tfhka.api.log.system,model_tfhka_api_log,base.group_system,1,1,1,1

--- a/l10n_ve_invoice_digital/security/ir_rule.xml
+++ b/l10n_ve_invoice_digital/security/ir_rule.xml
@@ -1,0 +1,12 @@
+<odoo>
+
+    <record id="tfhka_api_log_multi_company" model="ir.rule">
+        <field name="name">TFHKA API Log multi-company</field>
+        <field name="model_id" ref="model_tfhka_api_log"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">
+            ['|',('company_id','=',False),('company_id', 'in', company_ids)]
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ve_invoice_digital/services/tfhka_client.py
+++ b/l10n_ve_invoice_digital/services/tfhka_client.py
@@ -106,7 +106,11 @@ class TfhkaApiClient(models.AbstractModel):
                 # TFHKA devuelve "codigo" indistintamente como entero o cadena
                 # según el endpoint; se normaliza para no depender del tipo.
                 code = str(data.get("codigo"))
-                response_json = json.dumps(data, default=str, indent=2)
+                response_json = json.dumps(
+                    self.env["tfhka.api.log"]._sanitize_payload(data),
+                    default=str,
+                    indent=2,
+                )
                 if code == "200":
                     self._log_call(
                         company, endpoint, payload, origin, response.status_code, response_json, True

--- a/l10n_ve_invoice_digital/services/tfhka_client.py
+++ b/l10n_ve_invoice_digital/services/tfhka_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import requests
@@ -42,13 +43,49 @@ class TfhkaApiClient(models.AbstractModel):
             return company.token_auth_tfhka
         raise ValidationError(_("Configuration error: The authentication token is empty."))
 
-    def _request(self, company, endpoint_key, payload, _retried=False):
+    def _log_call(self, company, endpoint, payload, origin, status_code, response_payload, success):
+        log_vals = {
+            "company_id": company.id,
+            "endpoint": endpoint,
+            "http_method": "POST",
+            "request_payload": json.dumps(
+                self.env["tfhka.api.log"]._sanitize_payload(payload),
+                default=str,
+                indent=2,
+            )
+            if payload
+            else False,
+            "status_code": status_code,
+            "response_payload": str(response_payload) if response_payload is not None else False,
+            "success": bool(success),
+        }
+        if origin:
+            log_vals.update(
+                {
+                    "res_model": origin._name,
+                    "res_id": origin.id,
+                    "res_name": origin.display_name,
+                }
+            )
+
+        # Persist in an isolated cursor: the caller often raises right after
+        # this (e.g. a UserError for a business error TFHKA returned), which
+        # rolls back the current transaction and would silently wipe out the
+        # very log row we just wrote if it shared that transaction.
+        try:
+            with self.pool.cursor() as log_cr:
+                self.env(cr=log_cr)["tfhka.api.log"].sudo().create(log_vals)
+        except Exception:
+            _logger.exception("TFHKA: failed to persist API log entry for %s", endpoint)
+
+    def _request(self, company, endpoint_key, payload, _retried=False, origin=None):
         """Ejecuta un POST a TFHKA y devuelve la respuesta decodificada.
 
         Preserva el protocolo actual: ``codigo == "200"`` ok, ``codigo == "203"``
         con validaciones en ``ultimo_documento`` -> 0, 401 -> regenera el token y
         reintenta **una sola vez**, HTTP != 200 -> ``UserError``, y
-        ``RequestException`` -> ``UserError``.
+        ``RequestException`` -> ``UserError``. Cada intento (incluido el
+        reintento tras un 401) se registra en ``tfhka.api.log``.
         """
         base_url = self._base_url(company)
         endpoint = TFHKA_ENDPOINTS.get(endpoint_key)
@@ -69,12 +106,22 @@ class TfhkaApiClient(models.AbstractModel):
                 # TFHKA devuelve "codigo" indistintamente como entero o cadena
                 # según el endpoint; se normaliza para no depender del tipo.
                 code = str(data.get("codigo"))
+                response_json = json.dumps(data, default=str, indent=2)
                 if code == "200":
+                    self._log_call(
+                        company, endpoint, payload, origin, response.status_code, response_json, True
+                    )
                     return data
                 elif code == "203" and data.get("validaciones") and endpoint_key == "ultimo_documento":
+                    self._log_call(
+                        company, endpoint, payload, origin, response.status_code, response_json, False
+                    )
                     return 0
                 else:
                     _logger.error("Error in the API response: %s \n%s", data.get('mensaje'), data.get('validaciones'))
+                    self._log_call(
+                        company, endpoint, payload, origin, response.status_code, response_json, False
+                    )
                     raise UserError(
                         _("Error in the API response: %(message)s \n%(validation)s")
                         % {"message": data.get('mensaje'), "validation": data.get('validaciones')}
@@ -82,33 +129,43 @@ class TfhkaApiClient(models.AbstractModel):
             if response.status_code == 401:
                 if _retried:
                     _logger.error("TFHKA authentication still failing after token refresh.")
+                    self._log_call(
+                        company, endpoint, payload, origin, response.status_code, response.text, False
+                    )
                     raise UserError(_("TFHKA authentication failed: the token is invalid even after refreshing it. Please verify the credentials."))
                 _logger.error("Error 401: Invalid or expired token. Refreshing and retrying once.")
+                self._log_call(
+                    company, endpoint, payload, origin, response.status_code, response.text, False
+                )
                 company.generate_token_tfhka()
-                return self._request(company, endpoint_key, payload, _retried=True)
+                return self._request(company, endpoint_key, payload, _retried=True, origin=origin)
             else:
                 _logger.error("HTTP error %s: %s", response.status_code, response.text)
+                self._log_call(
+                    company, endpoint, payload, origin, response.status_code, response.text, False
+                )
                 raise UserError(
                     _("HTTP error %(status_code)s: %(text)s")
                     % {"status_code": response.status_code, "text": response.text}
                 )
         except requests.exceptions.RequestException as e:
             _logger.error("Error connecting to the API: %s", e)
+            self._log_call(company, endpoint, payload, origin, None, str(e), False)
             raise UserError(_("Error connecting to the API: %(error)s") % {"error": e})
 
     # ------------------------------------------------------------------
     # Endpoints
     # ------------------------------------------------------------------
 
-    def emit(self, company, payload):
+    def emit(self, company, payload, origin=None):
         """POST /Emision. Devuelve la respuesta validada."""
-        return self._request(company, "emision", payload)
+        return self._request(company, "emision", payload, origin=origin)
 
-    def annul(self, company, payload):
+    def annul(self, company, payload, origin=None):
         """POST /Anular. Anula un documento digital (serie/tipo/numero + motivo)."""
-        return self._request(company, "anular", payload)
+        return self._request(company, "anular", payload, origin=origin)
 
-    def get_last_document_number(self, company, document_type, series=""):
+    def get_last_document_number(self, company, document_type, series="", origin=None):
         """POST /UltimoDocumento. Devuelve el último número como entero (0 si no existe).
 
         ``numeroDocumento = 0`` es un valor legítimo: significa que la serie aún
@@ -121,7 +178,7 @@ class TfhkaApiClient(models.AbstractModel):
             "serie": series,
             "tipoDocumento": document_type,
         }
-        response = self._request(company, "ultimo_documento", payload)
+        response = self._request(company, "ultimo_documento", payload, origin=origin)
 
         if not isinstance(response, dict):
             return int(response or 0)
@@ -134,14 +191,14 @@ class TfhkaApiClient(models.AbstractModel):
             )
             return 0
 
-    def query_numbering(self, company, series=""):
+    def query_numbering(self, company, series="", origin=None):
         """POST /ConsultaNumeraciones. Valida que la serie exista y tenga rango."""
         payload = {
             "serie": series,
             "tipoDocumento": "",
             "prefix": "",
         }
-        response = self._request(company, "consulta_numeraciones", payload)
+        response = self._request(company, "consulta_numeraciones", payload, origin=origin)
 
         if response:
             approves = False

--- a/l10n_ve_invoice_digital/services/tfhka_document_service.py
+++ b/l10n_ve_invoice_digital/services/tfhka_document_service.py
@@ -38,8 +38,10 @@ class TfhkaDocumentService(models.AbstractModel):
     ``_prepare_document_payload`` que compone todo y un ``send_document`` que
     orquesta el envío. El transporte HTTP lo hace ``tfhka.api.client``
     (``emit`` / ``query_numbering`` / ``get_last_document_number``), al que la
-    compañía se pasa explícita. Extensible vía el hook
-    ``_prepare_extra_payload_values``.
+    compañía se pasa explícita. Extensible vía los hooks
+    ``_prepare_extra_header_values`` (se mezcla en ``encabezado``) y
+    ``_prepare_extra_payload_values`` (se mezcla en la raíz de
+    ``documentoElectronico``).
     """
 
     _name = "tfhka.document.service"
@@ -85,7 +87,7 @@ class TfhkaDocumentService(models.AbstractModel):
         company = invoice.company_id
         client = self.env["tfhka.api.client"]
 
-        client.query_numbering(company, series)
+        client.query_numbering(company, series, origin=invoice)
 
         # Secuencia: en modo "pago primero" (o con la sincronización desactivada)
         # se usa el correlativo local de Odoo; en el modo normal se ADOPTA el
@@ -93,7 +95,7 @@ class TfhkaDocumentService(models.AbstractModel):
         if company.digitalization_with_payment_tfhka or not company.sequence_validation_tfhka:
             document_number = invoice.sequence_number
         else:
-            last = client.get_last_document_number(company, document_type, series)
+            last = client.get_last_document_number(company, document_type, series, origin=invoice)
             try:
                 document_number = int(last) + 1
             except (ValueError, TypeError):
@@ -131,6 +133,9 @@ class TfhkaDocumentService(models.AbstractModel):
             payload["documentoElectronico"]["encabezado"]["vendedor"] = seller
         if foreign_totals:
             payload["documentoElectronico"]["encabezado"]["totalesOtraMoneda"] = foreign_totals
+        payload["documentoElectronico"]["encabezado"].update(
+            self._prepare_extra_header_values(invoice, currency_context)
+        )
         if additional_information:
             payload["documentoElectronico"]["infoAdicional"] = additional_information
         if dispatch_guide_reference:
@@ -138,7 +143,7 @@ class TfhkaDocumentService(models.AbstractModel):
 
         payload["documentoElectronico"].update(self._prepare_extra_payload_values(invoice))
         _logger.info("Payload: %s", payload)
-        response = self.env["tfhka.api.client"].emit(invoice.company_id, payload)
+        response = self.env["tfhka.api.client"].emit(invoice.company_id, payload, origin=invoice)
 
         if response:
             self._register_success(invoice, response, document_number)
@@ -188,6 +193,10 @@ class TfhkaDocumentService(models.AbstractModel):
 
     def _prepare_extra_payload_values(self, invoice):
         """Hook de extensión: valores extra del payload. Por defecto vacío."""
+        return {}
+
+    def _prepare_extra_header_values(self, invoice, ctx):
+        """Hook de extensión: valores extra para encabezado. Por defecto vacío."""
         return {}
 
     # ------------------------------------------------------------------

--- a/l10n_ve_invoice_digital/services/tfhka_retention_service.py
+++ b/l10n_ve_invoice_digital/services/tfhka_retention_service.py
@@ -32,8 +32,8 @@ class TfhkaRetentionService(models.AbstractModel):
         document_type = retention.env.context.get('document_type')
         company = retention.company_id
         client = self.env["tfhka.api.client"]
-        client.query_numbering(company)
-        document_number = client.get_last_document_number(company, document_type)
+        client.query_numbering(company, origin=retention)
+        document_number = client.get_last_document_number(company, document_type, origin=retention)
 
         document_number_str = str(document_number)
         if len(document_number_str) > 6:
@@ -88,7 +88,7 @@ class TfhkaRetentionService(models.AbstractModel):
             "horaAnulacion": now_local.strftime("%I:%M:%S %p").lower(),
         }
 
-        self.env["tfhka.api.client"].annul(company, payload)
+        self.env["tfhka.api.client"].annul(company, payload, origin=retention)
         retention.write({"annulled_tfhka": True})
         retention.message_post(
             body=_("Retention annulled in The Factory HKA. Reason: %s", reason),
@@ -114,7 +114,7 @@ class TfhkaRetentionService(models.AbstractModel):
         }
         payload["documentoElectronico"].update(self._prepare_extra_retention_values(retention))
 
-        response = self.env["tfhka.api.client"].emit(retention.company_id, payload)
+        response = self.env["tfhka.api.client"].emit(retention.company_id, payload, origin=retention)
 
         if response:
             retention.is_digitalized = True

--- a/l10n_ve_invoice_digital/services/tfhka_service_base.py
+++ b/l10n_ve_invoice_digital/services/tfhka_service_base.py
@@ -49,7 +49,7 @@ class TfhkaServiceBase(models.AbstractModel):
 
     def _get_party_address(self, partner):
         """Dirección a reportar para el sujeto. Punto de extensión."""
-        return partner.contact_address_complete or "no definida"
+        return partner.contact_address or "no definida"
 
     def _parse_partner_identification(self, partner):
         """(tipo, número) de identificación fiscal a partir de ``vat``/``prefix_vat``.

--- a/l10n_ve_invoice_digital/services/tfhka_service_base.py
+++ b/l10n_ve_invoice_digital/services/tfhka_service_base.py
@@ -48,8 +48,25 @@ class TfhkaServiceBase(models.AbstractModel):
         return record.partner_id
 
     def _get_party_address(self, partner):
-        """Dirección a reportar para el sujeto. Punto de extensión."""
-        return partner.contact_address or "no definida"
+        """Dirección a reportar para el sujeto. Punto de extensión.
+
+        Se arma localmente a partir de los campos de dirección estándar
+        (calle, calle 2, código postal + ciudad, estado, país), sin
+        depender de ``contact_address_complete`` (vive en ``web_map``,
+        Enterprise, no declarado como dependencia de este módulo LGPL-3 -
+        en Community el campo no existe) ni de ``contact_address`` (repite
+        el nombre del contacto, que ya va en ``razonSocial``, y separa con
+        saltos de línea literales).
+        """
+        zip_city = " ".join(filter(None, [partner.zip, partner.city]))
+        parts = [
+            partner.street,
+            partner.street2,
+            zip_city,
+            partner.state_id.name,
+            partner.country_id.name,
+        ]
+        return ", ".join(filter(None, parts)) or "no definida"
 
     def _parse_partner_identification(self, partner):
         """(tipo, número) de identificación fiscal a partir de ``vat``/``prefix_vat``.

--- a/l10n_ve_invoice_digital/services/tfhka_service_base.py
+++ b/l10n_ve_invoice_digital/services/tfhka_service_base.py
@@ -49,7 +49,30 @@ class TfhkaServiceBase(models.AbstractModel):
 
     def _get_party_address(self, partner):
         """Dirección a reportar para el sujeto. Punto de extensión."""
-        return partner.street or "no definida"
+        return partner.contact_address_complete or "no definida"
+
+    def _parse_partner_identification(self, partner):
+        """(tipo, número) de identificación fiscal a partir de ``vat``/``prefix_vat``.
+
+        Requiere que ``partner.vat`` ya esté validado como no vacío por el
+        llamador — cada punto de uso lanza su propio mensaje de negocio para
+        ese caso. Compartido entre ``_get_fiscal_party`` (comprador / sujeto
+        retenido) y cualquier otro sujeto fiscal que necesite el mismo
+        formato de RIF/cédula (p. ej. el tercero de facturación a terceros).
+        """
+        vat = partner.vat.upper()
+        if vat[0].isalpha():
+            identification_type = vat[0]
+            identification_number = vat[1:]
+        else:
+            identification_type = ""
+            identification_number = vat
+
+        if partner.prefix_vat:
+            identification_type = partner.prefix_vat
+
+        identification_number = identification_number.replace("-", "").replace(".", "")
+        return identification_type, identification_number
 
     def _get_fiscal_party(self, record):
         """Construye el nodo de identificación (comprador / sujeto retenido).
@@ -66,18 +89,7 @@ class TfhkaServiceBase(models.AbstractModel):
         if not partner.vat:
             raise UserError(_("The 'NIF' field of the Customer cannot be empty for digitalization."))
 
-        vat = partner.vat.upper()
-        if vat[0].isalpha():
-            identification_type = vat[0]
-            identification_number = vat[1:]
-        else:
-            identification_type = ""
-            identification_number = vat
-
-        if partner.prefix_vat:
-            identification_type = partner.prefix_vat
-
-        identification_number = identification_number.replace("-", "").replace(".", "")
+        identification_type, identification_number = self._parse_partner_identification(partner)
 
         if not partner.country_code:
             raise UserError(_("The 'Country' field of the Customer cannot be empty for digitalization."))

--- a/l10n_ve_invoice_digital/tests/__init__.py
+++ b/l10n_ve_invoice_digital/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_wizard_account_retention_alert
 from . import test_wizard_move_action_post_alert
 from . import test_res_config_settings
 from . import test_res_partner
+from . import test_tfhka_api_log

--- a/l10n_ve_invoice_digital/tests/__init__.py
+++ b/l10n_ve_invoice_digital/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_wizard_move_action_post_alert
 from . import test_res_config_settings
 from . import test_res_partner
 from . import test_tfhka_api_log
+from . import test_tfhka_service_base

--- a/l10n_ve_invoice_digital/tests/test_res_company.py
+++ b/l10n_ve_invoice_digital/tests/test_res_company.py
@@ -116,4 +116,4 @@ class TestAccountMoveApiCalls(TransactionCase):
             type(self.company), '_process_tfhka_response_data', side_effect=ValueError("bad data")
         ):
             with self.assertRaises(ValidationError):
-                self.company._handle_tfhka_response(mock_response)
+                self.company._handle_tfhka_response(mock_response, {"usuario": "u", "clave": "p"})

--- a/l10n_ve_invoice_digital/tests/test_tfhka_api_log.py
+++ b/l10n_ve_invoice_digital/tests/test_tfhka_api_log.py
@@ -80,6 +80,12 @@ class TestTfhkaApiLog(TransactionCase):
         self.assertEqual(self.log_model._sanitize_payload(None), None)
         self.assertEqual(self.log_model._sanitize_payload("raw"), "raw")
 
+    def test_sanitize_payload_redacts_token(self):
+        payload = {"token": "secret-token", "codigo": 200}
+        sanitized = self.log_model._sanitize_payload(payload)
+        self.assertEqual(sanitized["token"], "***")
+        self.assertEqual(sanitized["codigo"], 200)
+
     # ------------------------------------------------------------------
     # Payload HTML formatting
     # ------------------------------------------------------------------
@@ -93,6 +99,15 @@ class TestTfhkaApiLog(TransactionCase):
     def test_payload_to_html_empty_returns_false(self):
         self.assertFalse(self.log_model._payload_to_html(False))
         self.assertFalse(self.log_model._payload_to_html(""))
+
+    def test_payload_to_html_escapes_non_json_payload(self):
+        """A raw, non-JSON body (e.g. an HTML error page from a proxy in
+        front of TFHKA) must come out fully escaped, not partially matched
+        by the JSON token regex."""
+        rendered = self.log_model._payload_to_html("<script>alert(1)</script>")
+        self.assertTrue(rendered.startswith("<pre"))
+        self.assertNotIn("<script>", rendered)
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", rendered)
 
     def test_payload_to_html_highlights_tokens(self):
         rendered = self.log_model._payload_to_html('{\n  "a": 1,\n  "b": true\n}')
@@ -198,6 +213,22 @@ class TestTfhkaApiLog(TransactionCase):
         self.assertTrue(log["success"])
         self.assertNotIn("clave_prueba", log["request_payload"])
         self.assertIn("***", log["request_payload"])
+        self.assertNotIn("new-token", log["response_payload"])
+        self.assertIn("***", log["response_payload"])
+        self.assertEqual(self.company.token_auth_tfhka, "new-token")
+
+    def test_request_logs_token_redacted_in_response(self):
+        with patch(
+            CLIENT_REQUESTS_PATH,
+            return_value=_response(
+                json_data={"codigo": "200", "token": "leaked-token"}
+            ),
+        ):
+            self.client.emit(self.company, {"foo": "bar"})
+        log = self._last_log([("endpoint", "=", "/Emision")])
+        self.assertTrue(log)
+        self.assertNotIn("leaked-token", log["response_payload"])
+        self.assertIn("***", log["response_payload"])
 
     # ------------------------------------------------------------------
     # action_open_origin
@@ -221,6 +252,45 @@ class TestTfhkaApiLog(TransactionCase):
         action = log.action_open_origin()
         self.assertEqual(action["res_model"], "res.company")
         self.assertEqual(action["res_id"], self.company.id)
+
+    # ------------------------------------------------------------------
+    # Multi-company access
+    # ------------------------------------------------------------------
+
+    def test_logs_are_restricted_by_company(self):
+        other_company = self.env["res.company"].create({"name": "Other TFHKA Co"})
+        own_log = self.log_model.create(
+            {"endpoint": "/Emision", "company_id": self.company.id}
+        )
+        other_log = self.log_model.create(
+            {"endpoint": "/Emision", "company_id": other_company.id}
+        )
+
+        restricted_user = self.env["res.users"].create(
+            {
+                "name": "TFHKA Restricted User",
+                "login": "tfhka_restricted_user",
+                "group_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_user").id,
+                            self.env.ref(
+                                "l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin"
+                            ).id,
+                        ],
+                    )
+                ],
+                "company_ids": [(6, 0, [self.company.id])],
+                "company_id": self.company.id,
+            }
+        )
+
+        visible_logs = self.log_model.with_user(restricted_user).search(
+            [("id", "in", (own_log + other_log).ids)]
+        )
+        self.assertEqual(visible_logs, own_log)
 
     # ------------------------------------------------------------------
     # cron_purge_old_logs

--- a/l10n_ve_invoice_digital/tests/test_tfhka_api_log.py
+++ b/l10n_ve_invoice_digital/tests/test_tfhka_api_log.py
@@ -1,0 +1,242 @@
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+
+CLIENT_REQUESTS_PATH = (
+    "odoo.addons.l10n_ve_invoice_digital.services.tfhka_client.requests.post"
+)
+
+
+def _response(status_code=200, json_data=None):
+    response = MagicMock()
+    response.status_code = status_code
+    if json_data is None:
+        response.json.side_effect = ValueError("no json")
+        response.text = "not json"
+    else:
+        response.json.return_value = json_data
+    return response
+
+
+@tagged("post_install", "-at_install", "l10n_ve_invoice_digital")
+class TestTfhkaApiLog(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.ref("base.main_company")
+        self.company.write(
+            {
+                "username_tfhka": "usuario_prueba",
+                "password_tfhka": "clave_prueba",
+                "url_tfhka": "https://api.tfhka.test",
+                "token_auth_tfhka": "token-123",
+            }
+        )
+        self.client = self.env["tfhka.api.client"]
+        self.log_model = self.env["tfhka.api.log"]
+
+    def _last_log(self, domain):
+        """Read the log's field values through a brand-new cursor.
+
+        ``_log_call`` persists via its own isolated cursor so the entry
+        survives even if the caller raises right after (see
+        ``tfhka_client.py``). Odoo cursors run at REPEATABLE READ, so the
+        test's own cursor took its snapshot before that isolated cursor
+        committed and will never see the row; a fresh cursor opened here
+        takes its snapshot afterwards and does. Returns a plain dict (or
+        None) since the underlying recordset can't outlive this cursor.
+        """
+        with self.registry.cursor() as cr:
+            log = self.env(cr=cr)["tfhka.api.log"].search(
+                domain, limit=1, order="id desc"
+            )
+            if not log:
+                return None
+            return {
+                "success": log.success,
+                "status_code": log.status_code,
+                "response_payload": log.response_payload,
+                "request_payload": log.request_payload,
+                "res_model": log.res_model,
+                "res_id": log.res_id,
+                "res_name": log.res_name,
+            }
+
+    # ------------------------------------------------------------------
+    # Sanitization
+    # ------------------------------------------------------------------
+
+    def test_sanitize_payload_redacts_password_and_clave(self):
+        payload = {"usuario": "user@test", "clave": "secret"}
+        sanitized = self.log_model._sanitize_payload(payload)
+        self.assertEqual(sanitized["usuario"], "user@test")
+        self.assertEqual(sanitized["clave"], "***")
+
+    def test_sanitize_payload_ignores_non_dict(self):
+        self.assertEqual(self.log_model._sanitize_payload(None), None)
+        self.assertEqual(self.log_model._sanitize_payload("raw"), "raw")
+
+    # ------------------------------------------------------------------
+    # Payload HTML formatting
+    # ------------------------------------------------------------------
+
+    def test_payload_to_html_wraps_in_pre_and_escapes(self):
+        rendered = self.log_model._payload_to_html('{"a": "<script>"}')
+        self.assertTrue(rendered.startswith("<pre"))
+        self.assertIn("&lt;script&gt;", rendered)
+        self.assertNotIn("<script>", rendered)
+
+    def test_payload_to_html_empty_returns_false(self):
+        self.assertFalse(self.log_model._payload_to_html(False))
+        self.assertFalse(self.log_model._payload_to_html(""))
+
+    def test_payload_to_html_highlights_tokens(self):
+        rendered = self.log_model._payload_to_html('{\n  "a": 1,\n  "b": true\n}')
+        self.assertIn(
+            '<span style="color:#a626a4;font-weight:600">&quot;a&quot;</span>', rendered
+        )
+        self.assertIn('<span style="color:#0184bc">1</span>', rendered)
+        self.assertIn('<span style="color:#c18401;font-weight:600">true</span>', rendered)
+
+    def test_compute_payload_html_from_stored_json(self):
+        log = self.log_model.create(
+            {
+                "endpoint": "/Emision",
+                "company_id": self.company.id,
+                "request_payload": '{\n  "a": 1\n}',
+                "response_payload": '{\n  "ok": true\n}',
+            }
+        )
+        self.assertIn("&quot;a&quot;", log.request_payload_html)
+        self.assertIn(">1<", log.request_payload_html)
+        self.assertIn("&quot;ok&quot;", log.response_payload_html)
+        self.assertIn(">true<", log.response_payload_html)
+
+    # ------------------------------------------------------------------
+    # Logging from the client
+    # ------------------------------------------------------------------
+
+    def test_request_creates_log_entry_on_success(self):
+        with patch(
+            CLIENT_REQUESTS_PATH,
+            return_value=_response(json_data={"codigo": "200", "resultado": {}}),
+        ):
+            self.client.emit(self.company, {"foo": "bar"})
+        log = self._last_log([("endpoint", "=", "/Emision")])
+        self.assertTrue(log)
+        self.assertTrue(log["success"])
+        self.assertEqual(log["status_code"], 200)
+        self.assertIn('"codigo"', log["response_payload"])
+
+    def test_request_logs_sensitive_key_redacted(self):
+        with patch(
+            CLIENT_REQUESTS_PATH,
+            return_value=_response(json_data={"codigo": "200"}),
+        ):
+            self.client._request(
+                self.company, "emision", {"usuario": "u", "clave": "topsecret"}
+            )
+        log = self._last_log([("endpoint", "=", "/Emision")])
+        self.assertTrue(log)
+        self.assertNotIn("topsecret", log["request_payload"])
+        self.assertIn("***", log["request_payload"])
+
+    def test_request_logs_connection_error(self):
+        with patch(
+            CLIENT_REQUESTS_PATH,
+            side_effect=requests.exceptions.RequestException("down"),
+        ):
+            with self.assertRaises(UserError):
+                self.client.emit(self.company, {"foo": "bar"})
+        log = self._last_log([("endpoint", "=", "/Emision")])
+        self.assertTrue(log)
+        self.assertFalse(log["success"])
+        self.assertFalse(log["status_code"])
+
+    def test_request_logs_origin(self):
+        with patch(
+            CLIENT_REQUESTS_PATH,
+            return_value=_response(json_data={"codigo": "200"}),
+        ):
+            self.client.emit(self.company, {"foo": "bar"}, origin=self.company)
+        log = self._last_log([("endpoint", "=", "/Emision")])
+        self.assertTrue(log)
+        self.assertEqual(log["res_model"], "res.company")
+        self.assertEqual(log["res_id"], self.company.id)
+        self.assertEqual(log["res_name"], self.company.display_name)
+
+    def test_request_survives_a_usererror_raised_after_logging(self):
+        """A call that ends in a UserError (e.g. a business error TFHKA
+        returned via ``codigo``) still leaves a log entry behind, not just
+        a network-level failure."""
+        with patch(
+            CLIENT_REQUESTS_PATH,
+            return_value=_response(
+                json_data={"codigo": "500", "mensaje": "boom", "validaciones": []}
+            ),
+        ):
+            with self.assertRaises(UserError):
+                self.client.emit(self.company, {"foo": "bar"})
+        log = self._last_log([("endpoint", "=", "/Emision")])
+        self.assertTrue(log)
+        self.assertFalse(log["success"])
+
+    def test_generate_token_logs_the_authentication_call(self):
+        with patch(
+            "requests.post",
+            return_value=_response(
+                json_data={"codigo": 200, "mensaje": "OK", "token": "new-token"}
+            ),
+        ):
+            self.company.generate_token_tfhka()
+        log = self._last_log([("endpoint", "=", "/Autenticacion")])
+        self.assertTrue(log)
+        self.assertTrue(log["success"])
+        self.assertNotIn("clave_prueba", log["request_payload"])
+        self.assertIn("***", log["request_payload"])
+
+    # ------------------------------------------------------------------
+    # action_open_origin
+    # ------------------------------------------------------------------
+
+    def test_action_open_origin_without_link_returns_false(self):
+        log = self.log_model.create(
+            {"endpoint": "/Emision", "company_id": self.company.id}
+        )
+        self.assertFalse(log.action_open_origin())
+
+    def test_action_open_origin_returns_act_window(self):
+        log = self.log_model.create(
+            {
+                "endpoint": "/Emision",
+                "company_id": self.company.id,
+                "res_model": "res.company",
+                "res_id": self.company.id,
+            }
+        )
+        action = log.action_open_origin()
+        self.assertEqual(action["res_model"], "res.company")
+        self.assertEqual(action["res_id"], self.company.id)
+
+    # ------------------------------------------------------------------
+    # cron_purge_old_logs
+    # ------------------------------------------------------------------
+
+    def test_cron_purge_old_logs_removes_only_old_records(self):
+        old_log = self.log_model.create(
+            {"endpoint": "/Emision", "company_id": self.company.id}
+        )
+        recent_log = self.log_model.create(
+            {"endpoint": "/Emision", "company_id": self.company.id}
+        )
+        old_log.write({"request_date": fields.Datetime.now() - timedelta(days=100)})
+        recent_log.write({"request_date": fields.Datetime.now()})
+
+        self.log_model.cron_purge_old_logs()
+
+        self.assertFalse(old_log.exists())
+        self.assertTrue(recent_log.exists())

--- a/l10n_ve_invoice_digital/tests/test_tfhka_service_base.py
+++ b/l10n_ve_invoice_digital/tests/test_tfhka_service_base.py
@@ -1,0 +1,24 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "l10n_ve_invoice_digital")
+class TestTfhkaServiceBase(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.service = self.env["tfhka.service.base"]
+
+    def test_get_party_address_uses_contact_address(self):
+        """``contact_address`` (Odoo core) is the field that actually
+        exists on res.partner; a previous change here used a
+        ``contact_address_complete`` name that isn't defined anywhere,
+        which broke digitalization for every invoice and retention."""
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Tercero de prueba",
+                "street": "Av. Principal",
+                "city": "Caracas",
+            }
+        )
+        address = self.service._get_party_address(partner)
+        self.assertTrue(address)
+        self.assertEqual(address, partner.contact_address)

--- a/l10n_ve_invoice_digital/tests/test_tfhka_service_base.py
+++ b/l10n_ve_invoice_digital/tests/test_tfhka_service_base.py
@@ -7,18 +7,78 @@ class TestTfhkaServiceBase(TransactionCase):
         super().setUp()
         self.service = self.env["tfhka.service.base"]
 
-    def test_get_party_address_uses_contact_address(self):
-        """``contact_address`` (Odoo core) is the field that actually
-        exists on res.partner; a previous change here used a
-        ``contact_address_complete`` name that isn't defined anywhere,
-        which broke digitalization for every invoice and retention."""
-        partner = self.env["res.partner"].create(
+    def _set_city(self, vals, name, state, country):
+        """``l10n_ve_location`` (no es dependencia de este módulo, pero suele
+        convivir instalado junto a él) convierte ``res.partner.city`` en un
+        campo ``related`` de solo lectura sobre ``city_id`` (Many2one a
+        ``res.country.city``): asignar el string directo no tiene efecto.
+        Si ese módulo está instalado, resuelve/crea el ``res.country.city``
+        y usa ``city_id``; si no, usa el ``city`` Char normal.
+        """
+        if "city_id" in self.env["res.partner"]._fields:
+            city = self.env["res.country.city"].search(
+                [("name", "=", name), ("state_id", "=", state.id)], limit=1
+            )
+            if not city:
+                city = self.env["res.country.city"].create(
+                    {"name": name, "state_id": state.id, "country_id": country.id}
+                )
+            return {**vals, "city_id": city.id}
+        return {**vals, "city": name}
+
+    def test_get_party_address_full(self):
+        """Se arma localmente (sin contact_address ni
+        contact_address_complete, ver _get_party_address): calle, calle 2,
+        código postal + ciudad, estado y país, sin repetir el nombre del
+        contacto (ya va en razonSocial) y sin saltos de línea."""
+        country = self.env.ref("base.ve")
+        state = self.env["res.country.state"].search(
+            [("country_id", "=", country.id)], limit=1
+        )
+        vals = self._set_city(
             {
                 "name": "Tercero de prueba",
+                "street": "Carrera 20 con calle 19 y 20",
+                "street2": "Calle 11",
+                "zip": "3001",
+                "state_id": state.id,
+                "country_id": country.id,
+            },
+            "Barquisimeto",
+            state,
+            country,
+        )
+        partner = self.env["res.partner"].create(vals)
+        address = self.service._get_party_address(partner)
+        self.assertEqual(
+            address,
+            "Carrera 20 con calle 19 y 20, Calle 11, 3001 Barquisimeto, "
+            f"{state.name}, Venezuela",
+        )
+        self.assertNotIn(partner.name, address)
+        self.assertNotIn("\n", address)
+
+    def test_get_party_address_skips_missing_fields(self):
+        """Sin street2/código postal/ciudad/estado, no deja comas ni
+        segmentos vacíos de más."""
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Tercero sin datos completos",
                 "street": "Av. Principal",
-                "city": "Caracas",
+                "country_id": self.env.ref("base.ve").id,
             }
         )
-        address = self.service._get_party_address(partner)
-        self.assertTrue(address)
-        self.assertEqual(address, partner.contact_address)
+        self.assertEqual(
+            self.service._get_party_address(partner),
+            "Av. Principal, Venezuela",
+        )
+
+    def test_get_party_address_falls_back_when_empty(self):
+        """``l10n_ve_contact`` (dependencia de este módulo) pone
+        ``country_id`` por defecto en Venezuela para cualquier partner
+        nuevo: hay que forzarlo vacío para probar el caso realmente sin
+        dirección."""
+        partner = self.env["res.partner"].create(
+            {"name": "Sin dirección", "country_id": False}
+        )
+        self.assertEqual(self.service._get_party_address(partner), "no definida")

--- a/l10n_ve_invoice_digital/tests/test_wizard_move_action_post_alert.py
+++ b/l10n_ve_invoice_digital/tests/test_wizard_move_action_post_alert.py
@@ -153,12 +153,15 @@ class TestMoveActionPostAlertWizard(TransactionCase):
         self.assertIn("debit note", str(e.exception).lower())
 
     def test_08_wizard_previous_credit_note_not_digitized(self):
-        prod = self.env['product.product'].create({
-            'name': 'Prod Credit', 'type': 'service', 'list_price': 100, 'taxes_id': [Command.set([self.tax_iva16.id])],
-        })
         base_inv = self._create_invoice(post=False)
+        # Cantidad 2 para que el monto facturado alcance para las dos notas de
+        # crédito (100 c/u) sin exceder lo facturado por el producto.
+        base_inv.invoice_line_ids.quantity = 2
         base_inv.with_context(move_action_post_alert=True).action_post()
         self._advance_correlative_sequence()
+        # La nota de crédito debe usar el mismo producto de base_inv: l10n_ve_invoice
+        # exige que los productos de una nota de crédito existan en la factura original.
+        prod = base_inv.invoice_line_ids.product_id
 
         credit1 = self._create_debit_or_credit("out_refund", prod, "reversed_entry_id", base_inv)
         credit1.with_context(move_action_post_alert=True).action_post()

--- a/l10n_ve_invoice_digital/views/tfhka_api_log_views.xml
+++ b/l10n_ve_invoice_digital/views/tfhka_api_log_views.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_tfhka_api_log_list" model="ir.ui.view">
+        <field name="name">tfhka.api.log.list</field>
+        <field name="model">tfhka.api.log</field>
+        <field name="arch" type="xml">
+            <list string="The Factory HKA API Log" default_order="request_date desc" create="false" edit="false">
+                <field name="request_date"/>
+                <field name="endpoint"/>
+                <field name="http_method"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="status_code"/>
+                <field name="success"/>
+                <field name="res_name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_tfhka_api_log_form" model="ir.ui.view">
+        <field name="name">tfhka.api.log.form</field>
+        <field name="model">tfhka.api.log</field>
+        <field name="arch" type="xml">
+            <form string="The Factory HKA API Log" create="false" edit="false">
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_open_origin"
+                                type="object"
+                                string="View Origin Document"
+                                class="oe_stat_button"
+                                icon="fa-external-link"
+                                invisible="not res_id"/>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="request_date"/>
+                            <field name="endpoint"/>
+                            <field name="http_method"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                        </group>
+                        <group>
+                            <field name="status_code"/>
+                            <field name="success"/>
+                            <field name="res_name"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="request_payload_html" readonly="1"/>
+                        <field name="response_payload_html" readonly="1"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_tfhka_api_log_search" model="ir.ui.view">
+        <field name="name">tfhka.api.log.search</field>
+        <field name="model">tfhka.api.log</field>
+        <field name="arch" type="xml">
+            <search string="Search The Factory HKA API Log">
+                <field name="endpoint"/>
+                <field name="company_id"/>
+                <filter string="Successful" name="filter_success" domain="[('success', '=', True)]"/>
+                <filter string="Failed" name="filter_failed" domain="[('success', '=', False)]"/>
+                <separator/>
+                <filter string="Endpoint" name="group_by_endpoint" context="{'group_by': 'endpoint'}"/>
+                <filter string="Company" name="group_by_company" context="{'group_by': 'company_id'}"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_tfhka_api_log" model="ir.actions.act_window">
+        <field name="name">The Factory HKA API Log</field>
+        <field name="res_model">tfhka.api.log</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_group_by_endpoint': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No records in the The Factory HKA API log yet
+            </p>
+            <p>
+                Every request and response to The Factory HKA API is logged here.
+                Records older than 3 months are automatically deleted.
+            </p>
+        </field>
+    </record>
+
+    <menuitem id="menu_tfhka_api_log"
+              name="The Factory HKA API Log"
+              parent="account.menu_finance_configuration"
+              action="action_tfhka_api_log"
+              groups="l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin"
+              sequence="91"/>
+</odoo>


### PR DESCRIPTION
Se agrega un historial de consultas y respuestas a la API de The Factory HKA (TFHKA), identificable y filtrable por endpoint, con purga automática de registros con más de 3 meses de antigüedad.

Se centraliza el logging en tfhka.api.client._request, que ahora crea un registro en el nuevo modelo tfhka.api.log por cada intento HTTP (incluidos los reintentos por token vencido y los errores de conexión), y también en res.company.generate_token_tfhka / _handle_tfhka_response para cubrir la autenticación (/Autenticacion), que vive fuera del cliente. El log se persiste en un cursor aislado (self.pool.cursor()) para que el registro sobreviva aunque el llamador levante una excepción justo después (p. ej. un error de negocio de TFHKA), que de otro modo haría rollback de la transacción completa y se llevaría el log con ella. El request/response se guarda como JSON formateado y resaltado por tipo de token en la vista; las claves sensibles (clave/password/authorization) se redactan antes de persistir. Cada registro puede enlazarse opcionalmente al documento origen (factura o retención) vía res_model/res_id.

Se agrega un cron diario que purga los registros con más de 3 meses de antigüedad, y una vista lista/búsqueda con filtro y agrupación por endpoint, visible solo para
l10n_ve_invoice_digital.group_l10n_ve_invoice_digital_admin y base.group_system.

Además, se resuelve un requisito previo para que
binaural_third_party_invoice_digital pueda inyectar el bloque "Tercero" en el payload: se agrega el hook
_prepare_extra_header_values (se mezcla en encabezado, junto a comprador/vendedor/totales) en tfhka.document.service, y se extrae _parse_partner_identification en tfhka.service.base como método reutilizable (compartido entre el comprador/sujeto retenido y cualquier otro sujeto fiscal, como el tercero de facturación a terceros). De paso, se corrige _get_party_address para usar contact_address_complete en vez de street, reportando la dirección fiscal completa del contacto en vez de solo la calle.

References:
- Tarea: https://binaural.odoo.com/odoo/action-341/81318