### PR TITLE
19.0_feat-ta_79483 Block referencia interna (limpio, sin 79675)

### DIFF
--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -17,9 +17,10 @@ class ProductProduct(models.Model):
         default=True,
         help=(
             "Si está activo, la referencia interna (código) no podrá "
-            "modificarse una vez que el producto tenga movimientos de "
-            "inventario confirmados (incluye los generados por órdenes de "
-            "compra o venta confirmadas)."
+            "modificarse una vez que el producto (siendo almacenable) tenga "
+            "movimientos de inventario ya validados (estado 'Hecho'). Un "
+            "pedido de compra o venta confirmado, sin la transferencia "
+            "asociada validada todavía, no cuenta como movimiento."
         ),
     )
 

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -40,7 +40,7 @@ class ProductProduct(models.Model):
     def write(self, vals):
         if "default_code" in vals:
             for product in self:
-                if not product.lock_internal_reference_on_moves:
+                if not product.is_storable or not product.lock_internal_reference_on_moves:
                     continue
                 if vals["default_code"] == product.default_code:
                     continue

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -12,12 +12,47 @@ _logger = logging.getLogger(__name__)
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
+    lock_internal_reference_on_moves = fields.Boolean(
+        string="Bloquear referencia interna con movimientos",
+        default=True,
+        help=(
+            "Si está activo, la referencia interna (código) no podrá "
+            "modificarse una vez que el producto tenga movimientos de "
+            "inventario confirmados (incluye los generados por órdenes de "
+            "compra o venta confirmadas)."
+        ),
+    )
+
+    def _has_moves(self):
+        """Return True if self (variant) has done stock moves."""
+        self.ensure_one()
+        return bool(
+            self.env["stock.move"].search_count(
+                [("product_id", "=", self.id), ("state", "=", "done")], limit=1
+            )
+        )
+
     def button_dummy(self):
         # TDE FIXME: this button is very interesting
         # Variante del maldito Raiver e.e
         return True
 
     def write(self, vals):
+        if "default_code" in vals:
+            for product in self:
+                if not product.lock_internal_reference_on_moves:
+                    continue
+                if vals["default_code"] == product.default_code:
+                    continue
+                if product._has_moves():
+                    raise ValidationError(
+                        _(
+                            "No se puede modificar la referencia interna del "
+                            "producto '%s' porque ya tiene movimientos de "
+                            "inventario confirmados.",
+                            product.display_name,
+                        )
+                    )
         res = super().write(vals)
         if "list_price" in vals:
             self._validate_list_price()

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -27,7 +27,7 @@ class ProductProduct(models.Model):
         """Return True if self (variant) has done stock moves."""
         self.ensure_one()
         return bool(
-            self.env["stock.move"].search_count(
+            self.env["stock.move"].sudo().search_count(
                 [("product_id", "=", self.id), ("state", "=", "done")], limit=1
             )
         )
@@ -40,7 +40,11 @@ class ProductProduct(models.Model):
     def write(self, vals):
         if "default_code" in vals:
             for product in self:
-                if not product.is_storable or not product.lock_internal_reference_on_moves:
+                lock_enabled = vals.get(
+                    "lock_internal_reference_on_moves",
+                    product.lock_internal_reference_on_moves,
+                )
+                if not product.is_storable or not lock_enabled:
                     continue
                 if vals["default_code"] == product.default_code:
                     continue

--- a/l10n_ve_stock/models/product_product.py
+++ b/l10n_ve_stock/models/product_product.py
@@ -244,8 +244,20 @@ class ProductProduct(models.Model):
 
         MoveLine = self.env['stock.move.line'].with_context(active_test=False)
 
-        domain_move_line_in = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_in_loc
-        domain_move_line_out = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_out_loc
+        # These lines are always filtered to state == 'done', so the "final destination
+        # of an in-progress chained move" branch of _get_domain_locations() does not
+        # apply here. `skip_in_progress=True` makes the core return the plain
+        # done-only in/out domains (each already excluding the other side via `~`,
+        # e.g. `dest_loc_domain_done & ~loc_domain`), instead of the union with the
+        # in-progress branch used for stock.move. Without that exclusion, an internal
+        # transfer (both origin and destination inside the selected locations) would
+        # count as incoming AND outgoing at once, inflating both quantities.
+        _, domain_move_line_in_loc, domain_move_line_out_loc = self.with_context(
+            skip_in_progress=True
+        )._get_domain_locations()
+
+        domain_move_line_in = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_line_in_loc
+        domain_move_line_out = [('product_id', 'in', self.ids), ('state', '=', 'done')] + domain_move_line_out_loc
 
         if from_date:
             domain_move_line_in += [('date', '>=', from_date)]

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -46,6 +46,19 @@ class ProductTemplate(models.Model):
 
     liters_per_unit = fields.Float(digits="Stock Weight")
 
+    lock_internal_reference_on_moves = fields.Boolean(
+        string="Bloquear referencia interna con movimientos",
+        compute="_compute_lock_internal_reference_on_moves",
+        inverse="_set_lock_internal_reference_on_moves",
+        store=True,
+        help=(
+            "Si está activo, la referencia interna (código) no podrá "
+            "modificarse una vez que el producto tenga movimientos de "
+            "inventario confirmados (incluye los generados por órdenes de "
+            "compra o venta confirmadas)."
+        ),
+    )
+
     def button_dummy(self):
         # TDE FIXME: this button is very interesting
         # Maldito Raiver e.e
@@ -130,3 +143,12 @@ class ProductTemplate(models.Model):
         domain = [('free_qty', operator, value)]
         product_variant_query = self.env['product.product'].sudo()._search(domain)
         return [('product_variant_ids', 'in', product_variant_query)]
+
+    @api.depends("product_variant_ids.lock_internal_reference_on_moves")
+    def _compute_lock_internal_reference_on_moves(self):
+        self._compute_template_field_from_variant_field(
+            "lock_internal_reference_on_moves", default=True
+        )
+
+    def _set_lock_internal_reference_on_moves(self):
+        self._set_product_variant_field("lock_internal_reference_on_moves")

--- a/l10n_ve_stock/models/product_template.py
+++ b/l10n_ve_stock/models/product_template.py
@@ -53,9 +53,10 @@ class ProductTemplate(models.Model):
         store=True,
         help=(
             "Si está activo, la referencia interna (código) no podrá "
-            "modificarse una vez que el producto tenga movimientos de "
-            "inventario confirmados (incluye los generados por órdenes de "
-            "compra o venta confirmadas)."
+            "modificarse una vez que el producto (siendo almacenable) tenga "
+            "movimientos de inventario ya validados (estado 'Hecho'). Un "
+            "pedido de compra o venta confirmado, sin la transferencia "
+            "asociada validada todavía, no cuenta como movimiento."
         ),
     )
 
