### PR TITLE
[FIX] l10n_ve_pos: alterno del vuelto en asientos PdV (#15090)

### DIFF
--- a/l10n_ve_pos/__manifest__.py
+++ b/l10n_ve_pos/__manifest__.py
@@ -8,7 +8,7 @@
     "support": "contacto@binaural.dev",
     "category": "Point of Sale",
     "website": "https://binauraldev.com/",
-    "version": "1.12",
+    "version": "1.13",
     # any module necessary for this one to work correctly
     "depends": [
         "base",

--- a/l10n_ve_pos/models/pos_order.py
+++ b/l10n_ve_pos/models/pos_order.py
@@ -42,6 +42,52 @@ class PosOrder(models.Model):
         )
         return res
 
+    def _amount_to_foreign(self, amount):
+        """Convert a POS main-currency amount (Bs.) into the company's foreign
+        currency (USD) using this order's rate, rounded to the foreign
+        currency precision.
+
+        Mirrors the frontend ``pos.order.localToForeign`` used to fill
+        ``foreign_amount`` on every regular payment line, so any line created
+        server-side (e.g. the change/vuelto line) gets the same value.
+        """
+        self.ensure_one()
+        rate = self.foreign_currency_rate
+        if not rate:
+            return 0.0
+        foreign_amount = amount * rate
+        foreign_currency = self.foreign_currency_id
+        if foreign_currency:
+            foreign_amount = foreign_currency.round(foreign_amount)
+        return foreign_amount
+
+    def _process_payment_lines(self, pos_order, order, pos_session, draft):
+        """Backfill the foreign-currency amount on the change (vuelto) line.
+
+        Odoo core creates the change payment server-side here (``is_change``)
+        without a ``foreign_amount``/``foreign_rate``. Both the invoice payment
+        moves (``pos.payment._create_payment_moves``) and the session-close
+        cross moves (``pos.session``) build the alternate-currency columns
+        (``foreign_debit``/``foreign_credit``) from ``payment.foreign_amount``,
+        so a missing value left the change move with USD 0,00 and the alternate
+        currency unbalanced against the invoice (ticket #15126). Populate it at
+        the source so every downstream consumer reads a correct value.
+        """
+        res = super()._process_payment_lines(pos_order, order, pos_session, draft)
+        change_payments = order.payment_ids.filtered(
+            lambda payment: payment.is_change
+            and payment.amount
+            and not payment.foreign_amount
+        )
+        for payment in change_payments:
+            payment.write(
+                {
+                    "foreign_amount": order._amount_to_foreign(payment.amount),
+                    "foreign_rate": order.foreign_currency_rate,
+                }
+            )
+        return res
+
     @api.model
     def get_payments_order_refund(self, order_ids):
         if not order_ids:

--- a/l10n_ve_pos/models/pos_payment.py
+++ b/l10n_ve_pos/models/pos_payment.py
@@ -92,12 +92,20 @@ class PosPayment(models.Model):
                     "manually_set_rate": True,
                 }
             )
+            # Fallback: a change (vuelto) line created server-side may reach
+            # here with foreign_amount == 0 (see pos.order._process_payment_lines).
+            # Derive it from the order rate so the alternate-currency columns are
+            # never silently zeroed (ticket #15126).
+            foreign_amount = payment.foreign_amount
+            if not foreign_amount and payment.amount:
+                foreign_amount = payment.pos_order_id._amount_to_foreign(payment.amount)
+
             for line in payment_move.line_ids:
                 line.write(
                     {
                         "not_foreign_recalculate": True,
-                        "foreign_debit": abs(payment.foreign_amount) if line.debit > 0 else 0,
-                        "foreign_credit":  abs(payment.foreign_amount) if line.credit > 0 else 0,
+                        "foreign_debit": abs(foreign_amount) if line.debit > 0 else 0,
+                        "foreign_credit":  abs(foreign_amount) if line.credit > 0 else 0,
                     }
                 )
         return move_id

--- a/l10n_ve_pos/tests/__init__.py
+++ b/l10n_ve_pos/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_pos_session_accounting_common
 from . import test_pos_session_accounting_accumulators
 from . import test_pos_session_accounting_move_creation
 from . import test_pos_session_cross_account_move
+from . import test_pos_change_foreign_amount

--- a/l10n_ve_pos/tests/test_pos_change_foreign_amount.py
+++ b/l10n_ve_pos/tests/test_pos_change_foreign_amount.py
@@ -1,0 +1,158 @@
+"""Change (vuelto) foreign-currency backfill tests (ticket #15126).
+
+Odoo core creates the change payment line server-side
+(``pos.order._process_payment_lines`` -> ``is_change=True``) WITHOUT a
+``foreign_amount``/``foreign_rate``. Both the invoice payment moves
+(``pos.payment._create_payment_moves``) and the session-close cross moves
+(``pos.session``) build the alternate-currency columns
+(``foreign_debit``/``foreign_credit``) from ``payment.foreign_amount``, so a
+missing value left the change move's foreign columns at 0 and the alternate
+currency unbalanced against the invoice.
+
+These tests cover the fix: ``pos.order._amount_to_foreign`` and the backfill
+in ``pos.order._process_payment_lines``. The defensive fallback in
+``pos.payment._create_payment_moves`` reuses the same ``_amount_to_foreign``
+helper exercised here.
+
+Spec: ``openspec/changes/vuelto-monto-alterno-asiento/specs/l10n_ve_pos/spec.md``
+"""
+
+from odoo import Command
+from odoo.tests import tagged
+
+from .test_pos_session_accounting_common import TestPosSessionAccountingBase
+
+
+@tagged("post_install", "-at_install", "l10n_ve_pos", "pos_change_foreign")
+class TestPosChangeForeignAmount(TestPosSessionAccountingBase):
+    def _new_session(self):
+        return self.env["pos.session"].create(
+            {
+                "config_id": self.config.id,
+                "user_id": self.env.ref("base.user_admin").id,
+            }
+        )
+
+    def _draft_order(self, session, *, rate=36.5, amount=116.0, tax_amount=16.0, name="OL/CHG"):
+        """A being-processed (draft) order with one line and the given rate.
+
+        Mirrors ``_create_paid_order`` but without the auto payment nor the
+        flip to ``paid`` — ``_process_payment_lines`` runs while the order is
+        still being processed, and adding a change line to a ``paid`` order
+        would trip ``pos.payment._check_amount``.
+        """
+        return self.env["pos.order"].create(
+            {
+                "company_id": self.company.id,
+                "session_id": session.id,
+                "partner_id": self.company.partner_id.id,
+                "pricelist_id": self.company.partner_id.property_product_pricelist.id,
+                "foreign_amount_total": amount,
+                "foreign_currency_rate": rate,
+                "lines": [
+                    Command.create(
+                        {
+                            "name": name,
+                            "product_id": self.product.id,
+                            "price_unit": amount - tax_amount,
+                            "qty": 1.0,
+                            "price_subtotal": amount - tax_amount,
+                            "price_subtotal_incl": amount,
+                            "tax_ids": [(6, 0, self.tax.ids)],
+                            "foreign_price": (amount - tax_amount) * rate,
+                        }
+                    )
+                ],
+                "amount_total": amount,
+                "amount_tax": tax_amount,
+                "amount_paid": 0.0,
+                "amount_return": 0.0,
+                "last_order_preparation_change": "{}",
+            }
+        )
+
+    def _add_change(self, order, *, amount=-16.0, foreign_amount=0.0, foreign_rate=0.0):
+        """Add a change line the way core does: is_change, no foreign amount."""
+        return order.add_payment(
+            {
+                "name": "CHANGE",
+                "pos_order_id": order.id,
+                "amount": amount,
+                "payment_method_id": self.combined_cash_method.id,
+                "payment_date": order.date_order,
+                "is_change": True,
+                "foreign_amount": foreign_amount,
+                "foreign_rate": foreign_rate,
+            }
+        )
+
+    def test_amount_to_foreign_multiplies_rounds_and_keeps_sign(self):
+        order = self._draft_order(self._new_session(), rate=36.5)
+        self.assertEqual(
+            order._amount_to_foreign(100.0),
+            self.foreign_currency.round(100.0 * 36.5),
+        )
+        # The change is negative; the sign must be preserved.
+        self.assertEqual(
+            order._amount_to_foreign(-16.0),
+            self.foreign_currency.round(-16.0 * 36.5),
+        )
+
+    def test_amount_to_foreign_zero_when_no_rate(self):
+        order = self._draft_order(self._new_session(), rate=36.5)
+        order.foreign_currency_rate = 0.0
+        self.assertEqual(order._amount_to_foreign(100.0), 0.0)
+
+    def test_process_payment_lines_backfills_change_foreign_amount(self):
+        session = self._new_session()
+        order = self._draft_order(session, rate=36.5)
+        change = self._add_change(order, amount=-16.0, foreign_amount=0.0, foreign_rate=0.0)
+        self.assertFalse(change.foreign_amount)
+
+        # amount_return=0 so core creates no new change line: only our
+        # backfill loop runs, over the existing is_change payment.
+        self.env["pos.order"]._process_payment_lines(
+            {"amount_return": 0.0}, order, session, False
+        )
+
+        self.assertEqual(
+            change.foreign_amount,
+            self.foreign_currency.round(-16.0 * 36.5),
+        )
+        self.assertEqual(change.foreign_rate, order.foreign_currency_rate)
+
+    def test_process_payment_lines_does_not_overwrite_existing_foreign_amount(self):
+        session = self._new_session()
+        order = self._draft_order(session, rate=36.5)
+        change = self._add_change(order, amount=-16.0, foreign_amount=-999.0, foreign_rate=1.0)
+
+        self.env["pos.order"]._process_payment_lines(
+            {"amount_return": 0.0}, order, session, False
+        )
+
+        # Guarded by ``not payment.foreign_amount`` — a line that already
+        # carries a foreign amount must be left untouched.
+        self.assertEqual(change.foreign_amount, -999.0)
+
+    def test_process_payment_lines_ignores_non_change_payment(self):
+        session = self._new_session()
+        order = self._draft_order(session, rate=36.5)
+        regular = order.add_payment(
+            {
+                "name": "REGULAR",
+                "pos_order_id": order.id,
+                "amount": 116.0,
+                "payment_method_id": self.combined_cash_method.id,
+                "payment_date": order.date_order,
+                "is_change": False,
+                "foreign_amount": 0.0,
+            }
+        )
+
+        self.env["pos.order"]._process_payment_lines(
+            {"amount_return": 0.0}, order, session, False
+        )
+
+        # The backfill only targets is_change lines; a regular payment that
+        # genuinely came in with 0 is not touched here.
+        self.assertFalse(regular.foreign_amount)

--- a/l10n_ve_pos/tests/test_pos_change_foreign_amount.py
+++ b/l10n_ve_pos/tests/test_pos_change_foreign_amount.py
@@ -72,8 +72,12 @@ class TestPosChangeForeignAmount(TestPosSessionAccountingBase):
         )
 
     def _add_change(self, order, *, amount=-16.0, foreign_amount=0.0, foreign_rate=0.0):
-        """Add a change line the way core does: is_change, no foreign amount."""
-        return order.add_payment(
+        """Add a change line the way core does: is_change, no foreign amount.
+
+        ``pos.order.add_payment`` returns None, so the created payment is
+        read back from ``order.payment_ids``.
+        """
+        order.add_payment(
             {
                 "name": "CHANGE",
                 "pos_order_id": order.id,
@@ -85,6 +89,7 @@ class TestPosChangeForeignAmount(TestPosSessionAccountingBase):
                 "foreign_rate": foreign_rate,
             }
         )
+        return order.payment_ids.filtered(lambda p: p.is_change)[:1]
 
     def test_amount_to_foreign_multiplies_rounds_and_keeps_sign(self):
         order = self._draft_order(self._new_session(), rate=36.5)
@@ -137,7 +142,7 @@ class TestPosChangeForeignAmount(TestPosSessionAccountingBase):
     def test_process_payment_lines_ignores_non_change_payment(self):
         session = self._new_session()
         order = self._draft_order(session, rate=36.5)
-        regular = order.add_payment(
+        order.add_payment(
             {
                 "name": "REGULAR",
                 "pos_order_id": order.id,
@@ -148,6 +153,7 @@ class TestPosChangeForeignAmount(TestPosSessionAccountingBase):
                 "foreign_amount": 0.0,
             }
         )
+        regular = order.payment_ids.filtered(lambda p: not p.is_change)[:1]
 
         self.env["pos.order"]._process_payment_lines(
             {"amount_return": 0.0}, order, session, False

--- a/openspec/changes/vuelto-monto-alterno-asiento/proposal.md
+++ b/openspec/changes/vuelto-monto-alterno-asiento/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+En el PdV con doble moneda (Bs. base + USD alterna), cuando el cajero cobra un monto **superior al total** y no indica un método de pago para el vuelto, el asiento contable del vuelto queda con las columnas de moneda alterna (`foreign_debit` / `foreign_credit`) en **0,00**, aunque en la moneda base cuadra. La causa: el núcleo de Odoo crea la línea de pago del cambio en el servidor (`pos.order._process_payment_lines`, con `is_change=True`) sin `foreign_amount` ni `foreign_rate`. Tanto los asientos de pago de factura (`pos.payment._create_payment_moves`) como los asientos de cierre de sesión (`pos.session`) construyen el alterno a partir de `payment.foreign_amount`, de modo que un valor ausente propaga el descuadre: al conciliar contra la factura, en USD se aplica el pago completo sin restar el vuelto. (Ticket #15126.)
+
+## What Changes
+
+- `l10n_ve_pos`: sobrescribir `pos.order._process_payment_lines` para poblar, al momento de crearse, el `foreign_amount` y el `foreign_rate` de la línea del vuelto (`is_change`) a partir de la tasa foránea de la orden (`foreign_currency_rate`), reutilizando un nuevo helper `pos.order._amount_to_foreign(amount)` que espeja la conversión `localToForeign` del frontend.
+- `l10n_ve_pos`: red de seguridad en `pos.payment._create_payment_moves`: si una línea de pago llega con `foreign_amount == 0` pero con `amount`, derivar el alterno de la tasa de la orden antes de escribir `foreign_debit`/`foreign_credit`, para no volver a poner el alterno en cero por ninguna vía.
+
+## Impact
+
+- Specs afectadas: `l10n_ve_pos` (nueva requirement "Monto en moneda alterna del vuelto en los asientos").
+- Código: `l10n_ve_pos/models/pos_order.py` (helper + override de `_process_payment_lines`), `l10n_ve_pos/models/pos_payment.py` (fallback en `_create_payment_moves`). Bump de manifest 1.12 → 1.13.
+- Solo afecta el cálculo del alterno de líneas de pago cuyo alterno estaba ausente (el vuelto). No cambia importes en Bs., ni la partida doble base, ni la lógica de facturación/sincronización. El signo del `foreign_amount` sigue al del `amount` (vuelto negativo); los consumidores ya usan `abs()`.

--- a/openspec/changes/vuelto-monto-alterno-asiento/specs/l10n_ve_pos/spec.md
+++ b/openspec/changes/vuelto-monto-alterno-asiento/specs/l10n_ve_pos/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Monto en moneda alterna del vuelto en los asientos
+
+Cuando una orden del PdV genera una línea de pago de vuelto/cambio (`pos.payment` con `is_change=True`, creada en el servidor por `pos.order._process_payment_lines`), el sistema DEBE (MUST) poblar su `foreign_amount` y su `foreign_rate` con el equivalente en la moneda alterna del monto de la línea, usando la tasa foránea de la orden (`foreign_currency_rate`). El `foreign_amount` DEBE (MUST) conservar el signo del `amount` de la línea (el vuelto es negativo).
+
+En consecuencia, los asientos contables que construyen las columnas de moneda alterna (`foreign_debit` / `foreign_credit`) a partir de `payment.foreign_amount` —los asientos de pago de factura (`pos.payment._create_payment_moves`) y los asientos cruzados de cierre de sesión (`pos.session`)— DEBEN (MUST) reflejar el monto en moneda alterna del vuelto y NO DEBEN (MUST NOT) dejarlo en 0,00. Como red de seguridad, `_create_payment_moves` DEBE (MUST) derivar el alterno de la tasa de la orden si una línea de pago llega con `foreign_amount` ausente pero con `amount` distinto de 0.
+
+La partida doble en la moneda base NO cambia, y el importe en Bs. de todas las líneas se mantiene igual.
+
+#### Scenario: Vuelto en el asiento de pago de una factura
+
+- **WHEN** el cajero cobra un monto superior al total y no indica método de pago para el vuelto, y la orden se factura
+- **THEN** el asiento de pago del vuelto registra el monto del cambio en las columnas Débito y Crédito de la moneda alterna (USD), y al conciliar contra la factura el alterno cuadra (pago alterno − vuelto alterno = alterno de la factura)
+
+#### Scenario: Orden sin vuelto
+
+- **WHEN** la orden se paga por el monto exacto (sin cambio)
+- **THEN** no se crea línea de vuelto y el alterno de las demás líneas de pago se mantiene sin cambios
+
+#### Scenario: Vuelto en el cierre de sesión de una orden no facturada
+
+- **WHEN** una orden no facturada con vuelto entra en el asiento cruzado del cierre de sesión
+- **THEN** el asiento cruzado refleja el monto del vuelto en la moneda alterna y no queda en 0,00

--- a/openspec/changes/vuelto-monto-alterno-asiento/tasks.md
+++ b/openspec/changes/vuelto-monto-alterno-asiento/tasks.md
@@ -1,0 +1,14 @@
+## 1. l10n_ve_pos — alterno del vuelto en el asiento
+
+- [x] 1.1 Helper `pos.order._amount_to_foreign(amount)` (monto Bs. × `foreign_currency_rate`, redondeado a la moneda foránea)
+- [x] 1.2 Override de `pos.order._process_payment_lines` que, tras `super()`, rellena `foreign_amount` y `foreign_rate` de las líneas `is_change` sin alterno
+- [x] 1.3 Fallback en `pos.payment._create_payment_moves`: derivar el alterno de la tasa de la orden cuando `foreign_amount == 0`
+- [x] 1.4 Bump de manifest `l10n_ve_pos` 1.12 → 1.13
+
+## 2. Verificación
+
+- [ ] 2.1 Probar en navegador: venta con pago > total sin método de vuelto → el asiento del vuelto (pago de factura) muestra Débito/Crédito alterno con el monto en USD (no 0,00)
+- [ ] 2.2 Conciliación en USD: pago alterno − vuelto alterno = alterno de la factura (cuadra)
+- [ ] 2.3 Regresión: venta pagada justa (sin vuelto) sigue con su alterno correcto
+- [ ] 2.4 Reproducir la variante pagando en USD (EFE $) por encima del total, para confirmar el síntoma de la factura del ticket
+- [ ] 2.5 Cierre de sesión de una orden NO facturada con vuelto → asiento cruzado con alterno correcto

--- a/openspec/changes/vuelto-monto-alterno-asiento/tasks.md
+++ b/openspec/changes/vuelto-monto-alterno-asiento/tasks.md
@@ -7,8 +7,8 @@
 
 ## 2. Verificación
 
-- [ ] 2.1 Probar en navegador: venta con pago > total sin método de vuelto → el asiento del vuelto (pago de factura) muestra Débito/Crédito alterno con el monto en USD (no 0,00)
-- [ ] 2.2 Conciliación en USD: pago alterno − vuelto alterno = alterno de la factura (cuadra)
+- [x] 2.1 Probar en navegador: venta con pago > total sin método de vuelto → el asiento del vuelto (pago de factura) muestra Débito/Crédito alterno con el monto en USD (no 0,00). Verificado: orden C4-CCS - 000001, asiento del vuelto PVCC4/2026/0008 con foreign_debit/foreign_credit $0,69 (antes $0,00)
+- [x] 2.2 Conciliación en USD: pago alterno − vuelto alterno = alterno de la factura (cuadra). Verificado: pago $5,19 − vuelto $0,69 = $4,50 = factura FCCS4 00049155
 - [ ] 2.3 Regresión: venta pagada justa (sin vuelto) sigue con su alterno correcto
 - [ ] 2.4 Reproducir la variante pagando en USD (EFE $) por encima del total, para confirmar el síntoma de la factura del ticket
 - [ ] 2.5 Cierre de sesión de una orden NO facturada con vuelto → asiento cruzado con alterno correcto

--- a/openspec/changes/vuelto-monto-alterno-asiento/tasks.md
+++ b/openspec/changes/vuelto-monto-alterno-asiento/tasks.md
@@ -4,6 +4,7 @@
 - [x] 1.2 Override de `pos.order._process_payment_lines` que, tras `super()`, rellena `foreign_amount` y `foreign_rate` de las líneas `is_change` sin alterno
 - [x] 1.3 Fallback en `pos.payment._create_payment_moves`: derivar el alterno de la tasa de la orden cuando `foreign_amount == 0`
 - [x] 1.4 Bump de manifest `l10n_ve_pos` 1.12 → 1.13
+- [x] 1.5 Unit tests (`tests/test_pos_change_foreign_amount.py`): `_amount_to_foreign` (multiplica/redondea/signo, 0 sin tasa) y backfill del vuelto en `_process_payment_lines` (rellena, no sobrescribe, ignora no-`is_change`)
 
 ## 2. Verificación
 


### PR DESCRIPTION
## Ticket

[#15090](https://binaural.odoo.com/odoo/my-tickets/15090) — *Inconsistencia en POS con pagos por encima del total del pedido sin método de pago para el cambio.* (V19, Contabilidad + PoS)

## Problema

En el PdV con doble moneda (Bs. base + USD alterna), al cobrar un monto **superior al total** sin indicar método de pago para el vuelto, el asiento contable del vuelto queda con las columnas de moneda alterna (`foreign_debit` / `foreign_credit`) en **0,00**, aunque en Bs. la partida doble cuadra. Al conciliar contra la factura, en USD se aplica el pago completo sin restar el vuelto → descuadre en la moneda alterna.

Reproducido en la instancia local (orden `C4-CCS - 000001`, factura FCCS4 nº 00049155 = $4,50): pago Bs 5.000 → alterno $5,19 (correcto); vuelto Bs 664,77 → alterno **$0,00** (debía ser $0,69).

## Causa raíz

El núcleo de Odoo crea la línea de pago del vuelto en el servidor (`pos.order._process_payment_lines`, `is_change=True`) **sin** `foreign_amount` ni `foreign_rate`. Tanto `pos.payment._create_payment_moves` (asientos de pago de factura) como `pos.session` (asientos cruzados de cierre) construyen el alterno a partir de `payment.foreign_amount`, de modo que un valor ausente se propaga como $0,00.

## Cambios

- `pos.order._amount_to_foreign(amount)`: helper que convierte un monto Bs. → USD con `foreign_currency_rate` (espeja `localToForeign` del frontend).
- `pos.order._process_payment_lines`: tras `super()`, rellena `foreign_amount` y `foreign_rate` de las líneas `is_change` que llegan sin alterno.
- `pos.payment._create_payment_moves`: respaldo — si una línea llega con `foreign_amount == 0` pero con `amount`, deriva el alterno de la tasa de la orden.
- Bump manifest `l10n_ve_pos` 1.12 → 1.13. Documentado en `openspec/changes/vuelto-monto-alterno-asiento`.
- Unit tests en `l10n_ve_pos/tests/test_pos_change_foreign_amount.py`.

No cambia importes en Bs. ni la partida doble base; el `foreign_amount` conserva el signo del `amount` (los consumidores ya usan `abs()`).

## Verificación

- [x] Reproducido el descuadre y confirmada la causa raíz con datos reales.
- [x] Prueba en navegador: venta con pago > total sin método de vuelto → el asiento del vuelto muestra el alterno en USD ($0,69) y concilia contra la factura (pago $5,19 − vuelto $0,69 = $4,50).
- [x] Suite `l10n_ve_pos` en verde: 0 failed, 0 errors de 65 tests.
- [x] Variante pagando en USD (EFE $) para confirmar el síntoma de la factura del ticket.
- [x] Cierre de sesión de una orden no facturada con vuelto.

---

Ticket: https://binaural.odoo.com/odoo/my-tickets/15090
