### PR TITLE
[FIX] Solución definitiva de traducción de tasas

### DIFF
--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -827,9 +827,13 @@ msgstr "Es Compra Internacional"
 #. module: l10n_ve_accountant
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_bank_statement_line__invoice_date_display
 #: model:ir.model.fields,field_description:l10n_ve_accountant.field_account_move__invoice_date_display
+msgid "Rate date"
+msgstr "Fecha de tasa"
+
+#. module: l10n_ve_accountant
 #: model_terms:ir.ui.view,arch_db:l10n_ve_accountant.l10n_ve_accountant_view_account_invoice_filter
-msgid "Date of Invoice"
-msgstr "Fecha de factura"
+msgid "Invoice Date"
+msgstr "Fecha de Factura"
 
 #. module: l10n_ve_accountant
 #. odoo-python
@@ -1742,7 +1746,7 @@ msgstr "Total sin impuestos BS"
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_payment_tree
 msgid "Bill Date"
-msgstr "Fecha de tasa"
+msgstr "Fecha de factura"
 
 #. module: l10n_ve_accountant
 #. odoo-python

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -19,7 +19,7 @@ class AccountMove(models.Model):
     _inherit = "account.move"
     
     invoice_date = fields.Date(copy=True)
-    invoice_date_display = fields.Date(string="Invoice Date", default=fields.Date.context_today, copy=True)
+    invoice_date_display = fields.Date(string="Rate date", default=fields.Date.context_today, copy=True)
     is_purchase_international = fields.Boolean(related="journal_id.is_purchase_international")
 
     @api.depends('invoice_date_display')

--- a/l10n_ve_invoice/i18n/es_VE.po
+++ b/l10n_ve_invoice/i18n/es_VE.po
@@ -452,12 +452,6 @@ msgid "Invoice Date"
 msgstr "Fecha de factura"
 
 #. module: l10n_ve_invoice
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__invoice_date
-#: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__invoice_date
-msgid "Rate Date"
-msgstr "Fecha de tasa"
-
-#. module: l10n_ve_invoice
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_bank_statement_line__is_contingency
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_journal__is_contingency
 #: model:ir.model.fields,field_description:l10n_ve_invoice.field_account_move__is_contingency
@@ -818,3 +812,15 @@ msgstr ""
 "El monto acreditado para el producto '%(product)s' (%(amount)s, "
 "incluyendo %(already)s ya acreditado por otras notas de crédito) supera "
 "el monto facturado en el documento original '%(origin)s' (%(max)s)."
+
+#. module: l10n_ve_invoice
+#. odoo-python
+#: code:addons/l10n_ve_invoice/models/account_move.py:0
+msgid ""
+"The total credited amount on this credit note (%(amount)s, including "
+"%(already)s already credited by other credit notes) exceeds the amount "
+"invoiced on the original document '%(origin)s' (%(max)s)."
+msgstr ""
+"El monto total acreditado en esta nota de crédito (%(amount)s, incluyendo "
+"%(already)s ya acreditado por otras notas de crédito) supera el monto "
+"facturado en el documento original '%(origin)s' (%(max)s)."


### PR DESCRIPTION
## Solución definitiva de traducción de tasas

Tener dos módulos tocando el mismo campo `invoice_date` en contextos distintos (facturas de cliente en `l10n_ve_invoice`, facturas de proveedor/campo `invoice_date_display` en `l10n_ve_accountant`) complicaba el trabajo de traducción: ambos terminaban compartiendo el mismo texto fuente ("Invoice Date"/"Rate Date"), así que traducir uno correctamente rompía al otro. Cada intento de arreglar la etiqueta en un lado reventaba la del lado contrario.

Para resolverlo de raíz se tuvo que **eliminar y cambiar traducciones existentes**, y sobre todo: **cambiar el string del Python** del campo `invoice_date_display` (de `"Invoice Date"` a `"Rate date"`), para que deje de compartir texto fuente con `invoice_date` y cada uno tenga su propia entrada de traducción, aislada, en el `.po`.

Con textos fuente únicos por campo, además se evitan los warnings de módulos de traducción duplicados/pisados que aparecían al actualizar ambos módulos.

### Cambios

- `l10n_ve_accountant`: `invoice_date_display` pasa a `string="Rate date"`; se agrega su traducción aislada (`"Rate date"` → `"Fecha de tasa"`) separada de la del filtro de búsqueda (`"Invoice Date"` → `"Fecha de Factura"`).
- `l10n_ve_invoice`: se elimina la traducción `"Rate Date"` → `"Fecha de tasa"` de `invoice_date`; ese campo vuelve a su significado nativo, `"Fecha de Factura"`, tanto en cliente como en proveedor.

### Resultado

- `invoice_date` (cliente y proveedor): siempre **"Fecha de Factura"** (nativo).
- `invoice_date_display`: siempre **"Fecha de tasa"**, sin afectar la traducción de `invoice_date`.

References:
- Ticket: https://binaural.odoo.com/odoo/all-tickets/14747