### PR TITLE
[FIX] l10n_ve_accountant: corregir error con moneda extranjera vacía

### DIFF
--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -216,6 +216,10 @@ class AccountMoveLine(models.Model):
         """
         usd = self.env.ref("base.USD", raise_if_not_found=False)
         for line in self:
+            if not line.foreign_currency_id:
+                line.foreign_subtotal = 0.0
+                line.foreign_price_total = 0.0
+                continue
             foreign_price_unit_full_precision = line.foreign_price * (
                 1 - (line.discount / 100.0)
             )


### PR DESCRIPTION
## Resumen

- `_compute_foreign_subtotal` llamaba incondicionalmente a `line.foreign_currency_id.round(...)`, sin resguardar el caso en que `foreign_currency_id` está vacío (compañía sin `currency_foreign_id` configurado).
- Esto disparaba `ValueError: Expected singleton: res.currency()` vía `ensure_one()` — un bug de producción real, no solo de test.
- Se agrega el mismo guard que ya existe en `_inverse_foreign_price` (mismo archivo): si no hay `foreign_currency_id`, se fijan `foreign_subtotal`/`foreign_price_total` en `0.0` y se continúa.

## Contexto

Detectado al arreglar tests rotos en el repositorio `countryclub` (`country_sale_subscription_fees`), donde este bug rompía varios tests de generación de deuda/facturación. El mismo fix ya fue aplicado al checkout usado como submódulo dentro de `countryclub`.

## Tarea

https://binaural.odoo.com/odoo/action-341/82191

## Test plan

- [x] Suite completa de `countryclub` (`country_basic_payments`, `country_sale_subscription`, `country_sale_subscription_fees`) en verde tras este fix (812/816 tests, 0 fallos, 0 errores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMUvucvX8v8eSBS5A5Erky