@@ -75,6 +76,23 @@ class ProductTemplate(models.Model):
                 raise ValidationError(_("Price cannot be negative or zero."))
 
     def write(self, vals):
+        # default_code and lock_internal_reference_on_moves are both stored
+        # fields with their own inverse (_set_default_code on the core side,
+        # _set_lock_internal_reference_on_moves here), so Odoo runs them as
+        # separate write() calls on the variant, in vals key order. In the
+        # resolved form arch, default_code renders before the toggle, so it
+        # always arrives first in vals - meaning product.product.write()'s
+        # own same-write guard (which reads
+        # vals.get("lock_internal_reference_on_moves", ...)) never sees the
+        # new toggle value, only the variant's still-locked stored one.
+        # Propagate the toggle to the variants directly, before super()
+        # triggers any inverse, so unlocking and fixing default_code in the
+        # same save always sees the intended state regardless of key order.
+        if "lock_internal_reference_on_moves" in vals and "default_code" in vals:
+            self.product_variant_ids.write(
+                {"lock_internal_reference_on_moves": vals["lock_internal_reference_on_moves"]}
+            )
+
         res = super().write(vals)
         if "taxes_id" in vals:
             self._validate_single_sale_tax()

--- a/l10n_ve_stock/tests/__init__.py
+++ b/l10n_ve_stock/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_stock_scrap
 from . import test_stock_quantity_history
 from . import test_stock_warehouse
 from . import test_stock_picking_product_no_quick_create
+from . import test_lock_internal_reference

--- a/l10n_ve_stock/tests/test_lock_internal_reference.py
+++ b/l10n_ve_stock/tests/test_lock_internal_reference.py
@@ -78,6 +78,25 @@ class TestLockInternalReferenceOnMoves(TransactionCase):
         self.assertEqual(product.default_code, "REF006-B")
         self.assertFalse(product.lock_internal_reference_on_moves)
 
+    def test_write_template_default_code_allowed_when_lock_disabled_in_same_write(self):
+        """Same unlock-and-fix flow as
+        test_write_default_code_allowed_when_lock_disabled_in_same_write,
+        but through product.template.write() - the real path the product
+        form uses. default_code and lock_internal_reference_on_moves each
+        have their own inverse, run as separate calls in vals key order;
+        the resolved form arch renders default_code before the toggle, so
+        it is listed first here too, matching what the UI actually sends.
+        """
+        product = self._create_product("REF007")
+        self._create_done_move(product)
+        template = product.product_tmpl_id
+        template.write({
+            "default_code": "REF007-B",
+            "lock_internal_reference_on_moves": False,
+        })
+        self.assertEqual(product.default_code, "REF007-B")
+        self.assertFalse(product.lock_internal_reference_on_moves)
+
     def test_write_default_code_allowed_when_not_storable(self):
         product = self.env["product.product"].create(
             {

--- a/l10n_ve_stock/tests/test_lock_internal_reference.py
+++ b/l10n_ve_stock/tests/test_lock_internal_reference.py
@@ -63,6 +63,21 @@ class TestLockInternalReferenceOnMoves(TransactionCase):
         product.write({"default_code": "REF004-B"})
         self.assertEqual(product.default_code, "REF004-B")
 
+    def test_write_default_code_allowed_when_lock_disabled_in_same_write(self):
+        """Disabling the toggle and changing default_code in a single write
+        (the natural flow to unlock and fix a product) must not raise -
+        the guard has to read the incoming value from vals, not the
+        still-True value stored on the record before the write applies.
+        """
+        product = self._create_product("REF006")
+        self._create_done_move(product)
+        product.write({
+            "lock_internal_reference_on_moves": False,
+            "default_code": "REF006-B",
+        })
+        self.assertEqual(product.default_code, "REF006-B")
+        self.assertFalse(product.lock_internal_reference_on_moves)
+
     def test_write_default_code_allowed_when_not_storable(self):
         product = self.env["product.product"].create(
             {

--- a/l10n_ve_stock/tests/test_lock_internal_reference.py
+++ b/l10n_ve_stock/tests/test_lock_internal_reference.py
@@ -1,0 +1,65 @@
+from odoo.tests import TransactionCase, tagged
+from odoo.exceptions import ValidationError
+
+
+@tagged("post_install", "-at_install", "l10n_ve_stock")
+class TestLockInternalReferenceOnMoves(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env["res.partner"].create({"name": "Cliente Test"})
+        self.location_src = self.env["stock.location"].create(
+            {"name": "Origen Test", "usage": "internal"}
+        )
+        self.location_dest = self.env["stock.location"].create(
+            {"name": "Destino Test", "usage": "internal"}
+        )
+
+    def _create_product(self, default_code):
+        return self.env["product.product"].create(
+            {
+                "name": "Producto Test",
+                "default_code": default_code,
+                "type": "consu",
+                "is_storable": True,
+            }
+        )
+
+    def test_create_product_with_default_code(self):
+        product = self._create_product("REF001")
+        self.assertEqual(product.default_code, "REF001")
+
+    def test_write_default_code_without_moves(self):
+        product = self._create_product("REF002")
+        product.write({"default_code": "REF002-B"})
+        self.assertEqual(product.default_code, "REF002-B")
+
+    def _create_done_move(self, product):
+        move = self.env["stock.move"].create(
+            {
+                "product_id": product.id,
+                "product_uom_qty": 1,
+                "product_uom": product.uom_id.id,
+                "location_id": self.location_src.id,
+                "location_dest_id": self.location_dest.id,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        move.quantity = 1
+        move.picked = True
+        move._action_done()
+        return move
+
+    def test_write_default_code_blocked_with_done_stock_move(self):
+        product = self._create_product("REF003")
+        self._create_done_move(product)
+        with self.assertRaises(ValidationError):
+            product.write({"default_code": "REF003-B"})
+
+    def test_write_default_code_allowed_when_lock_disabled(self):
+        product = self._create_product("REF004")
+        product.lock_internal_reference_on_moves = False
+        self._create_done_move(product)
+        product.write({"default_code": "REF004-B"})
+        self.assertEqual(product.default_code, "REF004-B")
+

--- a/l10n_ve_stock/tests/test_lock_internal_reference.py
+++ b/l10n_ve_stock/tests/test_lock_internal_reference.py
@@ -63,3 +63,16 @@ class TestLockInternalReferenceOnMoves(TransactionCase):
         product.write({"default_code": "REF004-B"})
         self.assertEqual(product.default_code, "REF004-B")
 
+    def test_write_default_code_allowed_when_not_storable(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Producto No Almacenable",
+                "default_code": "REF005",
+                "type": "consu",
+                "is_storable": False,
+            }
+        )
+        self._create_done_move(product)
+        product.write({"default_code": "REF005-B"})
+        self.assertEqual(product.default_code, "REF005-B")
+

--- a/l10n_ve_stock/tests/test_product_product.py
+++ b/l10n_ve_stock/tests/test_product_product.py
@@ -201,9 +201,55 @@ class TestProductProductComputeQuantitiesForReport(TransactionCase):
             "is_storable": True,
         })
 
-    @unittest.skip("_compute_quantities_dict_for_report depends on location_final_id removed in Odoo 19")
     def test_compute_quantities_dict_for_report_basic(self):
-        pass
+        self.env["stock.quant"].create({
+            "product_id": self.product.id,
+            "location_id": self.location.id,
+            "quantity": 10,
+        })
+        res = self.product._compute_quantities_dict_for_report(
+            lot_id=False, owner_id=False, package_id=False, location=self.location,
+        )
+        self.assertEqual(res[self.product.id]["qty_available"], 10.0)
+
+    def test_compute_quantities_dict_for_report_internal_transfer_does_not_inflate(self):
+        """A move.line whose origin and destination are both inside the
+        selected locations (e.g. WH/Stock -> WH/Output) must not be counted
+        as incoming AND outgoing at once, or the report's totals get
+        inflated for every internal transfer.
+        """
+        other_internal_location = self.env["stock.location"].create({
+            "name": "Internal Transfer Target",
+            "location_id": self.location.location_id.id,
+            "usage": "internal",
+        })
+        picking = self.env["stock.picking"].create({
+            "picking_type_id": self.warehouse.int_type_id.id,
+            "location_id": self.location.id,
+            "location_dest_id": other_internal_location.id,
+            "move_ids": [(0, 0, {
+                "product_id": self.product.id,
+                "product_uom_qty": 5,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.location.id,
+                "location_dest_id": other_internal_location.id,
+            })],
+        })
+        picking.action_confirm()
+        picking.move_ids.quantity = 5
+        picking.button_validate()
+
+        res = self.product._compute_quantities_dict_for_report(
+            lot_id=False, owner_id=False, package_id=False,
+        )
+        self.assertEqual(
+            res[self.product.id]["incoming_qty"], 0.0,
+            "An internal transfer between two selected locations must not count as incoming.",
+        )
+        self.assertEqual(
+            res[self.product.id]["outgoing_qty"], 0.0,
+            "An internal transfer between two selected locations must not count as outgoing.",
+        )
 
     @unittest.skip("_compute_quantities_dict_for_report depends on location_final_id removed in Odoo 19")
     def test_compute_quantities_dict_for_report_with_lot(self):

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -79,6 +79,13 @@
             <xpath expr="//field[@name='barcode']" position="before">
                 <field name="alternate_code"/>
             </xpath>
+            <xpath expr="//field[@name='default_code']" position="after">
+                <field
+                    name="lock_internal_reference_on_moves"
+                    widget="boolean_toggle"
+                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
+                />
+            </xpath>
         </field>
     </record>
     <record id="product_template_form_view_procurement_button" model="ir.ui.view">

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -69,6 +69,14 @@
             <xpath expr="//field[@name='default_code']" position="after">
                 <field name="alternate_code"/>
             </xpath>
+            <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
+                <field
+                    name="lock_internal_reference_on_moves"
+                    widget="boolean_toggle"
+                    invisible="not is_storable"
+                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
+                />
+            </xpath>
         </field>
     </record>
     <record id="product_normal_form_view" model="ir.ui.view">
@@ -79,10 +87,11 @@
             <xpath expr="//field[@name='barcode']" position="before">
                 <field name="alternate_code"/>
             </xpath>
-            <xpath expr="//field[@name='default_code']" position="after">
+            <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
                 <field
                     name="lock_internal_reference_on_moves"
                     widget="boolean_toggle"
+                    invisible="not is_storable"
                     help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
                 />
             </xpath>

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -74,7 +74,7 @@
                     name="lock_internal_reference_on_moves"
                     widget="boolean_toggle"
                     invisible="not is_storable"
-                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
+                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos de inventario validados (estado 'Hecho')."
                 />
             </xpath>
         </field>
@@ -92,7 +92,7 @@
                     name="lock_internal_reference_on_moves"
                     widget="boolean_toggle"
                     invisible="not is_storable"
-                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos asociados."
+                    help="Al activarlo, la referencia interna no podrá modificarse una vez que el producto tenga movimientos de inventario validados (estado 'Hecho')."
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Reemplaza a #1263 (cerrado — ver comentario de cierre en #1263 para el detalle completo).

## Motivo de la creación

Pastor identificó en #1263 que el PR traía la tarea **79675 completa** (Alternate Locations Tracking, commit `b568d47e` con indicios claros de ser un cherry-pick del commit ya mergeado en la rama `19.0` vía #1201 — mismo autor David Mendoza, mismos 26 archivos, contenido casi idéntico), no "3 commits de compatibilidad" como decía el body original.

Verificado con el equipo: la tarea 79675 ya está cerrada, aprobada y mergeada — pero contra la rama `19.0`, no contra `maintenance-19.0`. No es responsabilidad de esta tarea (79483) llevar ese código a `maintenance-19.0`.

## Resumen de la última review de Pastor en #1263 (2026-09-10)

> **Veredicto: no mergeable como está — pero no por el código de la 79483.** La feature de 79483 (bloqueo de referencia interna) está bien resuelta, bien cubierta y la doy por aprobada. Lo que frena el merge es que el PR contiene una segunda tarea completa que no declara, y esa segunda tarea trae un hueco de permisos real.

Hallazgos de esa review (todos originados en el código de 79675, ninguno en 79483):

- 🔴 **Scope**: de los 29 archivos del PR, la 79483 explicaba solo 5. Mergear cerraba de facto la 79675 sin PR propio, sin review propia y sin trazabilidad en su tarea.
- 🟠 **Hueco de permisos**: `su=True` sin `has_group()` en `action_internal_transfer`/`action_receive_quantity`/`action_move_to_output`/`action_deliver_from_output` permitía a cualquier usuario interno mover cantidades del ledger de ubicaciones alternas — las ACLs del modelo estaban bien puestas, pero la ruta de escritura real (botón sin `groups=`, ACL del wizard sin restringir) las esquivaba por completo.
- 🟡 El `.po` regenerado perdía traducciones que ya existían ("Quants"→vacío, "Transferencia"→"Transferir", entradas eliminadas) además de dejar strings nuevos de 79675 sin traducir.
- 🟢 La 79483 en sí — aprobada sin reservas: `write()` lee el toggle desde `vals`, la propagación a `product_variant_ids` resuelve el orden de inverses, `_has_moves()` sigue el patrón del core, el fix de dominio de inventario usa el mecanismo real del core (`_get_domain_locations()`), CI verde.

## Qué contiene este PR

Únicamente los 10 commits (+ merge) que son genuinamente de la tarea 79483, extraídos vía `git cherry-pick` sobre el `maintenance-19.0` más reciente (que ya incluye #1265, mergeado hoy):

- `ac2592d1` [FEAT] Bloquear referencia interna del producto tras movimientos confirmados
- `4b190bb8` [TEST] Cubrir bloqueo de referencia interna con movimientos
- `db72a351` [IMP] Restringir bloqueo de referencia interna a productos almacenables
- `7d30abf5` [TEST] Cubrir bypass de bloqueo para productos no almacenables
- `ba1cd774` [FIX] Leer el toggle de bloqueo desde vals en el mismo write
- `71d76609` [TEST] Cubrir toggle y default_code cambiados en el mismo write
- `ed9db57d` [FIX] Propagar el toggle de bloqueo antes de los inverses en template
- `72419f6b` [TEST] Cubrir desbloqueo de referencia interna vía product.template
- `05988aa7` [FIX] Corregir dominio de inventario para transferencias internas
- `56bfa682` [TEST] Cubrir dominio de transferencias internas en reporte

**Verificación de independencia de 79675**: se probó el cherry-pick completo contra `maintenance-19.0` limpio (sin 79675). Hubo 2 conflictos triviales de contexto (no de lógica) en `product_template.py::write()` y `product_product.py::_compute_quantities_dict_for_report`, ambos resueltos quitando únicamente líneas de contexto que pertenecían a 79675 (`old_physical_locations_ids`) o que ya venían del propio core de Odoo (`_get_domain_locations()`). Ningún fix de 79483 depende funcionalmente de código de 79675. El diff final de este PR no toca ni un archivo de `stock_picking_alter_location*`, wizards, ni grupos nuevos de esa tarea.

## Tarea

project.task 79483 — "1. Migracion de Referencia Interna a V19": bloquear la referencia interna (`default_code`) de un producto una vez que tiene movimientos de inventario confirmados, configurable por producto (`lock_internal_reference_on_moves`), activo por defecto.

References: https://binaural.odoo.com/odoo/action-341/79483

## Hallazgos de #1263 aplicables/no aplicables aquí

- 🟢 (Pastor) La feature de 79483 en sí — aprobada, sin cambios, incluida tal cual.
- ❌ NO APLICA: el hueco de permisos en `stock_picking_alter_location.py` (código de 79675, ausente en este PR).
- ❌ NO APLICA: el `.po` que pierde traducciones existentes (era del regenerado completo del `.po` al incluir 79675; este PR no lo toca).

## CI

`pre-commit` ✅ pass, `run-cli-command` ✅ pass.

@christopherBinaural @pastor-binaural
