### PR TITLE
[FIX] l10n_ve_invoice, l10n_ve_accountant: falta line_subsection

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.15",
+    "version": "19.0.1.0.17",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -256,8 +256,12 @@ class AccountMoveLine(models.Model):
         if self.display_type in ("payment_term", "tax"):
             return self.foreign_balance
 
-        # 2 — Section / Note: zero
-        if self.display_type in ("line_section", "line_note"):
+        # 2 — Section / Subsection / Note: zero. `line_subsection` is the
+        # display_type Odoo 19 added to this family; without it a
+        # subsection fell through to the branches below and could be
+        # handed a non-zero alternate-currency balance, unbalancing the
+        # entry in the foreign currency.
+        if self.display_type in ("line_section", "line_subsection", "line_note"):
             return 0.0
 
         # 3 — Manual debit adjustment

--- a/l10n_ve_accountant/openspec/changes/l10n-ve-subsection-foreign-value-zero/proposal.md
+++ b/l10n_ve_accountant/openspec/changes/l10n-ve-subsection-foreign-value-zero/proposal.md
@@ -1,0 +1,68 @@
+# Fix: una subsección puede recibir importe en moneda alterna y descuadrar el asiento
+
+## Why
+
+Detectado auditando el mismo defecto que dejaba infacturable la cotización
+S11508 de CDD Las Mercedes (tarea 82254): `line_subsection`, el
+`display_type` que **Odoo 19 agregó a la familia de líneas de maquetado**
+(`line_section`, `line_note`), quedó fuera de las tuplas que este repo tenía
+hardcodeadas.
+
+En `_get_foreign_value()` la rama 2 devuelve `0.0` para sección y nota,
+justamente porque una línea de maquetado no es contable y no puede llevar
+importe. Con `line_subsection` ausente de esa tupla, una subsección **cae por
+las ramas siguientes** y puede terminar con un `foreign_balance` distinto de
+cero: descuadra el asiento en la columna de moneda alterna.
+
+Este es el más silencioso de los dos bugs de la familia. El de
+`l10n_ve_invoice` es ruidoso y sin salida —lanza `ValidationError` y no
+podés facturar—, así que se ve al instante. Este no lanza nada: el asiento se
+postea y queda descuadrado en la moneda alterna, donde nadie mira hasta que
+un reporte no cierra.
+
+Es el mismo error de familia que ya se corrigió en
+`l10n-ve-real-portion-excludes-line-section`, en otro método
+(`_distribute_invoice_real_portion`), y por la misma causa: una tupla de
+`display_type` incompleta.
+
+## What Changes
+
+Se agrega `"line_subsection"` a la tupla de la rama 2 de
+`_get_foreign_value()`, con el comentario que explica de dónde viene el
+`display_type` y qué pasaba sin él.
+
+## Capabilities
+
+### New Capabilities
+- `foreign-value-layout-lines`: el cálculo del importe en moneda alterna de
+  un apunte (`_get_foreign_value`) debe devolver cero para toda la familia de
+  líneas de maquetado (`line_section`, `line_subsection`, `line_note`), antes
+  de evaluar cualquier otra rama, de modo que una línea no contable nunca
+  aporte al cuadre de la columna alterna.
+
+## Impact
+
+- Archivo: `l10n_ve_accountant/models/account_move_line.py`
+  (`_get_foreign_value`, rama 2).
+- Módulos afectados: cualquier cliente con `l10n_ve_accountant` en Odoo 19
+  que use subsecciones en documentos con moneda alterna configurada.
+- Ver también el cambio hermano en `l10n_ve_invoice`
+  (`l10n-ve-invoice-subsection-blocks-invoicing`), que corrige la misma
+  omisión en los tres guards de línea de producto. Los dos son la misma
+  causa raíz y van juntos.
+- **Posible corrección de datos, pero más acotada de lo que decía la primera
+  versión de este documento.** Un code review midió las rutas realmente
+  alcanzables y tenía razón: en una **factura**, pre-fix,
+  `_get_foreign_value()` caía hasta `return None` (la rama 8 solo cubre
+  `product`/`cogs`) y no escribía nada, y core 19 impide
+  `amount_currency != 0` en una línea de maquetado por CHECK constraint. Las
+  rutas alcanzables son los **ajustes manuales** (ramas 3 y 4) y
+  `_get_non_invoice_foreign_value()` (rama 7, asientos que no son factura).
+  Confirmado empíricamente: de los dos tests nuevos, el que revierte en rojo
+  sin el fix es el del ajuste manual, no el de la factura.
+
+  Sigue sin haber guard que impidiera persistir, así que la revisión de
+  asientos ya posteados sigue en pie y la consulta SQL de la sección de tasks
+  sigue siendo el filtro correcto; solo se espera que devuelva menos de lo
+  que sugería la redacción anterior.
+- Bump de manifest `19.0.1.0.15` → `19.0.1.0.16`.

--- a/l10n_ve_accountant/openspec/changes/l10n-ve-subsection-foreign-value-zero/specs/foreign-value-layout-lines/spec.md
+++ b/l10n_ve_accountant/openspec/changes/l10n-ve-subsection-foreign-value-zero/specs/foreign-value-layout-lines/spec.md
@@ -1,0 +1,59 @@
+# Spec delta: foreign-value-layout-lines
+
+## ADDED Requirements
+
+### Requirement: El importe en moneda alterna de una línea de maquetado es cero
+
+`_get_foreign_value()` SHALL devolver `0.0` para todo apunte con
+`display_type` en `('line_section', 'line_subsection', 'line_note')`, y SHALL
+hacerlo **antes** de evaluar cualquier otra rama del método (ajustes
+manuales, línea ya en moneda alterna, conversión).
+
+`l10n_ve_accountant` SHALL NOT asignar `foreign_balance`, `foreign_debit` ni
+`foreign_credit` distintos de cero a una línea de maquetado.
+
+Motivo: una línea de maquetado es un encabezado o una nota visual, no es
+contable y no puede aportar al cuadre de ninguna columna. `line_subsection`
+es el `display_type` que Odoo 19 agregó a esta familia; sin él en la tupla,
+la subsección caía por las ramas siguientes y podía recibir un importe
+alterno, descuadrando el asiento en la moneda alterna. El orden importa: si
+la exclusión se evaluara después de las ramas de ajuste manual, una
+subsección con `foreign_debit_adjustment` seteado volvería a recibir importe.
+
+#### Scenario: Documento en moneda alterna con una subsección
+
+- **GIVEN** una compañía con moneda alterna configurada
+- **AND** una factura con una línea `line_subsection` entre sus líneas de
+  producto
+- **WHEN** se postea la factura
+- **THEN** la subsección queda con `foreign_balance = 0`, `foreign_debit = 0`
+  y `foreign_credit = 0`
+
+#### Scenario: El asiento cuadra en la columna alterna
+
+- **GIVEN** el asiento del escenario anterior, ya posteado
+- **WHEN** se suman `foreign_debit` y `foreign_credit` de todos sus apuntes
+- **THEN** ambas sumas son iguales
+
+#### Scenario: La exclusión precede a los ajustes manuales
+
+- **GIVEN** un apunte con `display_type = 'line_subsection'` que tiene
+  `foreign_debit_adjustment` distinto de cero
+- **WHEN** se calcula su importe en moneda alterna
+- **THEN** el resultado es `0.0`
+- **AND** el ajuste manual no se aplica, porque la rama de maquetado se
+  evalúa primero
+
+#### Scenario: Las secciones y notas no cambian de comportamiento
+
+- **GIVEN** un documento con líneas `line_section` y `line_note`, sin
+  subsecciones
+- **WHEN** se calcula el importe alterno de sus apuntes
+- **THEN** el resultado es idéntico al de antes del fix
+
+#### Scenario: Las líneas contables no se ven afectadas
+
+- **GIVEN** un documento con líneas `product`, `tax` y `payment_term`
+- **WHEN** se calcula su importe alterno
+- **THEN** cada una sigue la rama que le corresponde y su valor no cambia
+  respecto a antes del fix

--- a/l10n_ve_accountant/openspec/changes/l10n-ve-subsection-foreign-value-zero/tasks.md
+++ b/l10n_ve_accountant/openspec/changes/l10n-ve-subsection-foreign-value-zero/tasks.md
@@ -1,0 +1,100 @@
+# Tasks
+
+## 1. Diagnóstico
+
+- [x] 1.1 Identificado `line_subsection` como `display_type` nuevo de Odoo 19
+      en la familia de líneas de maquetado, mientras auditábamos el bloqueo
+      de facturación de `l10n_ve_invoice` (tarea 82254, cotización S11508)
+- [x] 1.2 Auditadas las tuplas de `display_type` del módulo buscando la misma
+      omisión: aparece en la rama 2 de `_get_foreign_value()`
+- [x] 1.3 Confirmado que sin `line_subsection` en esa tupla la línea cae por
+      las ramas siguientes y puede recibir un `foreign_balance` distinto de
+      cero
+- [x] 1.4 Confirmado que el defecto es SILENCIOSO: no hay guard que lo
+      detenga, el asiento postea y queda descuadrado en la columna alterna
+
+## 2. Fix
+
+- [x] 2.1 Agregar `"line_subsection"` a la tupla de la rama 2 de
+      `_get_foreign_value()`
+- [x] 2.2 Comentario en el código explicando de dónde viene el
+      `display_type` y qué pasaba sin él
+- [x] 2.3 Bump de manifest `19.0.1.0.15` → `19.0.1.0.16`
+
+## 3. Test de regresión
+
+- [x] 3.1 `test_01b_subsection_gets_no_foreign_amount_and_entry_squares`
+      (`tests/test_real_portion.py`): postea una factura en USD con sección,
+      subsección, producto con IVA y nota, y verifica que las tres líneas de
+      maquetado quedan con `foreign_balance`, `foreign_debit` y
+      `foreign_credit` en 0
+- [x] 3.2 El mismo test cierra con `_assert_balances()` y
+      `_assert_foreign_squares()`, el helper que ya existía en el archivo
+      (`:185`) y que es exactamente el invariante que pedía esta tarea
+- [x] 3.3 Verificado revirtiendo la tupla de `_get_foreign_value()` a
+      `("line_section", "line_note")` y reejecutando el tag. **Resultado que
+      corrige el supuesto de esta tarea:** sin el fix falla SOLO
+      `test_01c`; `test_01b` sigue verde
+- [x] 3.4 `test_01c_subsection_exclusion_precedes_manual_adjustments`: es el
+      test que SÍ discrimina el fix. Pone `foreign_debit_adjustment` en la
+      subsección y verifica que igual queda en 0, o sea que la exclusión se
+      evalúa antes de las ramas de ajuste manual
+
+**Deuda cancelada, y el motivo declarado era falso.** La versión previa de
+este documento decía que el fixture "pide un documento en moneda alterna
+posteado, que es justo lo que la suite de este módulo no puede armar sobre
+base clonada". Un code review lo desmintió con la evidencia a la vista: el
+`setUp` de `tests/test_real_portion.py` (`:14-50`) ya escribe
+`company.foreign_currency_id = USD` y crea las tasas, `test_01` (`:228`) ya
+postea una factura en esa moneda, y `_assert_foreign_squares()` (`:185`) ya
+es la afirmación pedida. Eran 33 tests haciendo lo que este documento
+declaraba imposible. El revisor tenía razón; los tests se escribieron.
+
+**Hallazgo de alcance, medido.** El punto 3.3 dejó a la vista que el
+síntoma NO es alcanzable por las ramas de conversión: en una factura, core 19
+impide `amount_currency != 0` en una línea de maquetado por CHECK constraint,
+así que la subsección nunca recibe importe por esa vía. Las rutas realmente
+alcanzables son los ajustes manuales (ramas 3 y 4) y
+`_get_non_invoice_foreign_value()` (rama 7, asientos que no son factura). Eso
+acota el `Impact` de `proposal.md`, que sobredimensionaba el alcance.
+
+Comando exacto:
+
+```
+odoo -d <db> --without-demo=all -i l10n_ve_accountant --test-enable \
+     --test-tags l10n_ve_accountant_real_portion --stop-after-init
+```
+
+Corrido en base fresca: 36 tests, 0 fallos.
+
+## 4. Corrección de datos
+
+- [ ] 4.1 Detectar asientos ya posteados afectados. A diferencia del cambio
+      hermano, acá no hubo guard que impidiera persistir:
+
+      ```sql
+      SELECT aml.move_id, am.name,
+             SUM(aml.foreign_debit) AS fdeb,
+             SUM(aml.foreign_credit) AS fcred
+        FROM account_move_line aml
+        JOIN account_move am ON am.id = aml.move_id
+       WHERE am.state = 'posted'
+         AND aml.move_id IN (
+               SELECT move_id FROM account_move_line
+                WHERE display_type = 'line_subsection'
+             )
+       GROUP BY aml.move_id, am.name
+      HAVING SUM(aml.foreign_debit) <> SUM(aml.foreign_credit);
+      ```
+
+- [ ] 4.2 Para los que aparezcan, verificar si la subsección tiene
+      `foreign_balance`, `foreign_debit` o `foreign_credit` distinto de cero
+- [ ] 4.3 Decidir con el consultor si se corrigen a mano o se re-sincronizan.
+      NO asumir que la lista está vacía sin correr la consulta: `line_subsection`
+      está disponible en la UI de Odoo 19, así que cualquier usuario pudo
+      haber creado uno
+
+## 5. OpenSpec
+
+- [x] 5.1 `proposal.md` + spec delta
+- [x] 5.2 `openspec validate --changes` -> 5 passed, 0 failed

--- a/l10n_ve_accountant/report/account_report_document.xml
+++ b/l10n_ve_accountant/report/account_report_document.xml
@@ -241,7 +241,14 @@
                         <tbody class="tbody">
 
                             <t t-foreach="docs_by_page" t-as="line">
-                                <t t-if="line.display_type not in ['line_note', 'line_section']">
+                                <!--
+                                    'line_subsection' is the display_type Odoo 19
+                                    added to the layout family. Without it here a
+                                    subsection passed the filter and printed as a
+                                    data row (account, RIF, 0,00) in the middle of
+                                    the document.
+                                -->
+                                <t t-if="line.display_type not in ['line_note', 'line_section', 'line_subsection']">
 
                                     <t t-set="line" t-value="line.with_context(lang=lang)" />
 

--- a/l10n_ve_accountant/tests/test_real_portion.py
+++ b/l10n_ve_accountant/tests/test_real_portion.py
@@ -266,6 +266,150 @@ class TestRealPortion(TransactionCase):
         # Se ejecuto la distribucion
         self.assertGreaterEqual(invoice.real_portion_count, 0)
 
+    def test_01b_subsection_gets_no_foreign_amount_and_entry_squares(self):
+        """`line_subsection` is the display_type Odoo 19 added to the layout
+        family (`line_section`, `line_note`). It was missing from branch 2 of
+        `_get_foreign_value()`, so a subsection fell through to the branches
+        below and could be handed a non-zero alternate-currency amount,
+        unbalancing the entry in the foreign column.
+
+        Covers tasks 3.1 and 3.2 of
+        openspec/changes/l10n-ve-subsection-foreign-value-zero. Those were
+        declared as debt on the grounds that "the fixture needs a posted
+        foreign-currency document, which this module's suite cannot build";
+        a code review pointed out that this very file already does it --
+        `setUp` writes USD as the company's foreign currency and `test_01`
+        posts such an invoice. The reviewer was right, so the debt is paid
+        here instead of carried.
+
+        SCOPE, measured not assumed: this test does NOT discriminate the fix.
+        Verified by reverting the tuple in `_get_foreign_value()` and
+        re-running -- this one still passes. On an invoice the conversion
+        branches never hand a layout line an amount, because core 19 blocks
+        `amount_currency != 0` on them by CHECK constraint. So this is a
+        characterization test of the invariant (layout lines at zero, foreign
+        column squares), and
+        `test_01c_subsection_exclusion_precedes_manual_adjustments` is the
+        one that actually goes red without the fix.
+
+        Run with:
+            odoo -d <db> -i l10n_ve_accountant --test-enable \\
+                 --test-tags l10n_ve_accountant_real_portion --stop-after-init
+        """
+        invoice = self.env["account.move"].with_context(
+            check_move_validity=False,
+        ).create({
+            "move_type": "out_invoice",
+            "partner_id": self.partner.id,
+            "journal_id": self.sale_journal.id,
+            "currency_id": self.currency_usd.id,
+            "date": fields.Date.today(),
+            "invoice_line_ids": [
+                Command.create({
+                    "display_type": "line_section",
+                    "name": "Estudios",
+                }),
+                Command.create({
+                    "display_type": "line_subsection",
+                    "name": "Primera etapa",
+                }),
+                Command.create({
+                    "product_id": self.product.id,
+                    "quantity": 1.0,
+                    "price_unit": 800.00,
+                    "account_id": self.acc_inc.id,
+                    "tax_ids": [(6, 0, [self.tax_16.id])],
+                }),
+                Command.create({
+                    "display_type": "line_note",
+                    "name": "Nota al pie",
+                }),
+            ],
+        })
+        invoice.with_context(move_action_post_alert=True).action_post()
+        self.assertEqual(invoice.state, "posted")
+        self._log_lines(invoice, "test_01b_subsection")
+
+        layout_lines = invoice.line_ids.filtered(
+            lambda l: l.display_type in (
+                "line_section", "line_subsection", "line_note",
+            )
+        )
+        subsections = layout_lines.filtered(
+            lambda l: l.display_type == "line_subsection"
+        )
+        self.assertTrue(
+            subsections,
+            "fixture is broken: the posted move carries no line_subsection, "
+            "so this test would pass without asserting anything",
+        )
+
+        for line in layout_lines:
+            self.assertAlmostEqual(
+                line.foreign_balance, 0.0, places=2,
+                msg=f"{line.display_type} '{line.name}' received a foreign "
+                    f"balance of {line.foreign_balance}",
+            )
+            self.assertAlmostEqual(line.foreign_debit, 0.0, places=2)
+            self.assertAlmostEqual(line.foreign_credit, 0.0, places=2)
+
+        self._assert_balances(invoice, "test_01b")
+        self._assert_foreign_squares(invoice, "test_01b")
+
+    def test_01c_subsection_exclusion_precedes_manual_adjustments(self):
+        """The layout-line exclusion must be evaluated BEFORE the manual
+        adjustment branches of `_get_foreign_value()`.
+
+        This is the case that actually matters: the same review noted that
+        core 19 blocks `amount_currency != 0` on a layout line by CHECK
+        constraint, so the genuinely reachable way one could end up with an
+        alternate amount is a manual `foreign_debit_adjustment` /
+        `foreign_credit_adjustment` (branches 3 and 4), not the conversion
+        branches. If the exclusion were moved after them, this test fails
+        while `test_01b` still passes.
+
+        THIS is the regression test for the change. Verified by reverting the
+        tuple in `_get_foreign_value()` to `("line_section", "line_note")`
+        and re-running the tag: this test goes red and `test_01b` stays
+        green.
+        """
+        invoice = self.env["account.move"].with_context(
+            check_move_validity=False,
+        ).create({
+            "move_type": "out_invoice",
+            "partner_id": self.partner.id,
+            "journal_id": self.sale_journal.id,
+            "currency_id": self.currency_usd.id,
+            "date": fields.Date.today(),
+            "invoice_line_ids": [
+                Command.create({
+                    "display_type": "line_subsection",
+                    "name": "Etapa con ajuste manual",
+                    "foreign_debit_adjustment": 123.45,
+                }),
+                Command.create({
+                    "product_id": self.product.id,
+                    "quantity": 1.0,
+                    "price_unit": 500.00,
+                    "account_id": self.acc_inc.id,
+                    "tax_ids": [(6, 0, [self.tax_16.id])],
+                }),
+            ],
+        })
+        invoice.with_context(move_action_post_alert=True).action_post()
+        self.assertEqual(invoice.state, "posted")
+
+        subsection = invoice.line_ids.filtered(
+            lambda l: l.display_type == "line_subsection"
+        )
+        self.assertTrue(subsection, "fixture is broken: no subsection posted")
+        self.assertAlmostEqual(
+            subsection.foreign_balance, 0.0, places=2,
+            msg="the manual adjustment was applied to a layout line -- the "
+                "exclusion is being evaluated after the adjustment branches",
+        )
+        self._assert_foreign_squares(invoice, "test_01c")
+
     def test_02_invoice_usd_two_taxes_with_foreign_distribution(self):
         """Factura en USD con 2 productos usando IVA 16% y IVA 8%.
            Verifica que _distribute_foreign_pt_residual distribuye

--- a/l10n_ve_invoice/__manifest__.py
+++ b/l10n_ve_invoice/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
         Módulo de Facturación Venezuela
     """,
-    "version": "19.0.1.0.12",
+    "version": "19.0.1.0.14",
     "license": "LGPL-3",
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",

--- a/l10n_ve_invoice/models/account_move.py
+++ b/l10n_ve_invoice/models/account_move.py
@@ -13,19 +13,29 @@ class AccountMove(models.Model):
     _name = "account.move"
     _inherit = "account.move"
 
-    correlative = fields.Char("Control Number", copy=False, help="Sequence control number")
-    declaration_unique_of_customs = fields.Char('Declaration unique of customs', copy=False)
+    correlative = fields.Char(
+        "Control Number", copy=False, help="Sequence control number"
+    )
+    declaration_unique_of_customs = fields.Char(
+        "Declaration unique of customs", copy=False
+    )
 
     invoice_date = fields.Date(
         string="Rate Date",
         default=fields.Date.context_today,
-        help="Date of the invoice. Defaults to today when creating a new invoice."
+        help="Date of the invoice. Defaults to today when creating a new invoice.",
     )
-    
-    tax_base_for_international_purchase = fields.Float(string='Tax Base for International Purchase', help='Tax base for international purchase to show in purchase book')
-    
-    tax_amount_for_international_purchase = fields.Float(string='Tax Amount for International Purchase', help='Tax amount for international purchase to show in purchase book')
-    
+
+    tax_base_for_international_purchase = fields.Float(
+        string="Tax Base for International Purchase",
+        help="Tax base for international purchase to show in purchase book",
+    )
+
+    tax_amount_for_international_purchase = fields.Float(
+        string="Tax Amount for International Purchase",
+        help="Tax amount for international purchase to show in purchase book",
+    )
+
     invoice_reception_date = fields.Date(
         "Reception Date",
         help="Indicates when the invoice was received by the client/company",
@@ -37,13 +47,9 @@ class AccountMove(models.Model):
 
     next_installment_date = fields.Date(compute="_compute_next_installment_date")
 
-    display_date_warning = fields.Boolean(
-        compute="_compute_display_date_warning")
+    display_date_warning = fields.Boolean(compute="_compute_display_date_warning")
 
-    is_debit_journal = fields.Boolean(
-        compute="_compute_is_debit_journal",
-        store=True
-    )
+    is_debit_journal = fields.Boolean(compute="_compute_is_debit_journal", store=True)
 
     entry_in_period = fields.Boolean(
         compute="_compute_entry_in_period",
@@ -57,14 +63,30 @@ class AccountMove(models.Model):
         copy=False,
     )
 
-    @api.constrains('invoice_date_display', 'date')
+    @api.constrains("invoice_date_display", "date")
     def _check_invoice_date_display_purchases(self):
         for move in self:
-            _logger.warning(f"Checking invoice_date_display constraint for move {move.id} with move_type {move.move_type} and company setting block_invoice_display_date_upper_than_date {move.company_id.block_invoice_display_date_upper_than_date}")
-            if move.is_purchase_document(include_receipts=True) and move.company_id.block_invoice_display_date_upper_than_date:
-                if move.invoice_date_display and move.date and move.invoice_date_display > move.date:
-                    raise ValidationError(_("The invoice date cannot be greater than the accounting date."))
-    import_file_number_purchase_international = fields.Char(string="Import File Number Purchase International")
+            _logger.warning(
+                f"Checking invoice_date_display constraint for move {move.id} with move_type {move.move_type} and company setting block_invoice_display_date_upper_than_date {move.company_id.block_invoice_display_date_upper_than_date}"
+            )
+            if (
+                move.is_purchase_document(include_receipts=True)
+                and move.company_id.block_invoice_display_date_upper_than_date
+            ):
+                if (
+                    move.invoice_date_display
+                    and move.date
+                    and move.invoice_date_display > move.date
+                ):
+                    raise ValidationError(
+                        _(
+                            "The invoice date cannot be greater than the accounting date."
+                        )
+                    )
+
+    import_file_number_purchase_international = fields.Char(
+        string="Import File Number Purchase International"
+    )
 
     @api.depends("invoice_date", "state", "move_type")
     def _compute_entry_in_period(self):
@@ -87,8 +109,14 @@ class AccountMove(models.Model):
                 if not move.invoice_date:
                     continue
 
-                if (move.invoice_date.year, move.invoice_date.month) == (period_limit.year, period_limit.month) and move.invoice_date <= period_limit:
-                    if taxpayer_type == "special" and move.invoice_date.day < 15 < period_limit.day:
+                if (move.invoice_date.year, move.invoice_date.month) == (
+                    period_limit.year,
+                    period_limit.month,
+                ) and move.invoice_date <= period_limit:
+                    if (
+                        taxpayer_type == "special"
+                        and move.invoice_date.day < 15 < period_limit.day
+                    ):
                         move.entry_in_period = False
                     else:
                         move.entry_in_period = True
@@ -103,19 +131,32 @@ class AccountMove(models.Model):
 
     @api.constrains("invoice_line_ids")
     def _check_price_in_zero(self):
-        from_pos = self.env.context.get('from_pos', False)
-        invoice_lines = self.filtered(lambda m: m.is_invoice()).mapped("invoice_line_ids")
+        from_pos = self.env.context.get("from_pos", False)
+        invoice_lines = self.filtered(lambda m: m.is_invoice()).mapped(
+            "invoice_line_ids"
+        )
         # _get_discount_lines() is the hook Odoo uses to tag a line as a
         # recognized discount (sale_discount_product_id, pos_discount's
         # config.discount_product_id, loyalty rewards, display_type
         # 'discount', ...). Those are legitimate price <= 0 lines.
         discount_lines = invoice_lines._get_discount_lines()
+        # 'line_subsection' joined the layout-only family in Odoo 19. It
+        # has price_unit = 0 by definition, so leaving it out of the skip
+        # list below made any document using a subsection impossible to
+        # invoice at all (quote S11508). Same three types are skipped in
+        # _check_refund_against_origin() and action_post() -- keep them in
+        # sync.
         for line in invoice_lines - discount_lines:
-            if line.price_unit <= 0 and line.display_type not in ("line_section","line_note"):
-                from_loyalty = self.env.context.get('from_loyalty', False)
+            if line.price_unit <= 0 and line.display_type not in (
+                "line_section",
+                "line_subsection",
+                "line_note",
+            ):
+                from_loyalty = self.env.context.get("from_loyalty", False)
                 if not from_pos and not from_loyalty:
-                    raise ValidationError(_("An invoice cannot have a line with a price of zero"))
-
+                    raise ValidationError(
+                        _("An invoice cannot have a line with a price of zero")
+                    )
 
     @api.constrains("invoice_line_ids")
     def _check_refund_against_origin(self):
@@ -139,7 +180,7 @@ class AccountMove(models.Model):
         if self.env.context.get("l10n_ve_skip_refund_origin_validation"):
             return
 
-        product_line_types = ("line_section", "line_note")
+        product_line_types = ("line_section", "line_subsection", "line_note")
         for move in self:
             if move.move_type not in ("out_refund", "in_refund"):
                 continue
@@ -161,12 +202,14 @@ class AccountMove(models.Model):
             # where two never-posted credit notes could each individually
             # fit under the cap and only exceed it once both are posted,
             # at which point this constrains would no longer re-trigger.
-            sibling_refunds = self.env["account.move"].search([
-                ("reversed_entry_id", "=", origin.id),
-                ("move_type", "=", move.move_type),
-                ("state", "!=", "cancel"),
-                ("id", "!=", move.id),
-            ])
+            sibling_refunds = self.env["account.move"].search(
+                [
+                    ("reversed_entry_id", "=", origin.id),
+                    ("move_type", "=", move.move_type),
+                    ("state", "!=", "cancel"),
+                    ("id", "!=", move.id),
+                ]
+            )
             refund_totals = {}
             for line in sibling_refunds.invoice_line_ids.filtered(
                 lambda l: l.display_type not in product_line_types and l.product_id
@@ -185,20 +228,24 @@ class AccountMove(models.Model):
                     # letting it through would credit an arbitrary amount
                     # with no product to check it against, defeating both
                     # the product and the amount restriction below.
-                    raise ValidationError(_(
-                        "Every product line on this credit note must have "
-                        "a product, so it can be matched against the "
-                        "original invoice '%(origin)s'.",
-                        origin=origin.display_name,
-                    ))
+                    raise ValidationError(
+                        _(
+                            "Every product line on this credit note must have "
+                            "a product, so it can be matched against the "
+                            "original invoice '%(origin)s'.",
+                            origin=origin.display_name,
+                        )
+                    )
                 if line.product_id.id not in origin_totals:
-                    raise ValidationError(_(
-                        "You cannot add the product '%(product)s' to this credit "
-                        "note: it is not part of the original invoice "
-                        "'%(origin)s'.",
-                        product=line.product_id.display_name,
-                        origin=origin.display_name,
-                    ))
+                    raise ValidationError(
+                        _(
+                            "You cannot add the product '%(product)s' to this credit "
+                            "note: it is not part of the original invoice "
+                            "'%(origin)s'.",
+                            product=line.product_id.display_name,
+                            origin=origin.display_name,
+                        )
+                    )
                 current_totals[line.product_id.id] = (
                     current_totals.get(line.product_id.id, 0.0) + line.price_subtotal
                 )
@@ -208,42 +255,64 @@ class AccountMove(models.Model):
                 max_amount = origin_totals.get(product_id, 0.0)
                 already_credited = refund_totals.get(product_id, 0.0)
                 total_credited = already_credited + current_amount
-                if float_compare(total_credited, max_amount, precision_rounding=precision) > 0:
+                if (
+                    float_compare(
+                        total_credited, max_amount, precision_rounding=precision
+                    )
+                    > 0
+                ):
                     product = self.env["product.product"].browse(product_id)
-                    raise ValidationError(_(
-                        "The amount credited for product '%(product)s' "
-                        "(%(amount)s, including %(already)s already credited "
-                        "by other credit notes) exceeds the amount invoiced "
-                        "on the original document '%(origin)s' (%(max)s).",
-                        product=product.display_name,
-                        amount=total_credited,
-                        already=already_credited,
-                        origin=origin.display_name,
-                        max=max_amount,
-                    ))
+                    raise ValidationError(
+                        _(
+                            "The amount credited for product '%(product)s' "
+                            "(%(amount)s, including %(already)s already credited "
+                            "by other credit notes) exceeds the amount invoiced "
+                            "on the original document '%(origin)s' (%(max)s).",
+                            product=product.display_name,
+                            amount=total_credited,
+                            already=already_credited,
+                            origin=origin.display_name,
+                            max=max_amount,
+                        )
+                    )
 
     def action_post(self):
 
         for record in self:
-            if record.move_type in ("out_invoice", "in_invoice", "out_refund", "in_refund"):
+            if record.move_type in (
+                "out_invoice",
+                "in_invoice",
+                "out_refund",
+                "in_refund",
+            ):
                 for line in record.invoice_line_ids:
-                    if line.display_type in ("line_section", "line_note"):
+                    if line.display_type in (
+                        "line_section",
+                        "line_subsection",
+                        "line_note",
+                    ):
                         continue
                     if not line.tax_ids:
-                        raise ValidationError(_("Add a tax to each product line. You cannot confirm the invoice if any product line is missing a tax."))
+                        raise ValidationError(
+                            _(
+                                "Add a tax to each product line. You cannot confirm the invoice if any product line is missing a tax."
+                            )
+                        )
         return super().action_post()
 
     @api.model_create_multi
     def create(self, vals_list):
         now = fields.Datetime.now()
         for vals in vals_list:
-            if vals.get('invoice_date_display'):
-                date_part = fields.Date.to_date(vals['invoice_date_display'])
-                vals['invoice_date_display_datetime'] = now.replace(
+            if vals.get("invoice_date_display"):
+                date_part = fields.Date.to_date(vals["invoice_date_display"])
+                vals["invoice_date_display_datetime"] = now.replace(
                     year=date_part.year, month=date_part.month, day=date_part.day
                 )
-            elif 'invoice_date_display' in vals and not vals.get('invoice_date_display'):
-                vals['invoice_date_display_datetime'] = False
+            elif "invoice_date_display" in vals and not vals.get(
+                "invoice_date_display"
+            ):
+                vals["invoice_date_display_datetime"] = False
         moves = super().create(vals_list)
 
         for move in moves:
@@ -254,7 +323,11 @@ class AccountMove(models.Model):
                 )
 
         for move in moves:
-            if move.is_purchase_international and move.declaration_unique_of_customs and not move.correlative:
+            if (
+                move.is_purchase_international
+                and move.declaration_unique_of_customs
+                and not move.correlative
+            ):
                 move.correlative = move.declaration_unique_of_customs
         return moves
 
@@ -283,11 +356,14 @@ class AccountMove(models.Model):
                 )
                 if repeated_moves:
                     raise UserError(
-                        _("The correlative must be unique per journal when using a contingency journal")
+                        _(
+                            "The correlative must be unique per journal when using a contingency journal"
+                        )
                     )
 
             if (
-                move.correlative and not move.is_contingency
+                move.correlative
+                and not move.is_contingency
                 and move.move_type in ("out_invoice", "out_refund")
             ):
                 repeated_moves = AccountMove.search(
@@ -310,10 +386,12 @@ class AccountMove(models.Model):
                         )
                     )
 
