### PR TITLE
corrige el IGTF sugerido mostrando el total en vez del 3%

### DIFF
--- a/l10n_ve_igtf/__manifest__.py
+++ b/l10n_ve_igtf/__manifest__.py
@@ -19,7 +19,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Accounting",
-    "version": "19.0.1.2.16",
+    "version": "19.0.1.2.17",
 
     "depends": [
         "base",

--- a/l10n_ve_igtf/static/src/components/tax_totals.xml
+++ b/l10n_ve_igtf/static/src/components/tax_totals.xml
@@ -125,7 +125,7 @@
                     </td>
                     <td>
                         <span class="o_tax_group_amount_value">
-                            <t t-out="totals.igtf.formatted_foreign_igtf_base_amount"/>
+                            <t t-out="totals.igtf.formatted_foreign_igtf_amount"/>
                         </span>
                     </td>
                 </tr>

--- a/l10n_ve_igtf/tests/test_igtf_wizard_amounts.py
+++ b/l10n_ve_igtf/tests/test_igtf_wizard_amounts.py
@@ -181,6 +181,55 @@ class TestIgtfWizardAmounts(TestIndexedPayments):
             "foreign_amount_total_igtf must never be negative on a credit note.",
         )
 
+    def test_foreign_igtf_amount_is_percentage_of_base_for_vef_invoice(self):
+        """tax_totals['igtf']['foreign_igtf_amount'] (the '(sugerido)' row
+        rendered by TaxVesTotalsField) must be the IGTF percentage applied to
+        the base, not the base/total itself. Regression guard for ticket
+        81043: the QWeb template was reading foreign_igtf_base_amount (the
+        total invoice amount) instead of foreign_igtf_amount (the 3%) in
+        that row."""
+        invoice = self._create_vef_invoice(amount=1000.0)
+
+        igtf_totals = invoice.tax_totals["igtf"]
+        base = igtf_totals["foreign_igtf_base_amount"]
+        amount = igtf_totals["foreign_igtf_amount"]
+        percentage = self.company.igtf_percentage / 100
+
+        self.assertAlmostEqual(
+            amount, base * percentage, places=2,
+            msg="foreign_igtf_amount must equal foreign_igtf_base_amount * igtf_percentage.",
+        )
+        self.assertNotAlmostEqual(
+            amount, base, places=2,
+            msg="foreign_igtf_amount must NOT equal the base/total -- that's the "
+            "bug where the suggested IGTF showed the full invoice total.",
+        )
+
+    def test_foreign_igtf_amount_is_percentage_of_base_for_foreign_currency_invoice(self):
+        """Same guarantee as above, but for the exact scenario reported in
+        ticket 81043: an invoice booked in a foreign currency (USD) after a
+        currency recalculation, where company currency is VEF. The
+        '(sugerido)' amount must still be 3% of the base, never the base
+        itself."""
+        self._set_rate(self.currency_usd, self.invoice_date, 40.0)
+
+        invoice = self._create_foreign_invoice(self.currency_usd, amount=100.0)
+
+        igtf_totals = invoice.tax_totals["igtf"]
+        base = igtf_totals["foreign_igtf_base_amount"]
+        amount = igtf_totals["foreign_igtf_amount"]
+        percentage = self.company.igtf_percentage / 100
+
+        self.assertAlmostEqual(
+            amount, base * percentage, places=2,
+            msg="foreign_igtf_amount must equal foreign_igtf_base_amount * igtf_percentage.",
+        )
+        self.assertNotAlmostEqual(
+            amount, base, places=2,
+            msg="foreign_igtf_amount must NOT equal the base/total -- that's the "
+            "bug where the suggested IGTF showed the full invoice total.",
+        )
+
     def test_destination_account_id_domain_customer_uses_receivable(self):
         """A non-advance payment to a customer must offer receivable accounts
         (Por Cobrar), not payable ones -- the two branches were swapped

--- a/openspec/specs/l10n_ve_igtf/spec.md
+++ b/openspec/specs/l10n_ve_igtf/spec.md
@@ -219,6 +219,13 @@ El propio compute también lee `rec.payment_state` en su guard (`if abs(rec.amou
 - **WHEN** la factura de cliente no tiene IGTF aplicado
 - **THEN** `tax_totals['igtf']` reporta `apply_igtf` falso con la base igual al total de la factura y el bloque `igtf_free_form` sugiere el IGTF sobre ese total
 
+El widget `TaxVesTotalsField` (`static/src/components/tax_totals.xml`, usado cuando el documento se opera en moneda de la compañía) DEBE (MUST) renderizar en la fila "IGTF(sugerido)" el monto `totals.igtf.foreign_igtf_amount` (el porcentaje ya aplicado sobre la base), nunca `totals.igtf.foreign_igtf_base_amount` (la base/total del documento) -- ambas claves conviven en el mismo dict y son fáciles de confundir al extender la plantilla.
+
+#### Scenario: IGTF sugerido en la vista de moneda de la compañía
+
+- **WHEN** se muestra el bloque de totales de una factura en moneda de la compañía con `igtf_show` verdadero
+- **THEN** la fila "IGTF(sugerido)" muestra el 3% de la base (`foreign_igtf_amount`), no el total de la factura (`foreign_igtf_base_amount`)
+
 ### Requirement: Widget de anticipos pendientes en la factura
 
 Las facturas publicadas con estado de pago `not_paid` o `partial` DEBEN (MUST) exponer en `invoice_outstanding_credits_debits_widget_advance_payment` las líneas no conciliadas del partner comercial cuyo saldo tenga el signo contrario al documento, buscadas sobre las cuentas por cobrar/pagar de la propia factura más las cuentas de anticipo del tipo que corresponde al `move_type` (`liability_current` para `out_invoice` e `in_refund`; `asset_current` para el resto), y conservando solo las líneas que están en una cuenta de anticipo o que llevan `payment_id_advance`, con el monto residual convertido a la moneda de la factura. El widget estándar de créditos pendientes DEBE (MUST) excluir las líneas de anticipo y los asientos de cruce (`is_advance_move`), y `invoice_has_outstanding` considera ambos widgets. La conversión respeta `keep_alter_value_vef` del pago: los pagos en VEF con la marca se convierten desde `amount_residual` a la fecha del pago (revalorización), y sin la marca desde `amount_residual_currency` a la fecha mayor entre factura y pago; cuando la línea ya está en la moneda de la factura se usa `amount_residual_currency` sin conversión.


### PR DESCRIPTION
[FIX] l10n_ve_igtf: corrige el IGTF sugerido mostrando el total en vez del 3%

El bloque "IGTF(sugerido)" del widget de totales en moneda de la compañía (TaxVesTotalsField) pintaba totals.igtf.foreign_igtf_base_amount (la base, el total de la factura) en vez de totals.igtf.foreign_igtf_amount (el 3% ya calculado). Se reproducía al recalcular una factura de cliente/proveedor por cambio de moneda del pedido de origen.

Se agregan 2 tests de regresión sobre tax_totals['igtf'] (factura en VEF y en moneda extranjera) que verifican que foreign_igtf_amount sea la base por el porcentaje configurado y nunca igual a la base. Se documenta el requisito en openspec/specs/l10n_ve_igtf/spec.md y se sube versión a 19.0.1.2.17.

References:
- Ticket: (https://binaural.odoo.com/odoo/action-1963/4423/action-345/project.task/81043)
- Tarea:
- PR:
- Otros: