### PR TITLE
[FIX] l10n_ve_accountant: Corregir dependencia circular en foreign_balance

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -41,7 +41,7 @@ Cambios en UI / Modelos impactados
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.63",
+    "version": "17.0.0.0.64",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -41,7 +41,7 @@ Cambios en UI / Modelos impactados
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.66",
+    "version": "17.0.0.0.67",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -41,7 +41,7 @@ Cambios en UI / Modelos impactados
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.64",
+    "version": "17.0.0.0.65",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -41,7 +41,7 @@ Cambios en UI / Modelos impactados
     "author": "Binauraldev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.65",
+    "version": "17.0.0.0.66",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -685,14 +685,19 @@ class AccountMove(models.Model):
                 continue
             origin = move.reversed_entry_id or move.debit_origin_id
             if origin:
-                move.foreign_rate = origin.foreign_rate
-                move.foreign_inverse_rate = origin.foreign_inverse_rate
+                move.with_context(l10n_ve_force_rate_write=True).write({
+                    'foreign_rate': origin.foreign_rate,
+                    'foreign_inverse_rate': origin.foreign_inverse_rate,
+                })
                 continue
             date_field = "invoice_date" if move.is_invoice(include_receipts=True) else "date"
             rate_date = getattr(move, date_field) or fields.Date.context_today(self)
             rate_values = Rate.compute_rate(move.foreign_currency_id.id, rate_date)
-            move.foreign_rate = rate_values.get("foreign_rate", 0)
-            move.foreign_inverse_rate = rate_values.get("foreign_inverse_rate", 0)
+            move.write({
+                'foreign_rate': rate_values.get("foreign_rate", 0),
+                'foreign_inverse_rate': rate_values.get("foreign_inverse_rate", 0),
+            })
+            
 
     @api.depends("tax_totals")
     def _compute_foreign_taxable_income(self):

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -685,19 +685,14 @@ class AccountMove(models.Model):
                 continue
             origin = move.reversed_entry_id or move.debit_origin_id
             if origin:
-                move.with_context(l10n_ve_force_rate_write=True).write({
-                    'foreign_rate': origin.foreign_rate,
-                    'foreign_inverse_rate': origin.foreign_inverse_rate,
-                })
+                move.foreign_rate = origin.foreign_rate
+                move.foreign_inverse_rate = origin.foreign_inverse_rate
                 continue
             date_field = "invoice_date" if move.is_invoice(include_receipts=True) else "date"
             rate_date = getattr(move, date_field) or fields.Date.context_today(self)
             rate_values = Rate.compute_rate(move.foreign_currency_id.id, rate_date)
-            move.write({
-                'foreign_rate': rate_values.get("foreign_rate", 0),
-                'foreign_inverse_rate': rate_values.get("foreign_inverse_rate", 0),
-            })
-            
+            move.foreign_rate = rate_values.get("foreign_rate", 0)
+            move.foreign_inverse_rate = rate_values.get("foreign_inverse_rate", 0)
 
     @api.depends("tax_totals")
     def _compute_foreign_taxable_income(self):

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1114,9 +1114,9 @@ class AccountMove(models.Model):
                         fb = magnitude if tl.balance >= 0 else -magnitude
                         if not fc.is_zero(tl.foreign_balance - fb):
                             if fb >= 0:
-                                tl.write({'foreign_debit': fb, 'foreign_credit': 0.0})
+                                tl.write({'foreign_debit': fb, 'foreign_credit': 0.0, 'foreign_balance': fb})
                             else:
-                                tl.write({'foreign_debit': 0.0, 'foreign_credit': -fb})
+                                tl.write({'foreign_debit': 0.0, 'foreign_credit': -fb, 'foreign_balance': fb})
             finally:
                 guarded.discard(move.id)
 
@@ -1180,9 +1180,9 @@ class AccountMove(models.Model):
                 fb = fee(amount)
                 if not fc.is_zero(tl.foreign_balance - fb):
                     if fb >= 0:
-                        tl.write({'foreign_debit': fb, 'foreign_credit': 0.0})
+                        tl.write({'foreign_debit': fb, 'foreign_credit': 0.0, 'foreign_balance': fb})
                     else:
-                        tl.write({'foreign_debit': 0.0, 'foreign_credit': -fb})
+                        tl.write({'foreign_debit': 0.0, 'foreign_credit': -fb, 'foreign_balance': fb})
 
     def _distribute_foreign_pt_residual(self, moves):
         """Distributes foreign_debit/foreign_credit across payment term lines

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -285,7 +285,7 @@ class AccountMoveLine(models.Model):
                 return abs(self.foreign_debit_adjustment)
             if self.foreign_credit_adjustment:
                 return -abs(self.foreign_credit_adjustment)
-            return self.foreign_balance
+            return None
 
         if self.display_type in ("line_section", "line_note"):
             return 0.0

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -332,7 +332,6 @@ class AccountMoveLine(models.Model):
         "debit",
         "credit",
         "foreign_subtotal",
-        "foreign_balance",
         "amount_currency",
         "not_foreign_recalculate",
         "foreign_debit_adjustment",

--- a/l10n_ve_accountant/tests/test_account_move_rate.py
+++ b/l10n_ve_accountant/tests/test_account_move_rate.py
@@ -1,3 +1,4 @@
+from odoo import fields
 from odoo.tests import TransactionCase, tagged
 
 @tagged("post_install", "-at_install", "l10n_ve_accountant", "rate_decimal_precision")
@@ -12,7 +13,36 @@ class TestAccountMoveRate(TransactionCase):
             "currency_id": self.currency_usd.id,
             "currency_foreign_id": self.currency_vef.id,
         })
-    
+
+    def test_compute_rate_updates_new_record_without_saving(self):
+        """Regression: _compute_rate_for_documents must assign foreign_rate/
+        foreign_inverse_rate directly instead of calling move.write({...}).
+        write() is a no-op on NewId (onchange-preview) records, so the old code
+        left the recomputed rate invisible in the form until the user saved.
+        """
+        self.env["res.currency.rate"].create({
+            "name": fields.Date.today(),
+            "currency_id": self.currency_vef.id,
+            "company_rate": 42.5,
+            "company_id": self.company.id,
+        })
+        partner = self.env["res.partner"].create({"name": "Cliente Rate Preview"})
+
+        move_form = self.env["account.move"].with_context(default_move_type="out_invoice").new()
+        move_form.company_id = self.company.id
+        move_form.currency_id = self.currency_usd
+        move_form.foreign_currency_id = self.currency_vef
+        move_form.partner_id = partner
+        move_form.invoice_date = fields.Date.today()
+
+        self.assertEqual(
+            move_form.foreign_rate,
+            42.5,
+            "The onchange preview must reflect the recomputed foreign_rate without "
+            "saving; a move.write() inside the compute method silently no-ops on "
+            "NewId records.",
+        )
+
     def test_foreign_rate_decimal_precision(self):
         """
         Test that the foreign_rate field uses the 'Tasa' decimal precision

--- a/l10n_ve_accountant/tests/test_account_move_rate.py
+++ b/l10n_ve_accountant/tests/test_account_move_rate.py
@@ -1,4 +1,3 @@
-from odoo import fields
 from odoo.tests import TransactionCase, tagged
 
 @tagged("post_install", "-at_install", "l10n_ve_accountant", "rate_decimal_precision")
@@ -13,36 +12,7 @@ class TestAccountMoveRate(TransactionCase):
             "currency_id": self.currency_usd.id,
             "currency_foreign_id": self.currency_vef.id,
         })
-
-    def test_compute_rate_updates_new_record_without_saving(self):
-        """Regression: _compute_rate_for_documents must assign foreign_rate/
-        foreign_inverse_rate directly instead of calling move.write({...}).
-        write() is a no-op on NewId (onchange-preview) records, so the old code
-        left the recomputed rate invisible in the form until the user saved.
-        """
-        self.env["res.currency.rate"].create({
-            "name": fields.Date.today(),
-            "currency_id": self.currency_vef.id,
-            "company_rate": 42.5,
-            "company_id": self.company.id,
-        })
-        partner = self.env["res.partner"].create({"name": "Cliente Rate Preview"})
-
-        move_form = self.env["account.move"].with_context(default_move_type="out_invoice").new()
-        move_form.company_id = self.company.id
-        move_form.currency_id = self.currency_usd
-        move_form.foreign_currency_id = self.currency_vef
-        move_form.partner_id = partner
-        move_form.invoice_date = fields.Date.today()
-
-        self.assertEqual(
-            move_form.foreign_rate,
-            42.5,
-            "The onchange preview must reflect the recomputed foreign_rate without "
-            "saving; a move.write() inside the compute method silently no-ops on "
-            "NewId records.",
-        )
-
+    
     def test_foreign_rate_decimal_precision(self):
         """
         Test that the foreign_rate field uses the 'Tasa' decimal precision

--- a/l10n_ve_accountant/tests/test_coverage_gaps.py
+++ b/l10n_ve_accountant/tests/test_coverage_gaps.py
@@ -1131,11 +1131,12 @@ class TestCoverageGaps(TransactionCase):
         list `foreign_balance` in its `@api.depends`. `_compute_foreign_balance`
         depends on `foreign_debit`/`foreign_credit`, which
         `_compute_foreign_debit_credit` sets -- listing `foreign_balance` back
-        as one of ITS OWN dependencies closes a real A-depends-B/B-depends-A
-        cycle. The payment_term/tax branch of `_get_foreign_value` still reads
-        `self.foreign_balance`, but reacting to a manual write of that field is
-        already `_inverse_foreign_balance`'s job; the depends entry was a
-        redundant trigger and the actual source of the cycle.
+        as one of ITS OWN dependencies closed a real A-depends-B/B-depends-A
+        cycle. The payment_term/tax branch of `_get_foreign_value` no longer
+        reads `self.foreign_balance` either (it returns `None`, leaving
+        `foreign_debit`/`foreign_credit` untouched): those lines are correctly
+        resolved by `_distribute_foreign_pt_residual` when the document posts,
+        not by this compute.
         """
         compute_name = self.env['account.move.line']._fields['foreign_debit'].compute
         compute_method = getattr(self.env.registry['account.move.line'], compute_name)

--- a/l10n_ve_accountant/tests/test_coverage_gaps.py
+++ b/l10n_ve_accountant/tests/test_coverage_gaps.py
@@ -11,7 +11,7 @@ from odoo.exceptions import UserError, ValidationError
 _logger = logging.getLogger(__name__)
 
 
-@tagged("post_install", "-at_install", "l10n_ve_accountant_coverage")
+@tagged("post_install", "-at_install", "l10n_ve_accountant", "l10n_ve_accountant_coverage")
 class TestCoverageGaps(TransactionCase):
 
     def _set_correlative_if_required(self, form, value):

--- a/l10n_ve_accountant/tests/test_coverage_gaps.py
+++ b/l10n_ve_accountant/tests/test_coverage_gaps.py
@@ -1126,6 +1126,52 @@ class TestCoverageGaps(TransactionCase):
             self.assertGreater(rec_line.foreign_debit, 0)
             self.assertEqual(rec_line.foreign_credit, 0.0)
 
+    def test_compute_foreign_debit_credit_does_not_depend_on_foreign_balance(self):
+        """Regression (ticket 14979): `_compute_foreign_debit_credit` must not
+        list `foreign_balance` in its `@api.depends`. `_compute_foreign_balance`
+        depends on `foreign_debit`/`foreign_credit`, which
+        `_compute_foreign_debit_credit` sets -- listing `foreign_balance` back
+        as one of ITS OWN dependencies closes a real A-depends-B/B-depends-A
+        cycle. The payment_term/tax branch of `_get_foreign_value` still reads
+        `self.foreign_balance`, but reacting to a manual write of that field is
+        already `_inverse_foreign_balance`'s job; the depends entry was a
+        redundant trigger and the actual source of the cycle.
+        """
+        compute_name = self.env['account.move.line']._fields['foreign_debit'].compute
+        compute_method = getattr(self.env.registry['account.move.line'], compute_name)
+        self.assertNotIn(
+            'foreign_balance', compute_method._depends,
+            "_compute_foreign_debit_credit depending on foreign_balance recreates "
+            "the circular dependency with _compute_foreign_balance.",
+        )
+
+    def test_foreign_balance_matches_debit_credit_after_recompute(self):
+        """Regression (ticket 14979): production had 615 posted lines where
+        `foreign_credit`/`foreign_debit` recomputed correctly but
+        `foreign_balance` stayed stale (e.g. 0.0), because of the circular
+        `@api.depends` above. Two consecutive writes that retrigger
+        `_compute_foreign_debit_credit` (via `foreign_subtotal`) must still
+        leave every line's `foreign_balance` equal to
+        `foreign_debit - foreign_credit`.
+        """
+        invoice = self._create_invoice(self.currency_usd, 100.0)
+        product_line = invoice.line_ids.filtered(lambda l: l.display_type == 'product')
+        product_line.write({'price_unit': 150.0})
+        product_line.write({'price_unit': 200.0})
+        invoice.with_context(move_action_post_alert=True).action_post()
+
+        for line in invoice.line_ids:
+            self.assertAlmostEqual(
+                line.foreign_balance,
+                line.foreign_debit - line.foreign_credit,
+                places=2,
+                msg=(
+                    f"foreign_balance desincronizado en la linea {line.name!r} "
+                    f"(cuenta {line.account_id.code}): "
+                    f"{line.foreign_balance} != {line.foreign_debit} - {line.foreign_credit}"
+                ),
+            )
+
     # ═══════════════════════════════════════════════════════════════
     # account_move_line.py - _compute_foreign_subtotal: base VEF vs base
     # USD must use DIFFERENT formulas for the tax portion of


### PR DESCRIPTION
## Resumen

Se corrige una dependencia circular real en `l10n_ve_accountant` (`account_move_line.py`) que dejaba `foreign_balance` desincronizado de `foreign_debit - foreign_credit` en producción, y se alinea el tag del archivo de tests que concentra el grueso de la suite del módulo. `l10n_ve_accountant` es módulo compartido de `odoo-venezuela`, usado por los 10 proyectos homologados, no solo Country Club (ticket 14979).

## Problema

Se encontraron 615 líneas contables posteadas en producción (Country Club) donde `foreign_balance` no coincidía con `foreign_debit - foreign_credit` (~6.5M Bs de inconsistencia acumulada).

## Causa

`_compute_foreign_debit_credit` dependía de `foreign_balance` en su `@api.depends`, pero `_compute_foreign_balance` depende a su vez de `foreign_debit`/`foreign_credit` — una dependencia circular real que podía dejar `foreign_balance` desincronizado tras un recompute. Esa dependencia era redundante: la rama de `_get_foreign_value` que la necesitaba (payment_term/tax) no requiere reaccionar a un cambio de `foreign_balance` por sí solo. Además, dos `write()` de líneas de impuesto (`_compute_foreign_tax_balance` y `_compute_foreign_tax_balance_from_lines`) actualizaban `foreign_debit`/`foreign_credit` sin incluir `foreign_balance` en el mismo `write`, a diferencia del patrón que ya usaba correctamente otro método del mismo archivo.

El archivo `test_coverage_gaps.py` (82% de la suite del módulo, incluidos los tests que este fix corrige) tenía el tag `l10n_ve_accountant_coverage` en vez de `l10n_ve_accountant`, el tag estándar que usan los otros archivos de test del módulo.

## Solución

- Se quita `foreign_balance` del `@api.depends` de `_compute_foreign_debit_credit`, y se elimina también la lectura de `self.foreign_balance` en `_get_foreign_value` (rama payment_term/tax sin ajuste) — esas líneas ya quedan correctamente resueltas por `_distribute_foreign_pt_residual` al postear el documento.
- Se agrega `foreign_balance` a los dos `write()` de líneas de impuesto que no lo incluían.
- Se agrega el tag `l10n_ve_accountant` a `test_coverage_gaps.py`.
- Se agregan 2 tests de regresión.

**Nota sobre un intento revertido:** una versión anterior de este PR también cambiaba `_compute_rate_for_documents` de `move.write({...})` a asignación directa de campo, bajo la premisa de que `write()` no actualiza el preview de onchange sobre registros `NewId`. Se verificó en `odoo shell` (dos veces, con `.new()` directo y con el helper `Form()` real) que esa premisa es **falsa** en esta versión de Odoo: `Field.write` siempre actualiza la caché, el flag `dirty` solo afecta si se persiste a la base. Además, la asignación directa rompía el bypass `l10n_ve_force_rate_write` que protege la tasa de las rectificativas en cualquier recompute explícito posterior a su creación. Ese cambio se revirtió íntegramente; se deja esta nota para que nadie lo reintente sin volver a verificar.

**Pendiente antes de dar el ticket 14979 por cerrado (no forma parte de este PR):** `_compute_needed_terms` convierte el `foreign_balance` de las líneas payment_term sin pasar `custom_rate` (a diferencia de todas las demás conversiones del módulo, que sí lo hacen) — es una segunda causa plausible del descuadre de las 615 líneas, sin descartar todavía.

## Test plan

- [x] Suite completa de `l10n_ve_accountant` corrida contra Docker en base limpia (`testing_b3_6d5d687`), sobre el commit `5fc256a60` (head actual de esta rama): **198/198 tests, 0 fallos**.
  ```
  docker exec -uodoo odoo-countryclub-17.0 odoo --test-tags l10n_ve_accountant \
    -d testing_b3_6d5d687 -i l10n_ve_accountant --without-demo=True \
    --stop-after-init --no-http -c /home/odoo/.config/odoo.conf
  ```

References:
- Ticket: https://binaural.odoo.com/odoo/my-tickets/14979
- Tarea:
- PR:
