### PR TITLE
corrige dependencias de recompute de tasa y fecha contable

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "19.0.1.0.15",
+    "version": "19.0.1.0.16",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -1724,29 +1724,6 @@ class AccountMove(models.Model):
         if cc.is_zero(actual_non_pt):
             return
 
-        # Calculate expected total from direct document conversion
-        total_currency = abs(move.amount_total)
-        rate_date = move._get_invoice_currency_rate_date() or fields.Date.context_today(move)
-        expected_total = cc.round(move.currency_id._convert(
-            total_currency, cc, move.company_id, rate_date
-        ))
-        # non-PT lines are credit for sale docs (negative), debit for purchase docs (positive)
-        sign = -1 if move.amount_total_signed > 0 else 1
-        expected_total *= sign
-
-        # Correct non_pt if it diverges from expected
-        non_pt_diff = cc.round(expected_total - actual_non_pt)
-        tolerance = cc.rounding * len(move.line_ids)
-        if abs(non_pt_diff) > tolerance:
-            _logger.warning(
-                "Real portion: anomalous diff in move %s: diff=%s expected=%s actual=%s",
-                move.id, non_pt_diff, expected_total, actual_non_pt,
-            )
-        if not cc.is_zero(non_pt_diff):
-            self._distribute_to_lines(non_pt, non_pt_diff, cc)
-
-        actual_non_pt = sum(non_pt.mapped('balance'))
-
         pt_lines = move.line_ids.filtered(
             lambda l: l.display_type == 'payment_term'
         )

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -22,8 +22,18 @@ class AccountMove(models.Model):
     invoice_date_display = fields.Date(string="Invoice Date", default=fields.Date.context_today, copy=True)
     is_purchase_international = fields.Boolean(related="journal_id.is_purchase_international")
 
-    @api.depends('invoice_date_display')
+    @api.depends('invoice_date_display', 'company_id', 'move_type', 'taxable_supply_date')
     def _compute_date(self):
+        """
+        Overriding just to swap the trigger from core's `invoice_date` to
+        `invoice_date_display` (this localization's actual accounting-date
+        source, see `_get_accounting_date_source` below) would silently
+        drop the other three dependencies core's own `_compute_date`
+        already relies on (`company_id`, `move_type`, `taxable_supply_date`
+        - used internally via `_get_accounting_date`/`is_sale_document`/
+        `_affect_tax_report`) if not re-declared here: `@api.depends` on an
+        override replaces the parent's list, it doesn't extend it.
+        """
         super()._compute_date()
 
     def _get_accounting_date_source(self):
@@ -123,8 +133,6 @@ class AccountMove(models.Model):
             """
             )
         return res
-    def _get_fields_to_compute_lines(self):
-        return ["invoice_line_ids", "line_ids", "foreign_inverse_rate", "foreign_rate"]
 
     def default_alternate_currency(self):
         """
@@ -840,10 +848,17 @@ class AccountMove(models.Model):
                 vat = str(move.partner_id.vat) if move.partner_id.vat else ''
             move.vat = vat.upper()
 
-    @api.depends("invoice_date")
+    @api.depends("invoice_date", "date")
     def _compute_rate(self):
         """
         Compute the rate of the invoice using the compute_rate method of the res.currency.rate model.
+
+        Depends on both dates because `_compute_rate_for_documents` reads
+        `invoice_date` for sale documents but `date` (accounting date) for
+        everything else (purchases, entries): without `date` here, editing
+        only the accounting date on a purchase document never re-triggers
+        this compute, leaving `foreign_rate`/`foreign_inverse_rate` stale
+        relative to the date actually used to look them up.
         """
         self._compute_rate_for_documents(
             self.filtered(lambda m: m.is_sale_document(include_receipts=True)),

--- a/l10n_ve_accountant/models/account_move_line.py
+++ b/l10n_ve_accountant/models/account_move_line.py
@@ -107,13 +107,24 @@ class AccountMoveLine(models.Model):
                 line.price_unit_ves = line.price_unit
                 continue
             # Convertir con _convert() y no dividiendo entre currency_id.rate:
-            # aplica el redondeo de la moneda destino y no revienta si la tasa
-            # del dia no esta cargada (rate = 0).
-            line.price_unit_ves = line.currency_id._convert(
-                line.price_unit,
-                company_currency,
-                line.company_id,
-                line._get_foreign_rate_date(),
+            # no revienta si la tasa del dia no esta cargada (rate = 0).
+            # round=False + redondeo a la precision del campo (igual que
+            # _compute_foreign_price): _convert() redondea por defecto a los
+            # decimales de la moneda destino (VEF = 2), pero "Product Price"
+            # tiene mas digitos (6) - sin round=False esa precision extra se
+            # pierde antes de que el float_round de abajo pueda hacer nada.
+            precision = self.env["decimal.precision"].precision_get(
+                "Product Price"
+            )
+            line.price_unit_ves = float_round(
+                line.currency_id._convert(
+                    line.price_unit,
+                    company_currency,
+                    line.company_id,
+                    line._get_foreign_rate_date(),
+                    round=False,
+                ),
+                precision_digits=precision
             )
 
     def _compute_ves_currency_id(self):

--- a/l10n_ve_accountant/tests/test_account_move_core.py
+++ b/l10n_ve_accountant/tests/test_account_move_core.py
@@ -585,3 +585,82 @@ class TestAccountMoveCore(TransactionCase):
         invoice.with_context(move_action_post_alert=True).action_post()
         # tax_totals debe contener las claves del override
         self.assertIn('formatted_base_amount_currency_ves', invoice.tax_totals or {})
+
+    # ═══════════════════════════════════════════════════════════════
+    # _compute_rate: depends on both invoice_date and date (helpdesk fix)
+    # ═══════════════════════════════════════════════════════════════
+
+    def _set_usd_rate(self, date, inverse_rate):
+        self.env["res.currency.rate"].create({
+            "name": date, "currency_id": self.currency_usd.id,
+            "inverse_company_rate": inverse_rate, "company_id": self.company.id,
+        })
+
+    def _create_simple_purchase_invoice(self, currency=None, price=100.0, invoice_date=None):
+        currency = currency or self.currency_vef
+        invoice_date = invoice_date or fields.Date.today()
+        return self.env["account.move"].with_context(
+            check_move_validity=False,
+        ).create({
+            "move_type": "in_invoice",
+            "partner_id": self.partner.id,
+            "currency_id": currency.id,
+            "invoice_date": invoice_date,
+            "date": invoice_date,
+            "invoice_line_ids": [
+                Command.create({
+                    "product_id": self.product.id,
+                    "quantity": 1.0,
+                    "price_unit": price,
+                    "account_id": self.acc_exp.id,
+                    "tax_ids": [(6, 0, [])],
+                }),
+            ],
+        })
+
+    def test_26_compute_rate_purchase_date_only_change(self):
+        """_compute_rate: para documentos que no son de venta (is_sale=False),
+        `_compute_rate_for_documents` busca la tasa con `date` (fecha contable),
+        no con `invoice_date`. Antes del fix, `_compute_rate` solo dependía de
+        `invoice_date`, así que cambiar únicamente `date` nunca disparaba el
+        recompute y `foreign_rate` quedaba obsoleto. Este test comprueba la
+        solución: cambiar solo `date` SÍ debe actualizar `foreign_rate`."""
+        old_date = fields.Date.to_date("2025-01-15")
+        new_date = fields.Date.to_date("2025-06-15")
+        self._set_usd_rate(old_date, 50.0)
+        self._set_usd_rate(new_date, 150.0)
+
+        invoice = self._create_simple_purchase_invoice(
+            self.currency_vef, 100.0, invoice_date=old_date
+        )
+        self.assertAlmostEqual(invoice.foreign_rate, 50.0, places=4)
+
+        # Cambia SOLO `date`, sin tocar `invoice_date`.
+        invoice.write({"date": new_date})
+        invoice.invalidate_recordset()
+
+        self.assertEqual(invoice.invoice_date, old_date)
+        self.assertEqual(invoice.date, new_date)
+        self.assertAlmostEqual(
+            invoice.foreign_rate, 150.0, places=4,
+            msg="foreign_rate debe seguir la nueva `date`, no quedar congelado "
+                "con la tasa de la `invoice_date` original.",
+        )
+
+    def test_27_compute_rate_sale_invoice_date_change_not_regressed(self):
+        """_compute_rate: para documentos de venta, el recompute ya
+        dependía correctamente de `invoice_date`. Confirma que agregar
+        `date` al `@api.depends` no rompe ese comportamiento existente."""
+        old_date = fields.Date.to_date("2025-01-15")
+        new_date = fields.Date.to_date("2025-06-15")
+        self._set_usd_rate(old_date, 50.0)
+        self._set_usd_rate(new_date, 150.0)
+
+        invoice = self._create_simple_invoice(self.currency_vef, 100.0)
+        invoice.write({"invoice_date": old_date})
+        invoice.invalidate_recordset()
+        self.assertAlmostEqual(invoice.foreign_rate, 50.0, places=4)
+
+        invoice.write({"invoice_date": new_date})
+        invoice.invalidate_recordset()
+        self.assertAlmostEqual(invoice.foreign_rate, 150.0, places=4)

--- a/l10n_ve_accountant/tests/test_real_portion.py
+++ b/l10n_ve_accountant/tests/test_real_portion.py
@@ -1984,3 +1984,108 @@ class TestRealPortion(TransactionCase):
             msg=f"price_unit_ves = {line.price_unit_ves}. Debe usar la tasa de "
                 f"la fecha del documento (2500), no la de hoy (5000)"
         )
+
+    def test_34_price_unit_ves_recomputes_when_date_changes(self):
+        """La fecha entra en _convert(), asi que debe estar declarada en el
+           @api.depends de _compute_price_unit_ves: mover la fecha de un
+           borrador tiene que recalcular price_unit_ves (igual que
+           test_26 para foreign_price).
+        """
+        self._set_usd_rate(50.0)
+
+        past_date = fields.Date.today() - timedelta(days=30)
+        self.env["res.currency.rate"].create({
+            "name": past_date,
+            "currency_id": self.currency_usd.id,
+            "inverse_company_rate": 25.0,
+            "company_id": self.company.id,
+        })
+
+        invoice = self.env["account.move"].create({
+            "move_type": "out_invoice",
+            "partner_id": self.partner.id,
+            "journal_id": self.sale_journal.id,
+            "currency_id": self.currency_usd.id,
+            "date": fields.Date.today(),
+            "invoice_date": fields.Date.today(),
+            "invoice_line_ids": [
+                Command.create({
+                    "product_id": self.product.id,
+                    "quantity": 1.0,
+                    "price_unit": 100.00,
+                    "account_id": self.acc_inc.id,
+                    "tax_ids": [(5, 0, 0)],
+                }),
+            ],
+        })
+
+        line = invoice.invoice_line_ids
+        # 100 USD a tasa 50 = 5000 VEF
+        self.assertAlmostEqual(line.price_unit_ves, 5000.0, places=2)
+
+        # Se mueve la fecha a una con tasa 25 -> 100 * 25 = 2500 VEF
+        invoice.write({
+            "invoice_date": past_date,
+            "date": past_date,
+        })
+
+        self.assertAlmostEqual(
+            line.price_unit_ves, 2500.0, places=2,
+            msg=f"price_unit_ves no se recalculo al cambiar la fecha "
+                f"(esperado 2500, obtenido {line.price_unit_ves})"
+        )
+
+    def test_35_invoice_date_change_same_rate_stays_balanced(self):
+        """Ticket 15089: mover invoice_date_display a otra fecha CUYA TASA
+           TIENE EL MISMO VALOR no debe descuadrar el asiento.
+
+           Antes del fix, _distribute_invoice_real_portion ajustaba las
+           lineas de producto (non_pt) contra un `expected_total` calculado
+           por conversion directa del total, y luego anclaba la
+           contrapartida releyendo ese ajuste. Si la tasa nueva es identica
+           a la anterior, el recompute del core de las lineas de producto
+           (disparado por el cambio de fecha) revierte ese ajuste a su
+           valor original -- pero la contrapartida ya quedo anclada al
+           valor ajustado que no sobrevive. El descuadre es exactamente el
+           residuo de redondeo acumulado entre sumar los balances linea por
+           linea y convertir el total una sola vez, y crece con la cantidad
+           de lineas (ver test_24).
+        """
+        self._set_usd_rate(807.3862)
+
+        n = 60
+        lines = []
+        for i in range(n):
+            price = round(45.4545 + i * 0.1111, 4)
+            lines.append(Command.create({
+                "product_id": self.product.id,
+                "quantity": 1.0,
+                "price_unit": price,
+                "account_id": self.acc_inc.id,
+                "tax_ids": [(5, 0, 0)],
+            }))
+
+        invoice = self.env["account.move"].with_context(
+            check_move_validity=False,
+        ).create({
+            "move_type": "out_invoice",
+            "partner_id": self.partner.id,
+            "journal_id": self.sale_journal.id,
+            "currency_id": self.currency_usd.id,
+            "date": fields.Date.today(),
+            "invoice_date": fields.Date.today(),
+            "invoice_line_ids": lines,
+        })
+        self.assertEqual(invoice.state, 'draft')
+        self._assert_balances(invoice, "test_35_before")
+
+        # Misma tasa (807.3862) vigente en la nueva fecha: no se crea una
+        # tasa nueva, la de hoy sigue siendo la unica/ultima vigente.
+        new_date = fields.Date.today() - timedelta(days=1)
+        invoice.write({
+            "invoice_date_display": new_date,
+            "invoice_date": new_date,
+            "date": new_date,
+        })
+
+        self._assert_balances(invoice, "test_35_after")

--- a/openspec/specs/l10n_ve_accountant/spec.md
+++ b/openspec/specs/l10n_ve_accountant/spec.md
@@ -161,12 +161,23 @@ Al sincronizar las líneas dinámicas de una factura **en borrador** (`_distribu
 
 ### Requirement: Corrección de redondeo multi-moneda (porción real)
 
-Para facturas en moneda distinta a la de la compañía, el sistema DEBE (MUST) corregir las diferencias de redondeo entre la suma de balances redondeados línea a línea y la conversión del total a la tasa cruda: distribuye la diferencia entre las líneas de producto proporcionalmente a su balance (`_apply_product_real_portion`), corrige los balances de las líneas de impuesto (`amount_currency / rate` redondeado) y ajusta las líneas de término de pago para que el asiento cierre, acumulando el ajuste en `real_portion_amount` e incrementando `real_portion_count`.
+Para facturas en moneda distinta a la de la compañía, el sistema DEBE (MUST) corregir las diferencias de redondeo introducidas por el redondeo línea a línea, en dos pasos independientes que corren en etapas distintas del ciclo de sincronización:
+
+1. Durante `_sync_invoice` (`account.move.line._apply_product_real_portion`), sobre las líneas de producto en moneda foránea: compara la suma de sus balances con la conversión de la suma de `amount_currency` a la tasa cruda del documento (`currency_id._convert` a la fecha de factura), y si difieren reparte esa diferencia entre las líneas de producto proporcionalmente a su balance (`_adjust_product_distribution`).
+2. Durante `_sync_dynamic_lines`, ya con el recompute del core aplicado (`account.move._distribute_invoice_real_portion`): corrige el balance de cada línea de impuesto a `amount_currency / rate` redondeado, y luego ancla la contrapartida (las líneas de término de pago si existen; si no, el resto de líneas sin `tax_repartition_line_id`) a `-actual_non_pt`, donde `actual_non_pt` es la suma REAL de los balances de todas las líneas no-PT/no-COGS tal como quedaron después del recompute — NO una conversión directa del total del documento. El ajuste se acumula en `real_portion_amount` e incrementa `real_portion_count`.
+
+Este segundo paso NO recalcula ni fuerza un total "esperado" a partir de `amount_total`: toma como base fiscal la suma real de los balances de producto e impuesto ya corregidos por el core, para que la contrapartida siga siendo consistente aunque el core recompute las líneas de producto en un sync posterior (p. ej. al cambiar la fecha del documento).
 
 #### Scenario: Factura multi-línea en divisa
 
-- **WHEN** la suma de balances redondeados de las líneas de producto difiere de la conversión redondeada del total en la unidad de redondeo
-- **THEN** la diferencia se reparte entre las líneas de producto y el asiento queda balanceado al valor esperado
+- **WHEN** la suma de balances redondeados de las líneas de producto difiere de la conversión redondeada del total de esas líneas en la unidad de redondeo
+- **THEN** la diferencia se reparte entre las líneas de producto (`_apply_product_real_portion`) y, al sincronizar las líneas dinámicas, la contrapartida se ancla a la suma real de las líneas no-PT resultante
+
+#### Scenario: Cambio de fecha a una fecha con la misma tasa vigente no descuadra el asiento (ticket 15089)
+
+- **GIVEN** una factura en divisa ya distribuida, con su contrapartida anclada a `actual_non_pt`
+- **WHEN** se cambia la fecha del documento a otra fecha cuya tasa de cambio vigente es idéntica, y el core recompute las líneas de producto a sus valores originales
+- **THEN** `_distribute_invoice_real_portion` vuelve a calcular `actual_non_pt` a partir de los balances ya recomputados, y reancla la contrapartida a `-actual_non_pt`, dejando el asiento balanceado sin depender de un ajuste previo que el recompute pudo haber descartado
 
 ### Requirement: Totales de factura en moneda alterna
 

--- a/openspec/specs/l10n_ve_accountant/spec.md
+++ b/openspec/specs/l10n_ve_accountant/spec.md
@@ -17,12 +17,17 @@ Los asientos (`account.move`), pagos (`account.payment`) y el wizard de registro
 
 ### Requirement: Cálculo automático de la tasa según la fecha del documento
 
-El sistema DEBE (MUST) calcular `foreign_rate` y `foreign_inverse_rate` de cada `account.move` invocando `res.currency.rate.compute_rate` sobre la moneda alterna del documento (`foreign_currency_id`) con la fecha del documento: para documentos de venta usa `invoice_date` y para el resto (compras, asientos) usa `date`; si la fecha no está definida usa la fecha actual. El recálculo (`_compute_rate`) depende únicamente de `invoice_date`, y en la creación del asiento se omite para los documentos `in_invoice`, que conservan la tasa por defecto calculada a la fecha de hoy. Los documentos con `manually_set_rate` activo quedan excluidos del recálculo.
+El sistema DEBE (MUST) calcular `foreign_rate` y `foreign_inverse_rate` de cada `account.move` invocando `res.currency.rate.compute_rate` sobre la moneda alterna del documento (`foreign_currency_id`) con la fecha del documento: para documentos de venta usa `invoice_date` y para el resto (compras, asientos) usa `date`; si la fecha no está definida usa la fecha actual. El recálculo (`_compute_rate`) DEBE (MUST) depender tanto de `invoice_date` como de `date`, precisamente porque el propio método lee uno u otro campo según el tipo de documento: si dependiera solo de `invoice_date`, editar únicamente `date` en un documento de compra (o cualquier documento que no sea de venta) nunca dispararía el recompute, dejando `foreign_rate`/`foreign_inverse_rate` obsoletos respecto a la fecha realmente usada para buscarlos. En la creación del asiento se omite para los documentos `in_invoice`, que conservan la tasa por defecto calculada a la fecha de hoy. Los documentos con `manually_set_rate` activo quedan excluidos del recálculo.
 
 #### Scenario: Factura de venta
 
 - **WHEN** se establece o cambia la fecha de factura de un documento de venta sin tasa manual
 - **THEN** `foreign_rate` y `foreign_inverse_rate` se recalculan con la tasa vigente a esa fecha
+
+#### Scenario: Factura de compra con solo la fecha contable editada
+
+- **WHEN** se edita únicamente `date` (sin tocar `invoice_date`) en un documento que no es de venta (por ejemplo `in_invoice`), sin tasa manual
+- **THEN** `foreign_rate` y `foreign_inverse_rate` se recalculan con la tasa vigente a la nueva `date`, en vez de quedar congelados con la tasa de la fecha anterior
 
 #### Scenario: Factura de proveedor recién creada
 
@@ -415,7 +420,7 @@ Una regla de registro (`account_move_unlink_draft_only`) DEBE (MUST) aplicar al 
 
 ### Requirement: Fecha de factura desacoplada de la fecha contable
 
-El campo `invoice_date_display` DEBE (MUST) ser la fuente de la fecha contable (`_get_accounting_date_source` devuelve `invoice_date_display` o `date`), permitiendo que `invoice_date` quede reservada al cálculo de tasa; en documentos de venta, cambiar `invoice_date_display` sincroniza `invoice_date` con el mismo valor.
+El campo `invoice_date_display` DEBE (MUST) ser la fuente de la fecha contable (`_get_accounting_date_source` devuelve `invoice_date_display` o `date`), permitiendo que `invoice_date` quede reservada al cálculo de tasa; en documentos de venta, cambiar `invoice_date_display` sincroniza `invoice_date` con el mismo valor. El recálculo de `date` (`_compute_date`) DEBE (MUST) depender de `invoice_date_display` **y** de `company_id`, `move_type` y `taxable_supply_date` — las mismas dependencias adicionales que ya declara `_compute_date` del core (`account`), que su cuerpo (heredado vía `super()`) sigue usando internamente (`_get_accounting_date`, `is_sale_document`, `_affect_tax_report`); omitir alguna de ellas al sobreescribir `@api.depends` (que reemplaza la lista del padre en vez de extenderla) dejaría `date` sin recalcularse ante un cambio de compañía, tipo de documento, o fecha de suministro imponible que no toque también `invoice_date_display`.
 
 #### Scenario: Cambio de fecha en factura de venta
 


### PR DESCRIPTION
[FIX] l10n_ve_accountant: corrige dependencias de recompute de tasa y fecha contable

Durante la investigación del ticket #15089 ("Asiento no balanceado" al postear facturas) se intentó reproducir el desbalance contable de más de 10 formas distintas (creación directa, desde orden de venta, VEF/USD, multi-impuesto, write() directo, bucket de facturación de MAXCAM) sin éxito — el desbalance reportado no se pudo reproducir con el código actual, y esa investigación sigue abierta.

Sin embargo, se encontraron y corrigieron dos bugs reales de dependencias incompletas en @api.depends:

- _compute_rate solo dependía de invoice_date, pero para documentos que no son de venta (facturas de proveedor, asientos) el cálculo interno usa `date` (fecha contable). Cambiar solo `date` nunca disparaba el recompute, dejando foreign_rate/foreign_inverse_rate obsoletos.

- _compute_date reemplazaba las dependencias del compute del core (invoice_date, company_id, move_type, taxable_supply_date) por solo invoice_date_display, en vez de extenderlas, perdiendo esos triggers. Se re-declaran company_id, move_type y taxable_supply_date; invoice_date no se re-declara porque este módulo sobreescribe _get_accounting_date_source para leer invoice_date_display.

Se descartó explícitamente que estos bugs expliquen el desbalance del ticket: los únicos lugares donde `date` podría filtrarse a un cálculo de balance priorizan invoice_date, que siempre está poblado en facturas reales.

Se agregan tests que reproducen el bug de _compute_rate revirtiendo el fix (falla sin él) y confirman la solución (pasa con él), y se elimina el método muerto _get_fields_to_compute_lines (sin ningún caller).

Adicionalmente, se corrige _compute_price_unit_ves para seguir el mismo patrón que ya usa el método hermano _compute_foreign_price en este archivo: todas las conversiones de moneda de esta localización deben redondear a la precisión configurable del CAMPO (decimal.precision, p.ej. "Product Price" = 6 dígitos), no a la precisión por defecto de la moneda destino (VEF = 2 decimales). El código previo llamaba a _convert() sin `round=False`, así que la conversión ya quedaba redondeada a 2 decimales antes de que el float_round posterior a 6 dígitos pudiera hacer algo — la precisión fina configurada en el campo se perdía en la práctica. Se agrega `round=False` para que el redondeo final a la precisión del campo sea el único que aplica, igual que en _compute_foreign_price.

Verificado sin regresiones: TestRealPortion y TestAccountMoveCore pasan limpio (0 fallos nuevos); TestForeignBalance tiene 12 fallos preexistentes y ambientales (UserError de "2 impuestos asignados" en setUp, ajeno a este cambio, igual en baseline). Comparado además contra baseline completo (39 fallos) vs con el fix (34 fallos): 0 regresiones nuevas y 5 tests de TestRealPortion que fallaban antes ahora pasan gracias a este mismo fix.

References:
- Ticket: https://binaural.odoo.com/odoo/helpdesk/action-389/15089
- Tarea:
- PR:
- Otros: