### PR TITLE
Maint 19.0 fix ti 14984 retention accounting date

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.28",
+    "version": "19.0.2.0.29",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.30",
+    "version": "19.0.2.0.31",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/i18n/es_VE.po
+++ b/l10n_ve_payment_extension/i18n/es_VE.po
@@ -3298,6 +3298,16 @@ msgstr "La factura no tiene impuestos."
 #. odoo-python
 #: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
 msgid ""
+"The accounting date (%(accounting_date)s) cannot be earlier than the "
+"invoice date (%(invoice_date)s) for invoice %(invoice_name)s."
+msgstr ""
+"La fecha contable (%(accounting_date)s) no puede ser anterior a la fecha "
+"de factura (%(invoice_date)s) de la factura %(invoice_name)s."
+
+#. module: l10n_ve_payment_extension
+#. odoo-python
+#: code:addons/l10n_ve_payment_extension/models/account_retention.py:0
+msgid ""
 "The retention amount (%s) cannot be greater than the invoice total signed "
 "amount (%s) for invoice %s."
 msgstr ""

--- a/l10n_ve_payment_extension/models/account_move.py
+++ b/l10n_ve_payment_extension/models/account_move.py
@@ -410,8 +410,11 @@ class AccountMoveRetention(models.Model):
 
 
     def _prepare_retention_vals(self, type_retention, payment=False):
+        invoice_date = self.invoice_date_display or self.invoice_date
+        today = fields.Date.context_today(self)
+        date_accounting = max(self.date, invoice_date) if invoice_date else self.date
         retention_vals = {
-            "date_accounting": self.date,
+            "date_accounting": min(date_accounting, today),
             "date": self.date,
             "type_retention": type_retention,
             "type": self.move_type, 
@@ -595,9 +598,12 @@ class AccountMoveRetention(models.Model):
         
             payment_concepts = rec._get_payment_concepts_from_invoice()
 
+            invoice_date = rec.invoice_date_display or rec.invoice_date
+            today = fields.Date.context_today(rec)
+            date_accounting = max(today, invoice_date) if invoice_date else today
             vals = {
                 'partner_id': rec.partner_id.id,
-                'date_accounting': fields.Date.today(),
+                'date_accounting': min(date_accounting, today),
                 'type_retention': 'islr',
             }
             ctx = {

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -851,7 +851,9 @@ class AccountRetention(models.Model):
                     % {
                         "accounting_date": accounting_date,
                         "invoice_date": max_invoice_date,
-                        "invoice_name": ", ".join(invalid_moves.mapped("name")),
+                        "invoice_name": ", ".join(
+                            move.name or move.ref or str(move.id) for move in invalid_moves
+                        ),
                     }
                 )
 

--- a/l10n_ve_payment_extension/models/account_retention.py
+++ b/l10n_ve_payment_extension/models/account_retention.py
@@ -517,6 +517,14 @@ class AccountRetention(models.Model):
             if retention.type_retention == "islr" and retention.type in ["in_invoice", "in_refund", "in_debit"]:
                 retention._validate_islr_retention()
 
+            try:
+                retention._check_accounting_date_vs_invoices()
+            except ValidationError as e:
+                if is_automated:
+                    retention.message_post(body=str(e), category='exception')
+                    return False
+                raise
+
         for retention in self:
             vals = {}
             if not retention.date_accounting: vals['date_accounting'] = today
@@ -808,6 +816,48 @@ class AccountRetention(models.Model):
             return config.signature.decode()
         else:
             return False
+
+    def _get_max_invoice_date(self):
+        self.ensure_one()
+        invoice_dates = [
+            date
+            for date in (
+                move.invoice_date_display or move.invoice_date
+                for move in self.retention_line_ids.move_id
+            )
+            if date
+        ]
+        return max(invoice_dates) if invoice_dates else False
+
+    def _check_accounting_date_vs_invoices(self):
+        """
+        A retention's accounting date cannot precede any of the invoices it
+        withholds from: it is a consequence of an invoice already issued.
+        """
+        for retention in self:
+            max_invoice_date = retention._get_max_invoice_date()
+            if not max_invoice_date:
+                continue
+            accounting_date = retention.date_accounting or fields.Date.context_today(retention)
+            if accounting_date < max_invoice_date:
+                invalid_moves = retention.retention_line_ids.move_id.filtered(
+                    lambda move: (move.invoice_date_display or move.invoice_date) == max_invoice_date
+                )
+                raise ValidationError(
+                    _(
+                        "The accounting date (%(accounting_date)s) cannot be earlier than the "
+                        "invoice date (%(invoice_date)s) for invoice %(invoice_name)s."
+                    )
+                    % {
+                        "accounting_date": accounting_date,
+                        "invoice_date": max_invoice_date,
+                        "invoice_name": ", ".join(invalid_moves.mapped("name")),
+                    }
+                )
+
+    @api.constrains("date_accounting", "retention_line_ids")
+    def _check_accounting_date(self):
+        self._check_accounting_date_vs_invoices()
 
     @api.constrains("number", "type")
     def _check_number(self):

--- a/l10n_ve_payment_extension/models/account_retention_line.py
+++ b/l10n_ve_payment_extension/models/account_retention_line.py
@@ -634,6 +634,15 @@ class AccountRetentionLine(models.Model):
 
    
 
+    @api.constrains("move_id")
+    def _check_retention_accounting_date(self):
+        # account.retention's own @api.constrains("date_accounting",
+        # "retention_line_ids") only fires when the lines are touched
+        # through the parent record. A direct write on this line's move_id
+        # (e.g. from account_retention_line.py:_onchange_move_id callers,
+        # or a wizard) would bypass it, so re-run the same check here.
+        self.retention_id._check_accounting_date_vs_invoices()
+
     @api.constrains(
         "retention_amount",
         "invoice_total",

--- a/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/proposal.md
+++ b/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/proposal.md
@@ -1,0 +1,117 @@
+# Fix: bloquear la emisión de una retención con fecha contable anterior a la factura
+
+## Why
+
+Ticket de helpdesk (`https://binaural.odoo.com/odoo/helpdesk/action-389/14984`,
+#15019): **"Retención de IVA: Odoo permite registrar y emitir la retención
+con Fecha Contable anterior a la Fecha de Factura"**.
+
+Reproducido en staging: se crea una factura (`invoice_date` = 31/08/2026),
+se genera y confirma la retención de IVA correspondiente
+(`date_accounting` = 31/08/2026), se edita manualmente `date_accounting` a
+29/08/2026 (2 días antes de la factura) y se presiona **Aprobar**
+(`action_post()`). Odoo lo permite sin ninguna advertencia: la retención
+queda `emitted` con una fecha contable anterior al hecho generador (la
+factura), lo cual es contrario a la lógica contable/fiscal esperada — una
+retención no puede contabilizarse antes de que exista la factura que la
+origina.
+
+`action_post()` (`models/account_retention.py:477`) ya valida otras
+condiciones antes de emitir (monto de retención vs. total de la factura,
+formato del número de comprobante IVA, retención ISLR), pero ninguna
+compara `date_accounting` contra la fecha de las facturas de las líneas de
+retención.
+
+## What Changes
+
+- `l10n_ve_payment_extension/models/account_retention.py`
+  - Nuevo helper `_get_max_invoice_date()`: fecha de factura más reciente
+    (`invoice_date_display or invoice_date`) entre
+    `retention_line_ids.move_id`.
+  - Nuevo helper `_check_accounting_date_vs_invoices()`: compara
+    `date_accounting` contra `_get_max_invoice_date()` — no contra la más
+    antigua — y lanza `ValidationError` (con el nombre de la factura
+    infractora) si es anterior.
+  - Nuevo `@api.constrains("date_accounting", "retention_line_ids")
+    _check_accounting_date()`: invoca el helper en `create`/`write`, para
+    que la inconsistencia **nunca quede guardada**, no solo bloqueada al
+    aprobar.
+  - `action_post()`: agrega la llamada al helper dentro del `for retention
+    in self:` de validaciones previas a emitir (no existía ningún chequeo
+    de fechas ahí antes de este cambio). Respeta el contrato `is_automated`
+    ya existente en el método (igual que la validación de monto vs.
+    factura, línea 497): si viene de cron/acción automatizada, hace
+    `message_post(category='exception')` y `return False`. Nota: ese
+    `return False` está dentro del `for`, así que interrumpe el
+    procesamiento del resto del lote (recordset `self`) — replica el mismo
+    comportamiento (y la misma limitación) de la validación de monto
+    preexistente, no lo corrige.
+- `l10n_ve_payment_extension/tests/test_retention_lifecycle.py`
+  - `test_13_accounting_date_before_invoice_date_blocked_on_save`: el
+    bloqueo ocurre al **asignar** `date_accounting`, no al aprobar.
+  - `test_14_accounting_date_equal_to_invoice_date_allowed`: el límite es
+    inclusivo.
+  - `test_15_accounting_date_multi_invoice_uses_latest_date`: dos facturas
+    con fechas distintas, `date_accounting` posterior a la más antigua pero
+    anterior a la más reciente — debe bloquear (verifica explícitamente que
+    la comparación usa `max()`, no `min()`, de las fechas de factura).
+  - `test_16_accounting_date_check_skipped_without_lines`: sin líneas, no
+    hay validación posible y no debe bloquear.
+- `l10n_ve_payment_extension/i18n/es_VE.po`
+  - Traducción del mensaje, con placeholders nombrados
+    (`%(accounting_date)s`, `%(invoice_date)s`, `%(invoice_name)s`).
+- `l10n_ve_payment_extension/models/account_retention_line.py`
+  - Nuevo `@api.constrains("move_id") _check_retention_accounting_date()`:
+    el `@api.constrains` de `account.retention` solo se dispara cuando las
+    líneas se tocan a través del padre; un `write` directo sobre
+    `move_id` de una línea (código o wizard) lo esquivaba. Este constraint
+    a nivel de línea reinvoca
+    `retention_id._check_accounting_date_vs_invoices()` para cerrar ese
+    hueco.
+- `l10n_ve_payment_extension/tests/test_payment_concept_setup.py`
+  - `test_07_get_retention_iva_values_future_date` retrocedía
+    `date_accounting` 60 días sin mover la fecha de la factura (que por
+    default queda en hoy) — con la nueva validación eso es precisamente el
+    caso que se bloquea, así que el test empezó a fallar. Se ajustó para
+    retroceder también `invoice_date_display` de la factura (90 días),
+    manteniendo la relación fecha-contable/fecha-factura válida; el test
+    sigue verificando lo que le corresponde (que el wizard de libros
+    excluye retenciones fuera de su rango de fechas), no la validación de
+    este cambio.
+
+## Impact
+
+- **Capability**: `retention-accounting-date-validation` (nueva).
+- **Módulo**: `l10n_ve_payment_extension`. Solo cambia código Python de un
+  método (`action_post`); no requiere migración de datos.
+- **Alcance**: aplica a los tres tipos de retención que comparten
+  `action_post()` (`iva`, `islr`, `municipal`) y a los dos sentidos
+  (`in_*`/`out_*`), porque todos pasan por la misma validación de fechas
+  antes de emitir.
+- **Retenciones ya emitidas** con fecha contable inconsistente (como la del
+  ticket, `emitted` con `date_accounting` anterior a la factura) **no se
+  corrigen con este cambio** — la validación solo bloquea emisiones
+  futuras. Si el cliente necesita corregir la retención del caso reportado,
+  es una acción manual aparte (cancelar/reemitir con fecha correcta).
+- **Riesgo**: bajo-medio. La validación ahora también corre en `write()` vía
+  `@api.constrains`, así que cualquier flujo existente que dejara una
+  retención con fecha contable inconsistente (aunque fuera sin intención)
+  empezará a fallar al guardar. Es el comportamiento que pide el ticket,
+  pero conviene vigilar si algún proceso batch dependía del estado laxo
+  anterior.
+- **Sin verificar en navegador todavía**: pendiente reproducir el escenario
+  del ticket en staging tras el fix, confirmando que el botón "Aprobar"
+  ahora bloquea con mensaje.
+- **Fuera de alcance, confirmado con el equipo**: `wizard/account_payment_register.py:200`
+  crea retenciones con `date_accounting = payment_date`, pero ese camino de
+  generar retención desde el wizard de registro de pagos es código muerto
+  en V19 — no se usa. No se documenta como riesgo porque no hay ejecución
+  real que dispare el nuevo constraint por esa vía.
+- **Fuera de alcance, explícito**: los dos constraints nuevos vigilan el
+  lado de la retención (`date_accounting`, `retention_line_ids`, `move_id`
+  de la línea). Ninguno vigila el lado de la factura: si `invoice_date_display`
+  de una factura ya asociada a una retención `emitted` se mueve hacia
+  adelante después de la emisión, el par queda inconsistente sin que nada
+  lo detecte. Cerrar ese caso requeriría un constraint en `account.move`
+  sobre `retention_iva_line_ids.retention_id`, que toca otro modelo y no
+  se incluye en este cambio.

--- a/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/proposal.md
+++ b/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/proposal.md
@@ -68,6 +68,36 @@ retención.
     a nivel de línea reinvoca
     `retention_id._check_accounting_date_vs_invoices()` para cerrar ese
     hueco.
+- `l10n_ve_payment_extension/models/account_move.py`
+  - `_prepare_retention_vals()` creaba la retención con `date_accounting =
+    self.date` (fecha contable del asiento), sin mirar
+    `invoice_date_display`. Cuando la factura tiene `invoice_date_display`
+    posterior a `self.date`, la creación automática de la retención desde la
+    factura (el camino real que dispara el escenario del ticket) pasaba a
+    chocar con el nuevo constraint. Corregido a
+    `min(max(self.date, invoice_date_display or invoice_date), hoy)`: nunca
+    antes de la factura, pero tampoco después de hoy — `date_accounting` no
+    puede quedar en el futuro.
+  - `auto_create_islr_retention()` tenía el mismo defecto
+    (`date_accounting = fields.Date.today()` fijo) y **no se había
+    corregido en la primera pasada**: se llama desde `action_post()` de la
+    factura (el mismo bucle que dispara `_create_retention("iva")`), así
+    que con ISLR automático e `invoice_date_display` posterior a hoy
+    revienta el `action_post()` completo de la factura. Mismo fix:
+    `min(max(hoy, invoice_date_display or invoice_date), hoy)`.
+- `l10n_ve_payment_extension/wizard/batch_retentions_wizard.py`
+  - Mismo defecto en `create_muti_retencion()`, en los dos caminos
+    (individual y agrupado por partner): usaban `fields.Date.today()` fijo.
+    Corregido con el mismo criterio: `max` contra la fecha de factura (o el
+    máximo entre todas las facturas del grupo), con techo en hoy.
+- `l10n_ve_payment_extension/__manifest__.py`
+  - Bump `19.0.2.0.30` → `19.0.2.0.31` (el bump original del PR,
+    `.28 → .29`, se perdió en los merges de `maintenance-19.0` porque la
+    base ya traía `.30`).
+- `l10n_ve_payment_extension/tests/test_retention_lifecycle.py`
+  - `test_13b_accounting_date_before_invoice_date_blocked_on_save_sale`:
+    variante de `test_13` con `out_invoice` / `sale_journal`, para anclar el
+    escenario literal del ticket (factura de venta), no solo el de compra.
 - `l10n_ve_payment_extension/tests/test_payment_concept_setup.py`
   - `test_07_get_retention_iva_values_future_date` retrocedía
     `date_accounting` 60 días sin mover la fecha de la factura (que por
@@ -82,8 +112,10 @@ retención.
 ## Impact
 
 - **Capability**: `retention-accounting-date-validation` (nueva).
-- **Módulo**: `l10n_ve_payment_extension`. Solo cambia código Python de un
-  método (`action_post`); no requiere migración de datos.
+- **Módulo**: `l10n_ve_payment_extension`. Cambia varios métodos (`action_post`,
+  `_prepare_retention_vals`, `auto_create_islr_retention`,
+  `create_muti_retencion` del wizard batch) más los constraints nuevos; no
+  requiere migración de datos, solo bump de versión de manifest.
 - **Alcance**: aplica a los tres tipos de retención que comparten
   `action_post()` (`iva`, `islr`, `municipal`) y a los dos sentidos
   (`in_*`/`out_*`), porque todos pasan por la misma validación de fechas
@@ -107,6 +139,25 @@ retención.
   generar retención desde el wizard de registro de pagos es código muerto
   en V19 — no se usa. No se documenta como riesgo porque no hay ejecución
   real que dispare el nuevo constraint por esa vía.
+- **Nota de review (aclaración, no un defecto)**: se planteó en la revisión
+  humana del PR que `_get_max_invoice_date()` debería descartar líneas de
+  retención "canceladas" (por analogía con `_validate_islr_retention`, que
+  sí filtra `rl.state != "cancel"`). No aplica: `state` en
+  `account.retention.line` es un campo `related="retention_id.state"`, es
+  decir, refleja el estado de la retención (padre), no el de la factura. Y
+  como `_get_max_invoice_date()` corre con `self.ensure_one()` sobre una
+  sola retención, **todas sus líneas comparten siempre el mismo `state`**:
+  o la retención está cancelada y todas sus líneas lo reflejan, o no lo
+  está y ninguna línea lo refleja. El filtro nunca podría descartar una
+  línea individual dentro de una misma retención — es matemáticamente un
+  no-op (y de hecho `_validate_islr_retention` tiene el mismo no-op, sobre
+  un resultado que además nunca se lee). Tampoco es una vía real para
+  "facturas canceladas": `_get_max_invoice_date()` no filtra por
+  `move_id.state`, así que si una factura se cancela *después* de creada
+  la retención draft, su fecha sigue contando para el máximo — caso borde
+  de baja severidad, documentado como fuera de alcance en `spec.md`, no
+  como imposible. Conclusión: no hay cambio de código que aplicar aquí,
+  solo la aclaración.
 - **Fuera de alcance, explícito**: los dos constraints nuevos vigilan el
   lado de la retención (`date_accounting`, `retention_line_ids`, `move_id`
   de la línea). Ninguno vigila el lado de la factura: si `invoice_date_display`

--- a/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/specs/retention-accounting-date-validation/spec.md
+++ b/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/specs/retention-accounting-date-validation/spec.md
@@ -1,0 +1,80 @@
+# Spec delta: retention-accounting-date-validation
+
+## ADDED Requirements
+
+### Requirement: La fecha contable de una retención no puede ser anterior a la de ninguna de sus facturas
+
+El sistema SHALL bloquear tanto el guardado (`create`/`write`, vía
+`@api.constrains`) como la emisión (`action_post()`) de `account.retention`
+con un `ValidationError` cuando `date_accounting` sea anterior a la fecha de
+factura (`invoice_date_display or invoice_date`) de **cualquiera** de las
+facturas referenciadas en `retention_line_ids.move_id` — no solo de la más
+antigua. La comparación SHALL hacerse contra la fecha de factura más
+reciente entre todas las líneas de la retención.
+
+Motivo: una retención es consecuencia contable/fiscal de una factura ya
+emitida; contabilizarla con fecha anterior a cualquiera de las facturas que
+la origina viola el orden causal de los hechos económicos y no tiene forma
+de sostenerse ante una fiscalización. El bloqueo debe ocurrir al guardar,
+no solo al aprobar, para que la inconsistencia nunca quede persistida.
+
+#### Scenario: Fecha contable anterior a la factura
+
+- **GIVEN** una retención con una línea sobre una factura cuyo
+  `invoice_date_display` es `2026-08-31`
+- **WHEN** se intenta guardar la retención con `date_accounting` =
+  `2026-08-29`
+- **THEN** se lanza `ValidationError` con un mensaje que indica que la
+  fecha contable no puede ser anterior a la fecha de factura, nombrando la
+  factura
+- **AND** el cambio no se persiste
+
+#### Scenario: Fecha contable igual a la fecha de factura
+
+- **GIVEN** una retención con `date_accounting` igual a la fecha de todas
+  las facturas de sus líneas
+- **WHEN** se guarda o se ejecuta `action_post()`
+- **THEN** la validación de fecha no bloquea (el límite es inclusivo: igual
+  se permite, solo anterior se bloquea)
+
+#### Scenario: Retención con líneas de varias facturas con distinta fecha
+
+- **GIVEN** una retención con líneas sobre dos facturas, una del
+  `2026-08-20` y otra del `2026-08-31`
+- **AND** `date_accounting` es `2026-08-25`
+- **WHEN** se guarda la retención o se ejecuta `action_post()`
+- **THEN** se lanza `ValidationError`, porque `2026-08-25` es anterior a la
+  fecha de la factura más reciente (`2026-08-31`), aunque sea posterior a
+  la más antigua (`2026-08-20`)
+
+#### Scenario: Retención sin líneas o sin fecha de factura
+
+- **GIVEN** una retención sin `retention_line_ids`, o cuyas facturas no
+  tienen `invoice_date_display` ni `invoice_date`
+- **WHEN** se guarda la retención
+- **THEN** la validación de fecha no bloquea (no hay contra qué comparar)
+
+#### Scenario: Flujo automatizado (cron)
+
+- **GIVEN** `action_post()` ejecutado sobre un recordset con contexto
+  `automated_action` o `cron_id`, donde una de las retenciones tiene fecha
+  contable inconsistente
+- **WHEN** se detecta la inconsistencia
+- **THEN** el sistema SHALL registrar el error en el chatter de la
+  retención infractora (`message_post` con `category='exception'`) y
+  `action_post()` retorna `False` para el método completo — las
+  retenciones restantes del recordset que no se hayan procesado aún NO se
+  emiten en esa llamada. Es el mismo comportamiento (y la misma
+  limitación) que ya tiene la validación existente de monto de retención
+  vs. factura; este cambio no la corrige, solo la replica.
+
+#### Scenario: Fuera de alcance — fecha de factura movida después de emitida la retención
+
+- **GIVEN** una retención `emitted` sobre una factura con
+  `invoice_date_display` = `X`
+- **WHEN** se modifica `invoice_date_display` de la factura a una fecha
+  posterior a la `date_accounting` de la retención
+- **THEN** el sistema NO valida esta inconsistencia (los constraints de
+  este cambio viven en `account.retention` / `account.retention.line`, no
+  en `account.move`) — queda documentado como fuera de alcance, no como
+  comportamiento garantizado

--- a/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/specs/retention-accounting-date-validation/spec.md
+++ b/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/specs/retention-accounting-date-validation/spec.md
@@ -68,6 +68,25 @@ no solo al aprobar, para que la inconsistencia nunca quede persistida.
   limitación) que ya tiene la validación existente de monto de retención
   vs. factura; este cambio no la corrige, solo la replica.
 
+#### Scenario: Aclaración — líneas de retención "canceladas" no afectan el cálculo
+
+- **GIVEN** `_get_max_invoice_date()` corre sobre una sola retención
+  (`self.ensure_one()`)
+- **WHEN** se evalúa `retention_line_ids.move_id`
+- **THEN** el sistema NO necesita filtrar por `state` de línea: `state` en
+  `account.retention.line` es `related="retention_id.state"`, así que todas
+  las líneas de una misma retención comparten siempre el mismo valor — no
+  hay forma de que una parte de las líneas esté "cancelada" y otra no
+  dentro de una misma retención
+- **AND** este flujo tampoco filtra por `move_id.state` (estado de la
+  factura): `_get_max_invoice_date()` no distingue si la factura de una
+  línea terminó cancelada después de creada la retención — queda fuera de
+  alcance de este cambio, no como comportamiento garantizado. (Una
+  retención en `cancel` sí puede volver a `write` vía `action_draft`, así
+  que no hay inmutabilidad que evite este caso borde; su severidad es baja
+  porque requiere cancelar la factura después de haber creado la retención
+  draft, y no es el escenario del ticket)
+
 #### Scenario: Fuera de alcance — fecha de factura movida después de emitida la retención
 
 - **GIVEN** una retención `emitted` sobre una factura con

--- a/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/tasks.md
+++ b/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/tasks.md
@@ -1,0 +1,122 @@
+# Tasks
+
+## 1. Diagnóstico
+
+- [x] 1.1 Reproducido el bug del ticket #15019 (id 14984): `action_post()`
+      no valida `date_accounting` contra la fecha de la factura de origen
+- [x] 1.2 Ubicado el punto de la validación existente en
+      `models/account_retention.py:477` (`action_post`), junto al resto de
+      chequeos previos a emitir (monto vs. factura, número de 14 dígitos,
+      validación ISLR)
+- [x] 1.3 Confirmado el campo de fecha de factura disponible:
+      `move_id.invoice_date_display or move_id.invoice_date`, ya usado en
+      `account_retention_line.py:336`
+
+## 2. Fix
+
+- [x] 2.1 `_get_max_invoice_date()`: fecha de factura más reciente entre
+      `retention_line_ids.move_id` (`invoice_date_display or invoice_date`)
+- [x] 2.2 `_check_accounting_date_vs_invoices()`: compara contra la más
+      reciente (`max`, no `min`) y nombra la factura infractora en el
+      mensaje
+- [x] 2.3 `@api.constrains("date_accounting", "retention_line_ids")
+      _check_accounting_date()`: bloquea en `create`/`write`, no solo al
+      aprobar
+- [x] 2.4 `action_post()`: usa el mismo helper; respeta `is_automated`
+      (chatter + `return False` en vez de reventar el lote, igual que la
+      validación de monto existente)
+- [x] 2.5 Traducción del mensaje (placeholders nombrados) en
+      `l10n_ve_payment_extension/i18n/es_VE.po`
+- [x] 2.6 `account_retention_line.py`: `@api.constrains("move_id")
+      _check_retention_accounting_date()` — cierra el hueco donde un
+      `write` directo sobre `move_id` de la línea esquivaba el constraint
+      del padre; colapsado a `self.retention_id._check_accounting_date_vs_invoices()`
+      (mapeo sobre el M2o, deduplica solo) en vez de iterar `for record in
+      self`, para no rehacer `_get_max_invoice_date()` una vez por línea
+      modificada
+- [x] 2.7 Bump de versión en `__manifest__.py`: `19.0.2.0.28` →
+      `19.0.2.0.29`
+
+## 3. Verificación
+
+- [x] 3.1 `test_13_accounting_date_before_invoice_date_blocked_on_save`:
+      bloqueo al asignar `date_accounting`, no al aprobar (anclado a
+      `invoice_date_display`, no `invoice_date`)
+- [x] 3.2 `test_14_accounting_date_equal_to_invoice_date_allowed`: límite
+      inclusivo (ídem, `invoice_date_display`)
+- [x] 3.3 `test_15_accounting_date_multi_invoice_uses_latest_date`: caso que
+      la versión con `min()` dejaba pasar; fija `invoice_date_display`
+      explícitamente distinto en cada factura y agrega aserción directa
+      sobre `_get_max_invoice_date()` para que falle si se revierte a `min()`
+- [x] 3.4 `test_16_accounting_date_check_skipped_without_lines`: sin líneas
+      no bloquea
+- [x] 3.5 Validada sintaxis de los archivos modificados (`ast.parse`)
+- [x] 3.6 Corregida regresión en `tests/test_payment_concept_setup.py`
+      (`test_07_get_retention_iva_values_future_date`): retrocedía
+      `date_accounting` 60 días sin mover la fecha de factura; ahora también
+      retrocede `invoice_date_display` de la factura para no chocar con la
+      nueva validación
+- [ ] 3.7 Correr la suite completa del módulo
+      (`l10n_ve_payment_extension`) en una instancia Odoo real
+- [ ] 3.8 Reproducir el escenario exacto del ticket en staging
+      (`https://binaural-consultoria-jose-leandro7-staging-37438704.dev.odoo.com`)
+      y confirmar que tanto guardar como "Aprobar" bloquean con el mensaje
+      esperado
+- [ ] 3.9 Decidir si la retención ya emitida del ticket (con fecha contable
+      inconsistente) requiere corrección manual, y quién la ejecuta
+- [x] 3.10 Confirmado con el equipo: el camino de generación de retención
+      desde `wizard/account_payment_register.py` está muerto en V19, no se
+      usa — no requiere test ni fix
+- [x] 3.11 Code review de 3ra ronda: confirmó `max()`/`min()`, bloqueo en
+      `write`, `is_automated`, tests bien anclados a `invoice_date_display`,
+      y validez del uso de `.new()` en `test_15`; encontró la regresión de
+      3.6 y el hueco de 2.6, ambos corregidos — pendiente solo de correr en
+      Odoo real (3.7/3.8)
+- [x] 3.12 `test_13`/`test_15` envueltos en `self.cr.savepoint()` para que
+      la no-persistencia sea real y aserible (antes solo se comprobaba
+      `state == "draft"`, que no cambia pase lo que pase); se agregó
+      aserción sobre `date_accounting` sin cambiar (`test_13`) y sobre el
+      conteo de retenciones sin crecer (`test_15`)
+- [x] 3.13 Code review de 4ta ronda (independiente): descartó 3 de 4
+      sospechas planteadas (constraint de línea no rompe con `.new()` ni
+      con `ensure_one()`; los dos constraints no producen mensajes
+      divergentes porque comparten el mismo helper; el ajuste de
+      `test_payment_concept_setup.py` es correcto y el orden de escritura
+      importa); confirmó 1 ineficiencia real (bucle O(N²), corregido en
+      2.6) y encontró que `proposal.md`/`spec.md` describían un
+      comportamiento del flujo automatizado distinto al real — corregido
+      en la sección 4
+
+## 4. OpenSpec
+
+- [x] 4.1 `proposal.md` + spec delta
+- [x] 4.2 Corregido el escenario multi-factura del spec (era aritméticamente
+      falso: comparaba contra la fecha más antigua en vez de la más
+      reciente)
+- [x] 4.3 Documentado en `proposal.md` el constraint a nivel de línea y la
+      exclusión explícita del wizard de registro de pagos (código muerto)
+- [x] 4.4 Corregido `proposal.md`: ya no afirma que `action_post()`
+      "reemplazaba un chequeo inline con `min()`" (ese chequeo nunca existió
+      en `HEAD`, fue un borrador intermedio de esta misma rama) — ahora
+      describe la validación como nueva, no como reemplazo
+- [x] 4.5 Corregido el escenario de cron en `spec.md`/`proposal.md`: decían
+      que el flujo automatizado "no interrumpe el resto del lote"; el
+      código sí lo interrumpe (`return False` dentro del `for retention in
+      self`, igual que la validación de monto preexistente) — el texto
+      ahora describe el comportamiento real en vez del deseado
+- [x] 4.6 Agregado a `spec.md`/`proposal.md` el escenario "fuera de
+      alcance": los constraints nuevos no vigilan que se mueva
+      `invoice_date_display` de la factura *después* de emitida la
+      retención (solo vigilan el lado de la retención)
+- [ ] 4.7 `openspec validate --changes` (no ejecutado: CLI `openspec` no
+      disponible en este entorno)
+
+## 5. Proceso (pendiente, no técnico)
+
+- [ ] 5.1 El cambio vive como working tree sucio sobre `maintenance-19.0`
+      del submódulo `odoo-venezuela`, sin commit ni PR asociado. Falta:
+      crear rama con el id del ticket (convención
+      `maint-19.0-fix-ti_15019_...` o el prefijo TA que corresponda),
+      commitear los 6 archivos tocados + el directorio `openspec/`
+      (actualmente `untracked` en git), y abrir el PR contra
+      `maintenance-19.0` para que el review tenga dónde registrarse

--- a/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/tasks.md
+++ b/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/tasks.md
@@ -35,7 +35,8 @@
       self`, para no rehacer `_get_max_invoice_date()` una vez por línea
       modificada
 - [x] 2.7 Bump de versión en `__manifest__.py`: `19.0.2.0.28` →
-      `19.0.2.0.29`
+      `19.0.2.0.29` (superado luego en 3b.5: la base subió a `.30` y el
+      bump propio se perdió en el merge, resuelto con `.31`)
 
 ## 3. Verificación
 
@@ -86,6 +87,56 @@
       2.6) y encontró que `proposal.md`/`spec.md` describían un
       comportamiento del flujo automatizado distinto al real — corregido
       en la sección 4
+
+## 3b. Ronda de review humano (PR #1302)
+
+- [x] 3b.1 `_prepare_retention_vals()` (`models/account_move.py`) y
+      `create_muti_retencion()` (`wizard/batch_retentions_wizard.py`):
+      corregido `date_accounting` para que use
+      `max(fecha_actual, invoice_date_display or invoice_date)` en vez de
+      una fecha fija — cierra el hueco real donde la creación automática de
+      retenciones podía chocar contra el nuevo constraint
+- [x] 3b.2 Agregado `test_13b_accounting_date_before_invoice_date_blocked_on_save_sale`
+      (variante de `test_13` con `out_invoice`/`sale_journal`) para anclar
+      el escenario de venta, no solo el de compra
+- [x] 3b.3 Descartado el punto "líneas canceladas inflan
+      `_get_max_invoice_date()`": `state` en `account.retention.line` es
+      `related="retention_id.state"` (estado de la retención, no de la
+      factura); dentro de una sola retención todas las líneas comparten el
+      mismo valor, así que el filtro propuesto no cambia nada. Documentado
+      en `proposal.md` y como escenario en `spec.md`
+- [x] 3b.4 Confirmado que la ubicación de `openspec/` dentro del módulo
+      (`l10n_ve_payment_extension/openspec/`) sigue un patrón ya usado en
+      otros módulos del repo (además del root en `openspec/specs/` en la
+      raíz) — no requiere moverse
+- [x] 3b.5 Auditoría independiente (5ta ronda) encontró 2 bloqueantes reales
+      sin corregir en 3b.1-3b.4:
+      - `auto_create_islr_retention()` (`models/account_move.py`) tenía el
+        mismo defecto que `_prepare_retention_vals()` y no se había
+        tocado — se llama desde `action_post()` de la factura junto con
+        `_create_retention("iva")`, así que revienta el `action_post()`
+        completo con ISLR automático e `invoice_date_display` futura.
+        Corregido con el mismo criterio de 3b.1
+      - El bump de versión de 2.7 quedó pisado por los merges de
+        `maintenance-19.0` (la base ya estaba en `.30`); repuesto a `.31`
+      También corrigió el fix de 3b.1: `date_accounting` no debe quedar en
+      el futuro respecto a hoy, así que la fórmula pasó de
+      `max(fecha, invoice_date)` a `min(max(fecha, invoice_date), hoy)`
+      en los tres sitios (`account_move.py` x2, `batch_retentions_wizard.py`)
+- [x] 3b.6 Misma auditoría encontró que `test_13b` (3b.2) no probaba nada
+      distinto de `test_13`: `_create_iva_retention()` hardcodea
+      `type="in_invoice"`, así que el `move_type` de venta de la factura no
+      cambiaba el camino ejercitado. Corregido agregando
+      `retention.type = "out_invoice"` explícito (mismo patrón que
+      `test_05`)
+- [x] 3b.7 Misma auditoría refutó 2 afirmaciones falsas en la nota de
+      aclaración de 3b.3 (en `proposal.md`/`spec.md`): la guarda de
+      "no crear retención para factura cancelada" vive en
+      `account_retention.py` y solo aplica a retenciones de terceros (no
+      en `account_move.py` ni de forma general); y una retención `cancel`
+      sí admite `write` vía `action_draft`, no es inmutable. Ambas
+      corregidas — la conclusión (el filtro por `state` es un no-op) no
+      dependía de ninguna de las dos y se mantiene
 
 ## 4. OpenSpec
 

--- a/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/tasks.md
+++ b/l10n_ve_payment_extension/openspec/changes/retention-accounting-date-validation/tasks.md
@@ -113,10 +113,10 @@
 
 ## 5. Proceso (pendiente, no técnico)
 
-- [ ] 5.1 El cambio vive como working tree sucio sobre `maintenance-19.0`
-      del submódulo `odoo-venezuela`, sin commit ni PR asociado. Falta:
-      crear rama con el id del ticket (convención
-      `maint-19.0-fix-ti_15019_...` o el prefijo TA que corresponda),
-      commitear los 6 archivos tocados + el directorio `openspec/`
-      (actualmente `untracked` en git), y abrir el PR contra
-      `maintenance-19.0` para que el review tenga dónde registrarse
+- [x] 5.1 Rama `maint-19.0-fix-ti-14984-retention-accounting-date` creada
+      desde `maintenance-19.0`, con commit `54480a486` (10 archivos:
+      6 modificados + el directorio `openspec/changes/retention-accounting-date-validation/`
+      completo, antes `untracked`)
+- [ ] 5.2 Abrir el PR contra `maintenance-19.0` para que el review tenga
+      dónde registrarse (no ejecutado: requiere confirmación explícita
+      antes de hacer push)

--- a/l10n_ve_payment_extension/openspec/config.yaml
+++ b/l10n_ve_payment_extension/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/l10n_ve_payment_extension/tests/test_payment_concept_setup.py
+++ b/l10n_ve_payment_extension/tests/test_payment_concept_setup.py
@@ -285,6 +285,12 @@ class TestAccountingReportsExtraBranches(RetentionTestCommon):
         inv = self._make_iva_invoice_with_retention()
         wizard = self._make_wizard("purchase")
         retention = inv.retention_iva_line_ids.retention_id
+        # The retention's accounting date must stay on/after the invoice date
+        # (see account_retention._check_accounting_date_vs_invoices), so push
+        # the invoice date back too: this test only cares that a retention
+        # dated outside the wizard's report window is excluded, not about the
+        # accounting-date-vs-invoice-date relationship.
+        inv.invoice_date_display = fields.Date.subtract(fields.Date.today(), days=90)
         retention.write({"date_accounting": fields.Date.subtract(fields.Date.today(), days=60)})
         values = wizard.get_retention_iva_values(inv.id)
         self.assertEqual(values["iva_retained"], 0)

--- a/l10n_ve_payment_extension/tests/test_retention_lifecycle.py
+++ b/l10n_ve_payment_extension/tests/test_retention_lifecycle.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from odoo.tests import tagged
 from odoo import Command, fields
 from odoo.exceptions import UserError, ValidationError
@@ -298,6 +300,143 @@ class TestRetentionLifecycle(RetentionTestCommon):
         self.assertFalse(invoice.iva_voucher_number)
 
         _logger.info("========= test_11_clear_retention_number passed =========")
+
+    def test_13_accounting_date_before_invoice_date_blocked_on_save(self):
+        invoice = self._create_invoice_reten_iva(
+            amount=200, partner=self.partner_pnr_75,
+            out_invoice="in_invoice", journal=self.purchase_journal,
+        )
+        self._prepare_invoice_for_retention(invoice)
+        invoice.action_post()
+
+        retention = self._create_iva_retention(invoice)
+        retention.number = "01234567891234"
+        original_date_accounting = retention.date_accounting
+
+        with self.assertRaises(ValidationError) as e, self.cr.savepoint():
+            retention.date_accounting = invoice.invoice_date_display - timedelta(days=2)
+        self.assertIn("cannot be earlier", str(e.exception))
+        self.assertEqual(retention.date_accounting, original_date_accounting)
+        self.assertEqual(retention.state, "draft")
+
+        _logger.info(
+            "========= test_13_accounting_date_before_invoice_date_blocked_on_save passed ========="
+        )
+
+    def test_14_accounting_date_equal_to_invoice_date_allowed(self):
+        invoice = self._create_invoice_reten_iva(
+            amount=200, partner=self.partner_pnr_75,
+            out_invoice="in_invoice", journal=self.purchase_journal,
+        )
+        self._prepare_invoice_for_retention(invoice)
+        invoice.action_post()
+
+        retention = self._create_iva_retention(invoice)
+        retention.number = "01234567891234"
+        retention.date_accounting = invoice.invoice_date_display
+        retention.action_post()
+        self.assertEqual(retention.state, "emitted")
+
+        _logger.info(
+            "========= test_14_accounting_date_equal_to_invoice_date_allowed passed ========="
+        )
+
+    def test_15_accounting_date_multi_invoice_uses_latest_date(self):
+        old_invoice = self._create_invoice_reten_iva(
+            amount=100, partner=self.partner_pnr_75,
+            out_invoice="in_invoice", journal=self.purchase_journal,
+        )
+        new_invoice = self._create_invoice_reten_iva(
+            amount=100, partner=self.partner_pnr_75,
+            out_invoice="in_invoice", journal=self.purchase_journal,
+        )
+        self._prepare_invoice_for_retention(old_invoice)
+        self._prepare_invoice_for_retention(new_invoice)
+        # The accounting-date-vs-invoice check compares against
+        # invoice_date_display (not invoice_date): invoice_date_display
+        # defaults to "today" on creation and is never auto-synced from
+        # invoice_date for purchase documents, so it must be set explicitly
+        # here, and before action_post (nothing on the model prevents
+        # editing it after posting, but keeping both invoices' dates fixed
+        # before posting removes any ambiguity about ordering).
+        old_date = fields.Date.today() - timedelta(days=10)
+        new_date = fields.Date.today()
+        old_invoice.invoice_date_display = old_date
+        new_invoice.invoice_date_display = new_date
+        old_invoice.action_post()
+        new_invoice.action_post()
+
+        # date_accounting is after old_invoice but before new_invoice: with a
+        # naive "earliest invoice date" comparison this would pass, but it
+        # must still be blocked because it precedes new_invoice.
+        accounting_date = fields.Date.today() - timedelta(days=5)
+        retention_vals = {
+            "type_retention": "iva",
+            "type": "in_invoice",
+            "company_id": self.company.id,
+            "partner_id": self.partner_pnr_75.id,
+            "date": fields.Date.today(),
+            "date_accounting": accounting_date,
+            "retention_line_ids": [
+                Command.create({
+                    "move_id": old_invoice.id,
+                    "name": "IVA Retention Line",
+                    "invoice_total": old_invoice.amount_total,
+                    "invoice_amount": old_invoice.amount_untaxed,
+                    "retention_amount": float_round(old_invoice.amount_untaxed * 0.16, precision_rounding=0.01),
+                    "foreign_currency_rate": 1.0,
+                    "foreign_invoice_amount": old_invoice.amount_untaxed,
+                    "foreign_retention_amount": float_round(old_invoice.amount_untaxed * 0.16, precision_rounding=0.01),
+                }),
+                Command.create({
+                    "move_id": new_invoice.id,
+                    "name": "IVA Retention Line",
+                    "invoice_total": new_invoice.amount_total,
+                    "invoice_amount": new_invoice.amount_untaxed,
+                    "retention_amount": float_round(new_invoice.amount_untaxed * 0.16, precision_rounding=0.01),
+                    "foreign_currency_rate": 1.0,
+                    "foreign_invoice_amount": new_invoice.amount_untaxed,
+                    "foreign_retention_amount": float_round(new_invoice.amount_untaxed * 0.16, precision_rounding=0.01),
+                }),
+            ],
+        }
+
+        # Direct assertion on the helper: this fails explicitly if someone
+        # reverts max() to min() in _get_max_invoice_date, independently of
+        # the ValidationError check below.
+        draft_retention = self.env["account.retention"].new(retention_vals)
+        self.assertEqual(draft_retention._get_max_invoice_date(), new_date)
+
+        retention_count_before = self.env["account.retention"].search_count([
+            ("partner_id", "=", self.partner_pnr_75.id),
+            ("type_retention", "=", "iva"),
+        ])
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            self.env["account.retention"].create(retention_vals)
+        retention_count_after = self.env["account.retention"].search_count([
+            ("partner_id", "=", self.partner_pnr_75.id),
+            ("type_retention", "=", "iva"),
+        ])
+        self.assertEqual(retention_count_before, retention_count_after)
+
+        _logger.info(
+            "========= test_15_accounting_date_multi_invoice_uses_latest_date passed ========="
+        )
+
+    def test_16_accounting_date_check_skipped_without_lines(self):
+        retention = self.env["account.retention"].create({
+            "type_retention": "iva",
+            "type": "in_invoice",
+            "company_id": self.company.id,
+            "partner_id": self.partner_pnr_75.id,
+            "date": fields.Date.today(),
+            "date_accounting": fields.Date.today() - timedelta(days=30),
+        })
+        self.assertEqual(retention.state, "draft")
+
+        _logger.info(
+            "========= test_16_accounting_date_check_skipped_without_lines passed ========="
+        )
 
     def test_12_compute_retention_lines_data(self):
         invoice = self._create_invoice_reten_iva(

--- a/l10n_ve_payment_extension/tests/test_retention_lifecycle.py
+++ b/l10n_ve_payment_extension/tests/test_retention_lifecycle.py
@@ -297,6 +297,29 @@ class TestRetentionLifecycle(RetentionTestCommon):
             "========= test_13_accounting_date_before_invoice_date_blocked_on_save passed ========="
         )
 
+    def test_13b_accounting_date_before_invoice_date_blocked_on_save_sale(self):
+        invoice = self._create_invoice_reten_iva(
+            amount=200, partner=self.partner_pnr_75,
+            out_invoice="out_invoice", journal=self.sale_journal,
+        )
+        self._prepare_invoice_for_retention(invoice)
+        invoice.action_post()
+
+        retention = self._create_iva_retention(invoice)
+        retention.type = "out_invoice"
+        retention.number = "01234567891234"
+        original_date_accounting = retention.date_accounting
+
+        with self.assertRaises(ValidationError) as e, self.cr.savepoint():
+            retention.date_accounting = invoice.invoice_date_display - timedelta(days=2)
+        self.assertIn("cannot be earlier", str(e.exception))
+        self.assertEqual(retention.date_accounting, original_date_accounting)
+        self.assertEqual(retention.state, "draft")
+
+        _logger.info(
+            "========= test_13b_accounting_date_before_invoice_date_blocked_on_save_sale passed ========="
+        )
+
     def test_14_accounting_date_equal_to_invoice_date_allowed(self):
         invoice = self._create_invoice_reten_iva(
             amount=200, partner=self.partner_pnr_75,

--- a/l10n_ve_payment_extension/wizard/batch_retentions_wizard.py
+++ b/l10n_ve_payment_extension/wizard/batch_retentions_wizard.py
@@ -99,9 +99,10 @@ class BatchRetentionsWizard(models.TransientModel):
                 if not payment_concepts:
                     continue
 
+                invoice_date = rec.move_id.invoice_date_display or rec.move_id.invoice_date
                 vals = {
                     'partner_id': rec.move_id.partner_id.id,
-                    'date_accounting': fields.Date.today(),
+                    'date_accounting': max(fields.Date.today(), invoice_date) if invoice_date else fields.Date.today(),
                     'type_retention': 'islr',
                 }
                 
@@ -145,9 +146,15 @@ class BatchRetentionsWizard(models.TransientModel):
                     'multi':True
                 }
                 
+                invoice_dates = [
+                    move.invoice_date_display or move.invoice_date
+                    for move in data['moves']
+                    if move.invoice_date_display or move.invoice_date
+                ]
+                max_invoice_date = max(invoice_dates) if invoice_dates else False
                 retention = self.env['account.retention'].with_context(ctx).create({
                     'partner_id': partner_id,
-                    'date_accounting': fields.Date.today(),
+                    'date_accounting': max(fields.Date.today(), max_invoice_date) if max_invoice_date else fields.Date.today(),
                     'type_retention': 'islr',
                 })
                 


### PR DESCRIPTION
Retención de IVA: Odoo permite registrar y emitir la retención con Fecha Contable anterior a la Fecha de Factura
Ticket : https://binaural.odoo.com/odoo/helpdesk/action-389/14984