-    @api.depends('journal_id')
+    @api.depends("journal_id")
     def _compute_is_debit_journal(self):
         for move in self:
-            move.is_debit_journal = move.journal_id.is_debit if move.journal_id else False
+            move.is_debit_journal = (
+                move.journal_id.is_debit if move.journal_id else False
+            )
 
     @api.depends("amount_residual")
     def _compute_payment_dates(self):
@@ -368,7 +446,10 @@ class AccountMove(models.Model):
             max_product_invoice = self.company_id.max_product_invoice
             if len(self.invoice_line_ids) > max_product_invoice:
                 raise ValidationError(
-                    _("You can not add more than %s products to the invoice." % max_product_invoice)
+                    _(
+                        "You can not add more than %s products to the invoice."
+                        % max_product_invoice
+                    )
                 )
 
     @api.depends("line_ids.date_maturity", "line_ids.display_type", "invoice_date_due")
@@ -392,27 +473,29 @@ class AccountMove(models.Model):
                 if line.date_maturity and line.date_maturity >= today:
                     invoice.next_installment_date = line.date_maturity
                     break
-    
+
     @api.depends("invoice_date", "state")
     def _compute_display_date_warning(self):
         today = fields.Date.context_today(self)
         for move in self:
             move.display_date_warning = bool(
-                move.invoice_date and move.state == "draft" and move.invoice_date < today
+                move.invoice_date
+                and move.state == "draft"
+                and move.invoice_date < today
             )
 
     def _post(self, soft=True):
         # Filtramos para asegurarnos de que solo intentamos publicar lo que está en borrador
         # Esto evita el error de "debe ser un borrador" en procesos automáticos
-        draft_moves = self.filtered(lambda m: m.state == 'draft')
-        
-        # Si no hay nada en borrador (porque ya se publicó en un paso previo), 
+        draft_moves = self.filtered(lambda m: m.state == "draft")
+
+        # Si no hay nada en borrador (porque ya se publicó en un paso previo),
         # devolvemos el self original para no romper el flujo.
         if not draft_moves:
             return self
 
         res = super(AccountMove, draft_moves)._post(soft)
-        
+
         for move in res:
             # Solo aplicamos número de control a facturas de cliente/notas crédito
             # Evitamos tocar asientos de diferencia de cambio (entry) o pagos
@@ -421,12 +504,11 @@ class AccountMove(models.Model):
                     invoice_print_type = move.company_id.invoice_print_type
                 else:
                     invoice_print_type = None
-                
+
                 if move.is_valid_to_sequence() and invoice_print_type != "fiscal":
                     move.correlative = move.get_sequence()
-                    
+
         return res
-        
 
     @api.model
     def is_valid_to_sequence(self) -> bool:
@@ -437,7 +519,7 @@ class AccountMove(models.Model):
         Returns:
             True or False whether the invoice already has a sequence number or not.
         """
-        
+
         is_contingency = self.journal_id.is_contingency
         journal_type = self.journal_id.type == "sale"
         is_series_invoicing_enabled = self.company_id.group_sales_invoicing_series
@@ -469,11 +551,16 @@ class AccountMove(models.Model):
             correlative = self.journal_id.series_correlative_sequence_id
 
             if not correlative:
-                raise UserError(_("The sale's series sequence must be in the selected journal."))
+                raise UserError(
+                    _("The sale's series sequence must be in the selected journal.")
+                )
             return correlative.next_by_id()
 
         correlative = sequence.search(
-            [("code", "=", "invoice.correlative"), ("company_id", "=", self.env.company.id)]
+            [
+                ("code", "=", "invoice.correlative"),
+                ("company_id", "=", self.env.company.id),
+            ]
         )
         if not correlative:
             correlative = sequence.create(
@@ -485,33 +572,37 @@ class AccountMove(models.Model):
             )
         return correlative.next_by_id()
 
-
     def action_debit_note_button(self):
         action = ""
         for picking in self:
-            action = picking.env.ref('account_debit_note.action_view_account_move_debit').read()[0]
+            action = picking.env.ref(
+                "account_debit_note.action_view_account_move_debit"
+            ).read()[0]
         return action
 
     def write(self, vals):
-        if vals.get('invoice_date_display'):
-            date_part = fields.Date.to_date(vals['invoice_date_display'])
+        if vals.get("invoice_date_display"):
+            date_part = fields.Date.to_date(vals["invoice_date_display"])
             now = fields.Datetime.now()
-            vals['invoice_date_display_datetime'] = now.replace(
+            vals["invoice_date_display_datetime"] = now.replace(
                 year=date_part.year, month=date_part.month, day=date_part.day
             )
-        elif 'invoice_date_display' in vals and not vals.get('invoice_date_display'):
-            vals['invoice_date_display_datetime'] = False
+        elif "invoice_date_display" in vals and not vals.get("invoice_date_display"):
+            vals["invoice_date_display_datetime"] = False
         res = super().write(vals)
         for move in self:
             if move.is_purchase_international and move.declaration_unique_of_customs:
                 if move.correlative != move.declaration_unique_of_customs:
                     move.correlative = move.declaration_unique_of_customs
-            elif not move.is_purchase_international and move.correlative and move.correlative == move.declaration_unique_of_customs:
+            elif (
+                not move.is_purchase_international
+                and move.correlative
+                and move.correlative == move.declaration_unique_of_customs
+            ):
                 move.correlative = False
                 move.declaration_unique_of_customs = False
         return res
 
-    
     def print_invoice_free_form(self):
         self.ensure_one()
         self.free_form_copy_number += 1
@@ -520,52 +611,63 @@ class AccountMove(models.Model):
         if self.message_main_attachment_id:
             attachment = self.message_main_attachment_id
             return {
-                'type': 'ir.actions.act_url',
-                'url': f'/web/content/{attachment.id}?download=true',
-                'target': 'download',
+                "type": "ir.actions.act_url",
+                "url": f"/web/content/{attachment.id}?download=true",
+                "target": "download",
             }
 
         # Si no existe, genera el reporte mediante la acción QWeb estándar
-        report = self.env.ref("l10n_ve_invoice.action_invoice_free_form_l10n_ve_invoice")
+        report = self.env.ref(
+            "l10n_ve_invoice.action_invoice_free_form_l10n_ve_invoice"
+        )
         return report.report_action(self)
 
-
-    def _message_set_main_attachment_id(self, attachments, force=False, filter_xml=True):
+    def _message_set_main_attachment_id(
+        self, attachments, force=False, filter_xml=True
+    ):
         """
-        Solo permite establecer el message_main_attachment_id si la llamada 
+        Solo permite establecer el message_main_attachment_id si la llamada
         proviene del flujo explícito de impresión o envío mediante free_form_copy_number.
         """
         if self.free_form_copy_number >= 1 and not self.message_main_attachment_id:
-            return super()._message_set_main_attachment_id(attachments, force=force, filter_xml=filter_xml)
-        
+            return super()._message_set_main_attachment_id(
+                attachments, force=force, filter_xml=filter_xml
+            )
+
         return
 
     def _get_mail_thread_data_attachments(self):
         self.ensure_one()
-        
+
         if self.message_main_attachment_id:
             res = self.message_main_attachment_id
-            
-            if 'original_id' in self.env['ir.attachment']._fields:
-                svg_ids = res.filtered(lambda attachment: attachment.mimetype == 'image/svg+xml')
-                non_svg_ids = res - svg_ids
-                original_ids = res.mapped('original_id')
-                res = res.filtered(
-                    lambda attachment: (attachment in svg_ids and attachment not in original_ids) 
-                    or (attachment in non_svg_ids and attachment.original_id not in non_svg_ids)
+
+            if "original_id" in self.env["ir.attachment"]._fields:
+                svg_ids = res.filtered(
+                    lambda attachment: attachment.mimetype == "image/svg+xml"
                 )
-            
+                non_svg_ids = res - svg_ids
+                original_ids = res.mapped("original_id")
+                res = res.filtered(
+                    lambda attachment: (
+                        attachment in svg_ids and attachment not in original_ids
+                    )
+                    or (
+                        attachment in non_svg_ids
+                        and attachment.original_id not in non_svg_ids
+                    )
+                )
+
             return res
 
         return super()._get_mail_thread_data_attachments()
 
-
     def action_invoice_sent(self):
-        """ Sobrescribimos para pasar la clave de contexto 'allow_main_attachment_from_system'
-            al abrir la ventana/wizard de enviar e imprimir factura.
+        """Sobrescribimos para pasar la clave de contexto 'allow_main_attachment_from_system'
+        al abrir la ventana/wizard de enviar e imprimir factura.
         """
         self.free_form_copy_number += 1
-        
+
         res = super(AccountMove, self).action_invoice_sent()
 
         return res

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-subsection-blocks-invoicing/proposal.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-subsection-blocks-invoicing/proposal.md
@@ -1,0 +1,74 @@
+# Fix: una subsección hace imposible facturar el documento
+
+## Why
+
+Reportado en CDD Las Mercedes (tarea 82254) sobre la cotización **S11508**:
+la factura no se podía crear, y una vez sorteado eso, tampoco validar.
+
+`line_subsection` es un `display_type` que **Odoo 19 agregó a la familia de
+líneas de maquetado** (`line_section`, `line_note`). Todos los guards de este
+módulo tenían las dos tuplas viejas hardcodeadas, así que una subsección
+—que por definición tiene `price_unit = 0` y no puede llevar impuesto— era
+leída como **línea de producto**:
+
+1. `_check_price_in_zero` la veía como producto a precio cero y lanzaba
+   `ValidationError: "An invoice cannot have a line with a price of zero"` al
+   **crear** la factura.
+2. `action_post` le exigía impuesto y lanzaba `"Add a tax to each product
+   line..."` al **validar**. Es decir: arreglar solo el punto 1 no destraba
+   nada, mueve el bloqueo de crear a postear.
+3. `_check_refund_against_origin` la trataba como producto a acreditar,
+   exigiéndole `product_id` en una nota de crédito.
+
+El síntoma es duro y sin salida: cualquier documento que use una subsección
+—una función nativa de Odoo 19, disponible en la UI— es infacturable. No hay
+workaround más que borrar la subsección.
+
+## What Changes
+
+Se agrega `"line_subsection"` a las tres tuplas de `display_type` del módulo,
+para que las tres queden alineadas con la familia completa de líneas de
+maquetado:
+
+- `_check_price_in_zero`: la tupla de tipos que se saltea la validación de
+  precio cero.
+- `_check_refund_against_origin`: `product_line_types`, los tipos que no son
+  producto acreditable.
+- `action_post`: la tupla que hace `continue` antes de exigir impuesto.
+
+Las tres tuplas quedan explícitamente marcadas en el código como "mantener
+en sincronía": son el mismo concepto repetido tres veces, y el bug fue
+justamente que se actualizó cero de las tres.
+
+El archivo además pasó por `black`, que es de dónde sale el grueso del diff.
+El cambio funcional son tres tuplas.
+
+## Capabilities
+
+### New Capabilities
+- `invoice-layout-line-exclusions`: los guards de `l10n_ve_invoice` que
+  validan líneas de producto (precio distinto de cero, impuesto obligatorio,
+  correspondencia con la factura de origen en notas de crédito) deben excluir
+  siempre la familia completa de líneas de maquetado
+  (`line_section`, `line_subsection`, `line_note`), sin importar cuál de
+  ellas se agregue en una versión futura de Odoo.
+
+## Impact
+
+- Archivo: `l10n_ve_invoice/models/account_move.py`
+  (`_check_price_in_zero`, `_check_refund_against_origin`, `action_post`).
+- Archivo: `l10n_ve_invoice/tests/test_account_move_extended.py` (un test
+  extendido y renombrado, uno nuevo).
+- Módulos afectados: cualquier cliente con `l10n_ve_invoice` en Odoo 19 que
+  use subsecciones en facturas, cotizaciones facturadas o notas de crédito.
+- **Bloquea a otros repos.** El fix de secciones con combos en
+  `cdd-las-mercedes` (`cdd_account`, `cdd_sections`) no se puede verificar en
+  ambiente sin esto: la factura de S11508 no llega a crearse. Este cambio
+  tiene que mergearse primero.
+- Ver también el cambio hermano en `l10n_ve_accountant`
+  (`l10n-ve-subsection-foreign-value-zero`), que corrige la misma omisión en
+  el cálculo del importe en moneda alterna.
+- Sin migración de datos: los guards impedían persistir cualquier cosa. Los
+  documentos afectados quedaban trabados en borrador o sin poder crearse,
+  nunca llegaron a la base con datos inválidos.
+- Bump de manifest `19.0.1.0.12` → `19.0.1.0.13`.

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-subsection-blocks-invoicing/specs/invoice-layout-line-exclusions/spec.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-subsection-blocks-invoicing/specs/invoice-layout-line-exclusions/spec.md
@@ -1,0 +1,63 @@
+# Spec delta: invoice-layout-line-exclusions
+
+## ADDED Requirements
+
+### Requirement: Los guards de línea de producto excluyen toda la familia de maquetado
+
+Todo guard de `l10n_ve_invoice` que valide propiedades exigibles a una línea
+de **producto** SHALL excluir las líneas con `display_type` en
+`('line_section', 'line_subsection', 'line_note')`, y SHALL NOT exigirles
+precio distinto de cero, impuesto asignado ni `product_id`.
+
+Motivo: una línea de maquetado es un encabezado o una nota visual. No tiene
+precio (`price_unit = 0` por definición), no puede llevar impuesto y no
+representa nada acreditable. `line_subsection` es el `display_type` que Odoo
+19 agregó a esta familia; quedó fuera de las tres tuplas del módulo y eso
+hizo infacturable cualquier documento que usara una subsección.
+
+Los tres guards afectados son `_check_price_in_zero`,
+`_check_refund_against_origin` y `action_post`. SHALL mantenerse en sincronía:
+son el mismo concepto expresado tres veces, y el defecto original fue
+actualizar ninguna de las tres.
+
+#### Scenario: Crear una factura con una subsección
+
+- **GIVEN** una factura de cliente con una línea `line_section`, una
+  `line_subsection`, una `line_note` y una línea de producto con precio e
+  impuesto válidos
+- **WHEN** se crea la factura
+- **THEN** la creación tiene éxito
+- **AND** no se lanza `"An invoice cannot have a line with a price of zero"`
+
+#### Scenario: Validar una factura con una subsección
+
+- **GIVEN** la factura del escenario anterior, en estado borrador
+- **WHEN** se ejecuta `action_post()`
+- **THEN** la factura queda en estado `posted`
+- **AND** no se lanza `"Add a tax to each product line..."` por la
+  subsección, que no puede llevar impuesto
+
+#### Scenario: Nota de crédito con una subsección
+
+- **GIVEN** una nota de crédito contra una factura de origen, con una línea
+  `line_subsection` intercalada entre sus líneas de producto
+- **WHEN** se valida la correspondencia con el documento de origen
+- **THEN** la subsección no se cuenta como producto a acreditar
+- **AND** no se le exige `product_id` ni presencia en la factura de origen
+
+#### Scenario: Una línea de producto a precio cero sigue bloqueada
+
+- **GIVEN** una factura con una línea de `display_type = 'product'` y
+  `price_unit = 0`, que no es una línea de descuento reconocida
+  (`_get_discount_lines`)
+- **WHEN** se crea la factura fuera del punto de venta y fuera de un flujo de
+  lealtad
+- **THEN** se lanza `ValidationError`
+- **AND** el guard conserva el comportamiento que tenía antes del fix
+
+#### Scenario: Una línea de producto sin impuesto sigue bloqueada
+
+- **GIVEN** una factura con una línea de producto sin `tax_ids`
+- **WHEN** se ejecuta `action_post()`
+- **THEN** se lanza `ValidationError` exigiendo el impuesto
+- **AND** el guard conserva el comportamiento que tenía antes del fix

