### PR TITLE
[FIX] l10n_ve_payment_extension: view_mode de reporte de retención

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.27",
+    "version": "19.0.2.0.28",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/report/retention_line_report_views.xml
+++ b/l10n_ve_payment_extension/report/retention_line_report_views.xml
@@ -46,7 +46,7 @@
 	<record id="action_retention_line_report" model="ir.actions.act_window">
 		<field name="name">Retention Line Report</field>
 		<field name="res_model">retention.line.report</field>
-		<field name="view_mode">tree</field>
+		<field name="view_mode">list</field>
 		<field name="context">{"search_default_filter_type_supplier": 1}</field>
 	</record>
 </odoo>


### PR DESCRIPTION
## Resumen
- La acción `action_retention_line_report` declaraba `view_mode="tree"`, valor legado que en Odoo 19 no resuelve ninguna vista (el tipo fue renombrado a `list`).
- Esto rompía Contabilidad > Reportes > Gestión > Reporte de Retención con `View types not defined tree found in act_window action`.
- Se corrige a `view_mode="list"`, que coincide con la vista `list` ya existente para el modelo `retention.line.report`.

## Referencias
- Ticket: https://binaural.odoo.com/odoo/helpdesk.ticket/15009

## Test plan
- [ ] Instalar/actualizar `l10n_ve_payment_extension` en una instancia 19.0 y confirmar que Contabilidad > Reportes > Gestión > Reporte de Retención abre sin error.