### PR TITLE
permite servicios ajenos al origen en notas de credito

### DIFF
--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.12",
+    "version": "19.0.1.0.13",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -818,3 +818,15 @@ msgstr ""
 "El monto acreditado para el producto '%(product)s' (%(amount)s, "
 "incluyendo %(already)s ya acreditado por otras notas de crédito) supera "
 "el monto facturado en el documento original '%(origin)s' (%(max)s)."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+msgid ""
+"The total credited amount on this credit note (%(amount)s, including "
+"%(already)s already credited by other credit notes) exceeds the amount "
+"invoiced on the original document '%(origin)s' (%(max)s)."
+msgstr ""
+"El monto total acreditado en esta nota de crédito (%(amount)s, incluyendo "
+"%(already)s ya acreditado por otras notas de crédito) supera el monto "
+"facturado en el documento original '%(origin)s' (%(max)s)."

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -176,6 +176,7 @@ class AccountMove(models.Model):
                 )
 
             current_totals = {}
+            service_exempt_total = 0.0
             for line in move.invoice_line_ids.filtered(
                 lambda l: l.display_type not in product_line_types
             ):
@@ -192,6 +193,18 @@ class AccountMove(models.Model):
                         origin=origin.display_name,
                     ))
                 if line.product_id.id not in origin_totals:
+                    if line.product_id.type == "service":
+                        # Ticket #81674: financial concepts that never
+                        # appear on the original invoice (early payment,
+                        # commercial discount, exchange difference) are
+                        # always service products. They're exempt from
+                        # the per-product origin-membership check, but
+                        # still count against the origin's overall total
+                        # below -- otherwise a service line with no
+                        # origin amount to cap it against could credit
+                        # an unlimited amount.
+                        service_exempt_total += line.price_subtotal
+                        continue
                     raise ValidationError(_(
                         "You cannot add the product '%(product)s' to this credit "
                         "note: it is not part of the original invoice "
@@ -220,6 +233,28 @@ class AccountMove(models.Model):
                         already=already_credited,
                         origin=origin.display_name,
                         max=max_amount,
+                    ))
+
+            if service_exempt_total:
+                # Ticket #81674: a foreign service line has no per-product
+                # cap (there's nothing on the origin to compare it to), so
+                # it's checked here against the origin's grand total instead
+                # -- credit notes still can't exceed what was invoiced
+                # overall, they just don't have to match line-for-line.
+                origin_total_all = sum(origin_totals.values())
+                already_credited_all = sum(refund_totals.values())
+                current_total_all = sum(current_totals.values()) + service_exempt_total
+                total_credited_all = already_credited_all + current_total_all
+                if float_compare(total_credited_all, origin_total_all, precision_rounding=precision) > 0:
+                    raise ValidationError(_(
+                        "The total credited amount on this credit note "
+                        "(%(amount)s, including %(already)s already credited "
+                        "by other credit notes) exceeds the amount invoiced "
+                        "on the original document '%(origin)s' (%(max)s).",
+                        amount=current_total_all,
+                        already=already_credited_all,
+                        origin=origin.display_name,
+                        max=origin_total_all,
                     ))
 
     def action_post(self):

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-allow-foreign-service-credit-note/proposal.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-allow-foreign-service-credit-note/proposal.md
@@ -1,0 +1,39 @@
+# Feat: Permitir productos tipo Servicio ajenos a la factura origen en Notas de Crédito
+
+## Why
+
+Tarea #81674. La constraint `_check_refund_against_origin` (agregada en el
+cambio `l10n-ve-invoice-credit-note-origin-validation`, ticket #13965) bloquea
+por igual cualquier producto de una Nota de Crédito que no esté en la factura
+origen, sin distinguir su tipo. Eso es correcto para devoluciones de
+inventario (Almacenable/Consumible), pero bloquea también conceptos
+financieros que por naturaleza nunca figuran en la factura original: pronto
+pago, descuento comercial, diferencial cambiario. Hoy el cliente necesita un
+rodeo manual para emitir esas Notas de Crédito.
+
+## What Changes
+
+- `_check_refund_against_origin` (`models/account_move.py`): cuando un
+  producto de la NC no está en la factura origen y es de tipo `service`, ya
+  no se lanza `ValidationError` -- se hace `continue` y su monto se acumula
+  aparte (`service_exempt_total`), en lugar de sumarse a `current_totals`.
+  Almacenable/Consumible ajeno al origen sigue bloqueado exactamente igual
+  que antes.
+- Nuevo chequeo agregado, solo cuando `service_exempt_total > 0`: la suma de
+  todo lo acreditado en la NC (productos normales + servicios exentos) más lo
+  ya acreditado por Notas de Crédito hermanas no puede superar el total
+  facturado en la factura origen (`origin_totals` sumado completo). Un
+  servicio ajeno no tiene tope por producto (no hay nada en el origen contra
+  qué compararlo), pero no puede dejar el monto sin control: se topa contra
+  el total general en lugar de contra un producto puntual.
+- Nueva traducción ES-VE para el mensaje de error del chequeo agregado.
+
+## Non-goals
+
+- No se crean los productos de servicio específicos (Pronto Pago, Descuento
+  Comercial, Diferencial Cambiario) -- se asume que ya existen en el catálogo
+  o se gestionan aparte.
+- No se valida ni modifica cuentas contables, impuestos o el asiento
+  generado por estos productos de servicio -- se asume que su ficha ya está
+  correctamente configurada.
+- No se migra ningún dato existente; el cambio rige hacia adelante.

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-allow-foreign-service-credit-note/specs/l10n_ve_invoice/spec.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-allow-foreign-service-credit-note/specs/l10n_ve_invoice/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Productos de una Nota de Crédito restringidos a la factura origen
+El sistema DEBE (MUST) impedir que una Nota de Crédito (`out_refund`/`in_refund`) con `reversed_entry_id` incluya un producto **Almacenable o Consumible** que no esté presente en las líneas de producto de la factura que revierte, salvo que la creación se realice con la clave de contexto `l10n_ve_skip_refund_origin_validation` activa. Un producto de tipo **Servicio** ajeno a la factura origen SIEMPRE se permite (queda sujeto al tope agregado del `Requirement` siguiente), sin necesidad del bypass.
+
+#### Scenario: Producto presente en la factura origen
+- **WHEN** se crea o edita una Nota de Crédito cuyas líneas de producto son un subconjunto de los productos de su factura origen
+- **THEN** la Nota de Crédito se guarda sin error
+
+#### Scenario: Producto Almacenable/Consumible ajeno a la factura origen
+- **WHEN** se crea o edita una Nota de Crédito agregando un producto de tipo Almacenable o Consumible que la factura origen nunca facturó
+- **THEN** el sistema rechaza la operación con un `ValidationError` indicando el producto y la factura origen
+
+#### Scenario: Producto tipo Servicio ajeno a la factura origen
+- **WHEN** se crea o edita una Nota de Crédito agregando un producto de tipo Servicio que la factura origen nunca facturó
+- **THEN** el sistema permite la operación sin error, siempre que el monto total acreditado no supere el total facturado en el origen
+
+#### Scenario: Edición directa de una línea ya creada
+- **WHEN** se modifica el `product_id` de una línea de una Nota de Crédito ya existente, sin pasar por el `write()` del documento padre
+- **THEN** la validación se ejecuta igual y rechaza el producto Almacenable/Consumible ajeno
+
+#### Scenario: Bypass explícito para módulos automáticos
+- **WHEN** un módulo crea la Nota de Crédito con el contexto `l10n_ve_skip_refund_origin_validation=True`
+- **THEN** la validación de producto y monto no se ejecuta, cualquiera sea el producto usado
+
+## ADDED Requirements
+
+### Requirement: Monto total de servicios ajenos al origen no puede superar lo facturado en el origen
+El sistema DEBE (MUST) impedir que la suma de lo acreditado por productos de tipo Servicio ajenos a la factura origen, más lo acreditado por productos presentes en el origen, más lo ya acreditado por todas las demás Notas de Crédito no canceladas contra el mismo origen, supere el total facturado (todas las líneas de producto) en la factura origen.
+
+#### Scenario: Servicio ajeno dentro del total facturado
+- **WHEN** el monto de un producto de Servicio ajeno al origen, sumado a lo demás acreditado en la Nota de Crédito y a lo ya acreditado por otras Notas de Crédito, no supera el total facturado en el origen
+- **THEN** la Nota de Crédito se guarda sin error
+
+#### Scenario: Servicio ajeno que por sí solo excede el total facturado
+- **WHEN** el monto de un único producto de Servicio ajeno al origen ya supera el total facturado en el origen
+- **THEN** el sistema rechaza la operación con un `ValidationError` indicando los montos y la factura origen
+
+#### Scenario: Servicio ajeno exactamente en el límite del total facturado
+- **WHEN** el monto acreditado total (incluyendo el servicio ajeno) es exactamente igual al total facturado en el origen
+- **THEN** la Nota de Crédito se guarda sin error
+
+#### Scenario: Mezcla de producto del origen y servicio ajeno que juntos exceden el total
+- **WHEN** una Nota de Crédito combina un producto presente en el origen con un producto de Servicio ajeno, y la suma de ambos supera el total facturado en el origen
+- **THEN** el sistema rechaza la operación, aunque cada línea individualmente no exceda su propio tope por producto
+
+#### Scenario: Varias Notas de Crédito hermanas consumen el total antes que la de servicio
+- **WHEN** una primera Nota de Crédito ya acreditó parte del total facturado con un producto presente en el origen, y una segunda Nota de Crédito intenta acreditar con un producto de Servicio ajeno un monto que, sumado a lo ya acreditado, supera el total facturado
+- **THEN** el sistema rechaza la segunda Nota de Crédito

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-allow-foreign-service-credit-note/tasks.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-allow-foreign-service-credit-note/tasks.md
@@ -1,0 +1,17 @@
+## 1. Validación en `l10n_ve_invoice`
+
+- [x] 1.1 Modificar `_check_refund_against_origin` (`models/account_move.py`): producto tipo `service` ajeno a la factura origen deja de lanzar `ValidationError` y se acumula en `service_exempt_total` en vez de en `current_totals`. Almacenable/Consumible sin cambios.
+- [x] 1.2 Corrección post-review (agente independiente `binaural-fn-lider-tecnico:lider-tecnico`): la primera versión dejaba el monto de servicios ajenos sin ningún tope (podía acreditarse un monto ilimitado). Se agregó un chequeo agregado: `service_exempt_total` + productos normales + lo ya acreditado por NC hermanas no puede superar el total facturado en el origen.
+- [x] 1.3 Bump de manifest `19.0.1.0.12` -> `19.0.1.0.13`.
+- [x] 1.4 Agregar traducción ES-VE del nuevo mensaje de error agregado en `i18n/es_VE.po`.
+
+## 2. Tests
+
+- [x] 2.1 `l10n_ve_invoice/tests/test_refund_origin_validation.py`: servicio ajeno permitido, servicio ajeno bloqueado si excede el total del origen (solo o combinado con otro servicio ajeno), boundary exacto en el total permitido, mezcla producto normal + servicio ajeno (dentro y fuera del total), acumulado entre NC hermanas (una NC con producto normal consume parte del total, una segunda NC con solo servicio ajeno respeta lo que queda).
+- [x] 2.1.1 Corrección post-review (agente independiente): los tests que probaban el bloqueo de producto ajeno usaban productos tipo `service` como fixture, por lo que dejaron de fallar por la razón correcta al aplicar este cambio. Se agregó `product_storable` (`type="consu"`) para esos casos y se dejó `service_early_payment`/`product_c` (tipo `service`) para los casos nuevos.
+- [x] 2.1.2 Corrección: el fixture inicial usaba el campo `is_storable`, que no existe en el `product.product` de este core (`type` solo admite `consu`/`service`/`combo`). Detectado al correr los tests contra una base de datos nueva instalada desde cero -- en una base ya existente el registro no fallaba porque venía de un esquema previo.
+
+## 3. Verificación
+
+- [x] 3.1 Corridos los 176 tests de `l10n_ve_invoice` (incluye subárbol de `test_refund_origin_validation.py`) contra una base de datos nueva (`test_refund_81674`), instalación limpia desde cero: 0 fallos, 0 errores.
+- [x] 3.2 Confirmado que los 3 fallos vistos en una corrida previa contra una base de datos ya existente (`testing`) eran por una vista de `l10n_ve_accountant` (`view_move_form_debit_inherit_l10n_ve`) desactualizada en esa base -- no relacionados a este cambio. Se resolvió con `-u l10n_ve_accountant` en esa base; en la base nueva instalada desde cero no aparece.

--- a/l10n_ve_invoice/tests/test_refund_origin_validation.py
+++ b/l10n_ve_invoice/tests/test_refund_origin_validation.py
@@ -36,6 +36,14 @@ class TestRefundOriginValidation(TransactionCase):
             "name": "Producto C",
             "type": "service",
         })
+        cls.product_storable = cls.env["product.product"].create({
+            "name": "Producto Almacenable",
+            "type": "consu",
+        })
+        cls.service_early_payment = cls.env["product.product"].create({
+            "name": "Pronto Pago",
+            "type": "service",
+        })
         cls.partner = cls.env["res.partner"].create({"name": "Cliente de prueba"})
         cls.journal = cls.env["account.journal"].create({
             "name": "Diario de Ventas Refund Test",
@@ -93,7 +101,115 @@ class TestRefundOriginValidation(TransactionCase):
         invoice.action_post()
         with self.assertRaises(ValidationError):
             self._create_invoice(
-                [self._create_invoice_line(self.product_b, 1, 10.0)],
+                [self._create_invoice_line(self.product_storable, 1, 10.0)],
+                move_type="out_refund",
+                reversed_entry_id=invoice,
+            )
+
+    def test_credit_note_with_foreign_service_product_is_allowed(self):
+        """Ticket #81674: financial concepts that never appear on the
+        original invoice (early payment, commercial discount, exchange
+        difference) are service products and must not be blocked by the
+        origin-membership check, unlike storable/consumable products."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        credit_note = self._create_invoice(
+            [self._create_invoice_line(self.service_early_payment, 1, 10.0)],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+        self.assertEqual(credit_note.invoice_line_ids.product_id, self.service_early_payment)
+
+    def test_credit_note_with_foreign_service_product_cannot_exceed_origin_total(self):
+        """A foreign service line has no per-product cap, but it must
+        still respect the origin's grand total."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [self._create_invoice_line(self.service_early_payment, 1, 150.0)],
+                move_type="out_refund",
+                reversed_entry_id=invoice,
+            )
+
+    def test_credit_note_with_foreign_service_product_exactly_at_origin_total_is_allowed(self):
+        """The boundary case: a foreign service line that credits exactly
+        the origin's total (not a cent more) must be allowed."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        credit_note = self._create_invoice(
+            [self._create_invoice_line(self.service_early_payment, 1, 100.0)],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+        self.assertEqual(credit_note.amount_untaxed, 100.0)
+
+    def test_credit_note_mixing_origin_product_and_foreign_service_cannot_exceed_origin_total(self):
+        """A credit note combining a same-origin product line with a
+        foreign service line must respect the origin's grand total across
+        both lines together, not just the per-product cap on the first
+        one."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [
+                    self._create_invoice_line(self.product_a, 1, 60.0),
+                    self._create_invoice_line(self.service_early_payment, 1, 60.0),
+                ],
+                move_type="out_refund",
+                reversed_entry_id=invoice,
+            )
+
+    def test_credit_note_mixing_origin_product_and_foreign_service_within_origin_total_is_allowed(self):
+        """Same combination as above, but staying within the origin's
+        grand total, so it must be allowed."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        credit_note = self._create_invoice(
+            [
+                self._create_invoice_line(self.product_a, 1, 60.0),
+                self._create_invoice_line(self.service_early_payment, 1, 30.0),
+            ],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+        self.assertEqual(credit_note.amount_untaxed, 90.0)
+
+    def test_credit_note_with_multiple_foreign_service_products_cannot_exceed_origin_total(self):
+        """Several distinct foreign service products on the same credit
+        note must have their amounts summed for the grand-total check,
+        not evaluated independently of each other."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [
+                    self._create_invoice_line(self.service_early_payment, 1, 60.0),
+                    self._create_invoice_line(self.product_c, 1, 60.0),
+                ],
+                move_type="out_refund",
+                reversed_entry_id=invoice,
+            )
+
+    def test_cumulative_credit_notes_with_foreign_service_cannot_exceed_origin_total(self):
+        """A first credit note against a normal product line uses up part
+        of the origin's total; a second credit note with only a foreign
+        service line must still be capped by what's left, not treated as
+        starting from zero."""
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+
+        first_credit_note = self._create_invoice(
+            [self._create_invoice_line(self.product_a, 1, 70.0)],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+        self.assertTrue(first_credit_note.id)
+
+        with self.assertRaises(ValidationError):
+            self._create_invoice(
+                [self._create_invoice_line(self.service_early_payment, 1, 40.0)],
                 move_type="out_refund",
                 reversed_entry_id=invoice,
             )
@@ -137,7 +253,7 @@ class TestRefundOriginValidation(TransactionCase):
         bill.action_post()
         with self.assertRaises(ValidationError):
             self._create_invoice(
-                [self._create_invoice_line(self.product_b, 1, 10.0, tax=self.purchase_tax)],
+                [self._create_invoice_line(self.product_storable, 1, 10.0, tax=self.purchase_tax)],
                 move_type="in_refund",
                 reversed_entry_id=bill,
                 journal=self.purchase_journal,
@@ -169,7 +285,7 @@ class TestRefundOriginValidation(TransactionCase):
             "invoice_date": fields.Date.today(),
             "invoice_date_display": fields.Date.today(),
             "reversed_entry_id": invoice.id,
-            "invoice_line_ids": [self._create_invoice_line(self.product_b, 1, 999.0)],
+            "invoice_line_ids": [self._create_invoice_line(self.product_storable, 1, 999.0)],
         })
         self.assertTrue(credit_note.id)
 
@@ -209,7 +325,7 @@ class TestRefundOriginValidation(TransactionCase):
         )
         line = credit_note.invoice_line_ids[0]
         with self.assertRaises(ValidationError):
-            line.write({"product_id": self.product_c.id})
+            line.write({"product_id": self.product_storable.id})
 
     def test_line_write_raising_amount_over_cap_is_blocked(self):
         """Same line-level trigger, but for the amount check instead of


### PR DESCRIPTION
[FEAT] l10n_ve_invoice: permite servicios ajenos al origen en notas de credito

Los productos tipo Servicio ajenos a la factura original (pronto pago, descuento comercial, diferencial cambiario) ya no son bloqueados por _check_refund_against_origin en las notas de credito.

Antes, la constraint bloqueaba por igual cualquier producto ajeno a la factura origen, sin distinguir tipo -- correcto para devoluciones de inventario (Almacenable/Consumible), pero impedia emitir notas de credito por conceptos financieros que por naturaleza nunca figuran en la factura original. Ahora un producto tipo Servicio ajeno al origen se permite, pero su monto queda sujeto a un tope agregado: la suma de lo acreditado en la nota (productos normales + servicios exentos) mas lo ya acreditado por notas de credito hermanas no puede superar el total facturado en el origen. Almacenable/Consumible ajeno al origen sigue bloqueado sin cambios.

References:
- Ticket:
- Tarea: 81674
- PR:
- Otros: https://binaural.odoo.com/odoo/action-1963/4291/action-345/81674