--- a/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-subsection-blocks-invoicing/tasks.md
+++ b/l10n_ve_invoice/openspec/changes/l10n-ve-invoice-subsection-blocks-invoicing/tasks.md
@@ -1,0 +1,73 @@
+# Tasks
+
+## 1. Diagnóstico
+
+- [x] 1.1 Reproducido sobre la cotización S11508 de CDD Las Mercedes: la
+      factura no se puede crear
+- [x] 1.2 Identificado `line_subsection` como `display_type` nuevo de Odoo 19
+      en la familia de líneas de maquetado, ausente de las tuplas del módulo
+- [x] 1.3 Confirmado que `_check_price_in_zero` la lee como producto a
+      precio cero (`price_unit = 0` por definición en una subsección)
+- [x] 1.4 Confirmado que arreglar solo `_check_price_in_zero` NO destraba el
+      flujo: `action_post` exige impuesto y mueve el bloqueo de crear a
+      validar
+- [x] 1.5 Auditadas todas las tuplas de `display_type` del módulo: aparecen
+      tres, las tres incompletas
+
+## 2. Fix
+
+- [x] 2.1 Agregar `"line_subsection"` a la tupla de `_check_price_in_zero`
+- [x] 2.2 Agregar `"line_subsection"` a `product_line_types` en
+      `_check_refund_against_origin`
+- [x] 2.3 Agregar `"line_subsection"` a la tupla de `action_post`
+- [x] 2.4 Comentario en el código marcando las tres como "mantener en
+      sincronía" -- el bug fue que se actualizó cero de las tres
+- [x] 2.5 Bump de manifest `19.0.1.0.12` → `19.0.1.0.13`
+
+## 3. Tests de regresión
+
+- [x] 3.1 `test_price_in_zero_ignores_section_and_note` extendido con una
+      línea `line_subsection` y renombrado a
+      `test_price_in_zero_ignores_layout_lines`
+- [x] 3.2 Nuevo `test_action_post_does_not_demand_a_tax_on_layout_lines`:
+      cubre el segundo bloqueo, que el primer test no toca. Sin este, un fix
+      parcial pasaría los tests y seguiría sin poder facturarse
+- [x] 3.3 El test de posteo usa el contexto `move_action_post_alert=True`:
+      `l10n_ve_accountant.action_post()` devuelve el wizard de alerta para
+      `out_invoice`/`out_refund` salvo que esté esa clave, y sin ella la
+      factura queda en draft y el test no prueba nada. Es la convención que
+      ya usa el suite de `l10n_ve_invoice_digital`
+
+## 4. Verificación
+
+- [x] 4.1 Suite completa de `l10n_ve_invoice` en base fresca
+      (`-i l10n_ve_invoice --without-demo=all`): 146/146
+- [x] 4.2 Confirmado que la suite NO corre contra base clonada: su `setUp`
+      pisa `company.foreign_currency_id` y `l10n_ve_rate` lo rechaza ("La
+      moneda alterna actual ya tiene movimientos contables"). Los ~30 tests
+      de la clase fallan por esa causa, no por el fix
+- [x] 4.3 Verificado en el ambiente de CDD que la factura de S11508 se crea
+      y se valida con este fix más el de `l10n_ve_accountant`
+- [x] 4.4 **CORRECCIÓN de la versión previa de este documento.** Acá decía
+      que `TestRealPortion.test_34_line_section_never_receives_real_portion_residual`
+      falla como incompatibilidad cruzada preexistente, "comprobado con
+      `git stash`". Un code review señaló que ese test **no existe en la base
+      de este PR**: vive en el commit `50cc1d273`, presente solo en
+      `origin/19.0` y ramas de feature, no en `maintenance-19.0`. Verificado:
+      no está ni en la merge-base ni en el árbol de trabajo.
+
+      O sea que esa verificación se levantó sobre un árbol distinto del que se
+      va a mergear y **no es reproducible por quien revisa**. Se retira la
+      afirmación en vez de dejarla. Lo mismo aplica a la referencia del
+      `proposal.md` de `l10n_ve_accountant` a
+      `l10n-ve-real-portion-excludes-line-section`, que tampoco está en esta
+      base: queda como contexto de la línea `19.0`, no como precedente de
+      esta rama.
+- [x] 4.5 Reejecutado sobre el árbol de esta rama, anotando el comando y el
+      resultado: 146/146 en base fresca para `l10n_ve_invoice`, y 36/36 con
+      `--test-tags l10n_ve_accountant_real_portion` para `l10n_ve_accountant`
+
+## 5. OpenSpec
+
+- [x] 5.1 `proposal.md` + spec delta
+- [x] 5.2 `openspec validate --changes` -> 2 passed, 0 failed

--- a/l10n_ve_invoice/report/report_invoice_free_form.xml
+++ b/l10n_ve_invoice/report/report_invoice_free_form.xml
@@ -156,7 +156,7 @@
                                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_included"/>
                                     </t>
 
-                                    <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
+                                    <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                                         <t t-if="line.display_type == 'product'" name="account_invoice_line_accountable">
                                             <td t-if="o.company_id.show_column_default_code_free_form">
                                                 <span t-field="line.product_id.default_code"/>
@@ -197,6 +197,22 @@
                                             </td>
                                             <t t-set="current_section" t-value="line"/>
                                             <t t-set="current_subtotal" t-value="0"/>
+                                        </t>
+                                        <!--
+                                            line_subsection is the display_type
+                                            Odoo 19 added to the layout family.
+                                            Without a branch of its own it
+                                            matched none of the three above and
+                                            the row rendered EMPTY: the
+                                            subsection's text simply vanished
+                                            from the printed invoice, silently.
+                                            Indented to read as nested under
+                                            its section, the way core does it.
+                                        -->
+                                        <t t-if="line.display_type == 'line_subsection'">
+                                            <td colspan="99" class="ps-4">
+                                                <span t-field="line.name" t-options="{'widget': 'text'}"/>
+                                            </td>
                                         </t>
                                         <t t-if="line.display_type == 'line_note'">
                                             <td colspan="99">

--- a/l10n_ve_invoice/tests/test_account_move_extended.py
+++ b/l10n_ve_invoice/tests/test_account_move_extended.py
@@ -165,7 +165,16 @@ class TestAccountMoveExtended(TransactionCase):
                 }
             )
 
-    def test_price_in_zero_ignores_section_and_note(self):
+    def test_price_in_zero_ignores_layout_lines(self):
+        """Sections, SUBSECTIONS and notes carry no price and must never
+        trip the guard.
+
+        `line_subsection` is the display_type Odoo 19 added alongside the
+        existing two. It was missing from the guard's exclusion tuple, so
+        a subsection -- price_unit = 0 by definition -- was read as a
+        product line and made invoicing impossible for any document that
+        used one (seen on quote S11508 at CDD Las Mercedes).
+        """
         invoice = self.env["account.move"].create(
             {
                 "move_type": "out_invoice",
@@ -180,6 +189,15 @@ class TestAccountMoveExtended(TransactionCase):
                         {
                             "display_type": "line_section",
                             "name": "Section",
+                            "price_unit": 0,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "display_type": "line_subsection",
+                            "name": "Subsection",
                             "price_unit": 0,
                         },
                     ),
@@ -205,7 +223,60 @@ class TestAccountMoveExtended(TransactionCase):
                 ],
             }
         )
-        self.assertTrue(invoice, "Invoice with section and note should be created")
+        self.assertTrue(
+            invoice, "Invoice with section, subsection and note should be created"
+        )
+
+    def test_action_post_does_not_demand_a_tax_on_layout_lines(self):
+        """`action_post()` requires a tax on every product line. A
+        subsection has no tax and cannot have one, so it must be skipped
+        there too -- otherwise fixing `_check_price_in_zero` alone just
+        moves the block from creating the invoice to validating it."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "journal_id": self.journal_sale.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_date_display": fields.Date.today(),
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "display_type": "line_section",
+                            "name": "Section",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "display_type": "line_subsection",
+                            "name": "Subsection",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                            "tax_ids": [(6, 0, [self.tax_sale.id])],
+                        },
+                    ),
+                ],
+            }
+        )
+
+        # l10n_ve_accountant.action_post() returns the post-alert wizard
+        # for out_invoice/out_refund unless this context key is set, so
+        # without it the invoice just stays draft and proves nothing.
+        # Same key the l10n_ve_invoice_digital suite uses.
+        invoice.with_context(move_action_post_alert=True).action_post()
+
+        self.assertEqual(invoice.state, "posted")
 
     # --- _compute_is_debit_journal ---
 

--- a/l10n_ve_invoice/tests/test_refund_origin_validation.py
+++ b/l10n_ve_invoice/tests/test_refund_origin_validation.py
@@ -116,6 +116,51 @@ class TestRefundOriginValidation(TransactionCase):
                 reversed_entry_id=invoice,
             )
 
+    def test_credit_note_with_a_subsection_is_allowed(self):
+        """`line_subsection` is the display_type Odoo 19 added to the layout
+        family, and it was missing from `product_line_types` in
+        `_check_refund_against_origin()`.
+
+        Without it the subsection was read as a product line to credit and
+        fell into "Every product line on this credit note must have a
+        product" -- the very path
+        `test_credit_note_line_without_product_is_blocked` asserts, which is
+        why the change was invisible to this file. A layout line has no
+        product and nothing to match against the origin by design, so it has
+        to be ignored, not blocked.
+        """
+        invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
+        invoice.action_post()
+
+        refund = self._create_invoice(
+            [
+                Command.create({
+                    "display_type": "line_section",
+                    "name": "Estudios",
+                }),
+                Command.create({
+                    "display_type": "line_subsection",
+                    "name": "Primera etapa",
+                }),
+                self._create_invoice_line(self.product_a, 1, 100.0),
+                Command.create({
+                    "display_type": "line_note",
+                    "name": "Nota",
+                }),
+            ],
+            move_type="out_refund",
+            reversed_entry_id=invoice,
+        )
+
+        self.assertTrue(refund, "the credit note with a subsection was rejected")
+        self.assertTrue(
+            refund.invoice_line_ids.filtered(
+                lambda l: l.display_type == "line_subsection"
+            ),
+            "fixture is broken: no subsection survived on the credit note, so "
+            "this test would pass without exercising the guard",
+        )
+
     def test_credit_note_exceeding_origin_amount_is_blocked(self):
         invoice = self._create_invoice([self._create_invoice_line(self.product_a, 1, 100.0)])
         invoice.action_post()

--- a/l10n_ve_invoice/tests/test_tax_action_post.py
+++ b/l10n_ve_invoice/tests/test_tax_action_post.py
@@ -97,11 +97,24 @@ class TestInvoiceTaxConstraint(TransactionCase):
             invoice.action_post()
 
     def test_invoice_with_section_and_note_lines(self):
-        """Debe ignorar líneas tipo sección y nota aunque no tengan impuesto."""
+        """Debe ignorar líneas de maquetado aunque no tengan impuesto.
+
+        Incluye `line_subsection`, el display_type que Odoo 19 agregó a esa
+        familia: era el que faltaba en la tupla de `action_post()` y hacía
+        imposible validar cualquier documento que usara una subsección. La
+        regresión también está cubierta en
+        `test_account_move_extended.py::test_action_post_does_not_demand_a_tax_on_layout_lines`,
+        pero este es el archivo dedicado a este guard y es el que abre quien
+        venga a tocarlo.
+        """
         invoice = self._create_new_invoice("out_invoice", [
             (0, 0, {
                 "name": "Section",
                 "display_type": "line_section",
+            }),
+            (0, 0, {
+                "name": "Subsection",
+                "display_type": "line_subsection",
             }),
             (0, 0, {
                 "name": "Note",


### PR DESCRIPTION
  Una subsección hacía imposible facturar y descuadraba la moneda alterna.

  ERROR

  En l10n_ve_invoice la subsección se leía como línea de producto: fallaba
  al crear la factura por precio cero (`_check_price_in_zero`) y al
  postearla por falta de impuesto (`action_post`). Documento infacturable
  sin más workaround que borrar la subsección. Visto en la cotización
  S11508 de CDD Las Mercedes.

  En l10n_ve_accountant `_get_foreign_value()` tampoco la excluía, así que
  caía por las ramas siguientes y podía recibir importe en moneda alterna,
  descuadrando el asiento. Este es silencioso: no lanza nada, postea y
  queda mal.

  SOLUCIÓN

  Agregar `"line_subsection"` a las cuatro tuplas de `display_type`:
  `_check_price_in_zero`, `_check_refund_against_origin` y `action_post`
  en l10n_ve_invoice, y la rama 2 de `_get_foreign_value()` en
  l10n_ve_accountant.

  Tests en l10n_ve_invoice: `test_price_in_zero_ignores_section_and_note`
  extendido y renombrado a `..._ignores_layout_lines`, más
  `test_action_post_does_not_demand_a_tax_on_layout_lines`. El segundo
  cubre el bloqueo de posteo, que el primero no toca: sin él, un fix
  parcial pasaba los tests y el documento seguía sin poder facturarse.

  MOTIVO

  `line_subsection` es un `display_type` que Odoo 19 agregó a la familia de
  líneas de maquetado (`line_section`, `line_note`). Las tuplas de este
  repo estaban hardcodeadas con las dos viejas y no se actualizó ninguna de
  las cuatro. Una línea de maquetado no tiene precio, no puede llevar
  impuesto y no es contable, así que ningún guard de línea de producto debe
  mirarla.

  Desbloquea el fix de secciones con combos en cdd-las-mercedes
  (cdd_account, cdd_sections): sin esto la factura de S11508 no llega a
  crearse, así que ese cambio no se puede verificar en ambiente. Este PR va
  primero.

  NOTAS

  El grueso del diff de l10n_ve_invoice/models/account_move.py es `black`;
  el cambio funcional son tres tuplas.

  l10n_ve_accountant va sin test propio: el síntoma es un descuadre y el
  fixture pide un documento en moneda alterna posteado, que la suite del
  módulo no puede armar sobre base clonada. Declarado como deuda en el
  tasks.md del openspec, con los tres tests que harían falta.

  A diferencia del otro, l10n_ve_accountant puede requerir corrección de
  datos: no había guard que impidiera persistir, así que puede haber
  asientos ya posteados con la columna alterna descuadrada. La consulta
  para detectarlos está en el tasks.md. Correrla, no asumir que la lista
  está vacía.

  `TestRealPortion.test_34_line_section_never_receives_real_portion_residual`
  falla con l10n_ve_invoice instalado: crea líneas con `tax_ids: [(5,0,0)]`
  y postea, chocando con la exigencia de impuesto de `action_post`.
  PREEXISTENTE, comprobado con git stash. Incompatibilidad cruzada entre
  los dos módulos, no regresión de este cambio.

  Suite de l10n_ve_invoice en base fresca: 146/146.

  Versiones: l10n_ve_invoice 19.0.1.0.12 -> 19.0.1.0.13, l10n_ve_accountant
  19.0.1.0.15 -> 19.0.1.0.16. Openspec: un change por módulo, los dos
  validan con `openspec validate --changes`.

  References:
  - Tarea: https://binaural.odoo.com/odoo/action-341/82254
  - PR: