### PR TITLE
Maint 19.0 ti 15158 fix retentions automate islr

### DIFF
--- a/l10n_ve_payment_extension/__manifest__.py
+++ b/l10n_ve_payment_extension/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accountant/Accountant",
-    "version": "19.0.2.0.28",
+    "version": "19.0.2.0.29",
     "depends": [
         "base",
         "account",

--- a/l10n_ve_payment_extension/models/account_move.py
+++ b/l10n_ve_payment_extension/models/account_move.py
@@ -574,7 +574,7 @@ class AccountMoveRetention(models.Model):
                     if product_tmpl.type == 'service' and product_tmpl.payment_concept:
 
                         concept_id = product_tmpl.payment_concept.id
-                        base_amount = abs(line.price_unit) if use_price_unit else abs(line.move_id.tax_totals["base_amount"])
+                        base_amount = abs(line.price_subtotal) if use_price_unit else abs(line.move_id.tax_totals["base_amount"])
                         payment_concepts.append((
                             concept_id,
                             base_amount,

--- a/l10n_ve_payment_extension/openspec/changes/l10n-ve-payment-islr-retention-base-subtotal/proposal.md
+++ b/l10n_ve_payment_extension/openspec/changes/l10n-ve-payment-islr-retention-base-subtotal/proposal.md
@@ -1,0 +1,64 @@
+# Fix: la retención ISLR toma el precio unitario en vez del importe de la línea
+
+## Why
+
+Reportado por Miguel Casanova (cliente Maxcam) vía WhatsApp el 11/09/2026,
+ticket TI-15158/#15194 ("Ajustar error base imponible de retenciones ISLR").
+
+Caso de reproducción: orden de compra `P00192`, proveedor Hierros Miranda
+C.A. (RIF J-300819000), diario "Facturas de Proveedores Guarenas". Al generar
+la factura del proveedor y calcular la retención ISLR, el sistema tomaba el
+**precio unitario** de la línea como base imponible en vez del **importe de
+la línea** (precio unitario × cantidad, con descuento aplicado).
+
+### Causa raíz
+
+`AccountMoveRetention._get_payment_concepts_from_invoice()`
+(`l10n_ve_payment_extension/models/account_move.py`) calcula el monto base
+por línea de dos formas distintas según cuántas líneas de la factura tengan
+un concepto de pago ISLR asociado (`use_price_unit = len(valid_lines) > 1`):
+
+- **Una sola línea válida**: usa `move_id.tax_totals["base_amount"]` (el
+  subtotal de la factura completa) — correcto.
+- **Más de una línea válida**: usaba `abs(line.price_unit)` — el precio
+  unitario **sin multiplicar por cantidad ni aplicar descuento** — en vez de
+  `abs(line.price_subtotal)` (el importe real de la línea).
+
+Con cantidad distinta de 1 o cualquier descuento, el monto base de cada
+concepto quedaba mal calculado, generando una retención ISLR incorrecta con
+riesgo de incumplimiento fiscal.
+
+Esta lógica es compartida por los dos flujos de creación de retención ISLR
+del módulo, así que el bug afectaba a ambos por igual:
+
+- **Manual**: `action_create_islr_from_invoice()` (precarga
+  `default_islr_lines` del wizard).
+- **Automática**: `auto_create_islr_retention()`.
+
+## What Changes
+
+- `l10n_ve_payment_extension/models/account_move.py`
+  - `_get_payment_concepts_from_invoice()`: cuando hay más de una línea con
+    concepto de pago ISLR, el monto base por línea pasa de
+    `abs(line.price_unit)` a `abs(line.price_subtotal)`.
+
+## Impact
+
+- **Capability**: `islr-retention-base-amount` (nueva).
+- **Módulo**: `l10n_ve_payment_extension` (base de Venezuela, no específico
+  de Maxcam — el cálculo vive en el módulo de localización, así que el
+  fix beneficia a todo cliente con retención ISLR y facturas
+  multi-línea, no solo a Maxcam).
+- **Alcance real**: solo afecta facturas con **más de una línea con
+  concepto de pago ISLR** y cantidad ≠ 1 o descuento ≠ 0. Facturas de una
+  sola línea ISLR nunca tuvieron este problema (usan el subtotal total de
+  la factura).
+- **Riesgo**: bajo. Cambio de una sola expresión, sin tocar el resto del
+  flujo de creación de retenciones.
+- **Datos existentes**: las retenciones ISLR ya emitidas con esta base mal
+  calculada no se corrigen automáticamente por este cambio — es solo un fix
+  hacia adelante. Si el cliente necesita corregir retenciones ya
+  declaradas, requiere una tarea de corrección de datos histórica aparte.
+- **Verificado**: test automatizado `test_16b_...` (dos líneas ISLR con
+  cantidad y descuento ≠ 1/0) corrido en contenedor Docker sobre una base de
+  datos de prueba descartable; pasa con el fix y falla sin él.

--- a/l10n_ve_payment_extension/openspec/changes/l10n-ve-payment-islr-retention-base-subtotal/specs/islr-retention-base-amount/spec.md
+++ b/l10n_ve_payment_extension/openspec/changes/l10n-ve-payment-islr-retention-base-subtotal/specs/islr-retention-base-amount/spec.md
@@ -1,0 +1,60 @@
+# Spec delta: islr-retention-base-amount
+
+## ADDED Requirements
+
+### Requirement: El monto base de retención ISLR por línea usa el importe de la línea
+
+El sistema SHALL calcular el monto base de retención ISLR de cada línea de
+factura con concepto de pago asociado usando `price_subtotal` (precio
+unitario × cantidad, con descuento aplicado), y SHALL NOT usar `price_unit`
+sin multiplicar por cantidad ni aplicar descuento.
+
+Esto aplica quando la factura tiene más de una línea con concepto de pago
+ISLR (`use_price_unit=True` en
+`AccountMoveRetention._get_payment_concepts_from_invoice`). Cuando hay una
+sola línea válida, la base sigue siendo el subtotal total de la factura
+(`move_id.tax_totals["base_amount"]`), sin cambios.
+
+Motivo: `price_unit` es el precio por unidad, ajeno a la cantidad y al
+descuento de la línea. Usarlo como base imponible de una retención fiscal
+produce un monto incorrecto en cualquier línea con cantidad ≠ 1 o descuento
+≠ 0, con riesgo de incumplimiento fiscal para el cliente.
+
+#### Scenario: Factura con dos líneas ISLR, cantidad y descuento distintos de 1/0
+
+- **GIVEN** una factura de proveedor con dos líneas de servicio, cada una
+  con un concepto de pago ISLR asociado
+- **AND** la primera línea tiene cantidad 3, precio unitario 100 y
+  descuento 10%
+- **AND** la segunda línea tiene cantidad 5, precio unitario 50 y
+  descuento 20%
+- **WHEN** se calculan los conceptos de pago de la factura
+  (`_get_payment_concepts_from_invoice`)
+- **THEN** el monto base de la primera línea es su `price_subtotal` (270.0),
+  no su `price_unit` (100.0)
+- **AND** el monto base de la segunda línea es su `price_subtotal` (200.0),
+  no su `price_unit` (50.0)
+
+#### Scenario: Factura con una sola línea ISLR
+
+- **GIVEN** una factura de proveedor con una única línea de servicio con
+  concepto de pago ISLR asociado
+- **WHEN** se calculan los conceptos de pago de la factura
+- **THEN** el monto base sigue siendo el subtotal total de la factura
+  (comportamiento sin cambios)
+
+### Requirement: La corrección aplica por igual a la creación manual y automática de retención ISLR
+
+El sistema SHALL usar el mismo cálculo de monto base
+(`_get_payment_concepts_from_invoice`) tanto en el flujo manual
+(`action_create_islr_from_invoice`) como en el automático
+(`auto_create_islr_retention`), de modo que un fix en el cálculo de base
+corrija ambos flujos sin duplicar lógica.
+
+#### Scenario: Retención ISLR creada automáticamente desde una factura multi-línea
+
+- **GIVEN** una factura de proveedor con más de una línea ISLR con
+  cantidad y/o descuento distintos de 1/0
+- **WHEN** se ejecuta `auto_create_islr_retention()`
+- **THEN** cada línea de retención usa `price_subtotal` como base, igual
+  que en el flujo manual

--- a/l10n_ve_payment_extension/openspec/changes/l10n-ve-payment-islr-retention-base-subtotal/tasks.md
+++ b/l10n_ve_payment_extension/openspec/changes/l10n-ve-payment-islr-retention-base-subtotal/tasks.md
@@ -1,0 +1,44 @@
+# Tasks
+
+## 1. Diagnóstico
+
+- [x] 1.1 Reproducido el reporte del cliente: orden de compra `P00192`,
+      proveedor Hierros Miranda C.A., diario "Facturas de Proveedores
+      Guarenas"
+- [x] 1.2 Localizada la causa raíz en
+      `_get_payment_concepts_from_invoice()`
+      (`l10n_ve_payment_extension/models/account_move.py:577`):
+      `use_price_unit` (más de una línea ISLR) usaba `line.price_unit` en
+      vez de `line.price_subtotal`
+- [x] 1.3 Confirmado que el bug afecta a los dos flujos que comparten esta
+      función: creación manual (`action_create_islr_from_invoice`) y
+      automática (`auto_create_islr_retention`)
+- [x] 1.4 Confirmado que el caso de una sola línea ISLR no está afectado
+      (usa `move_id.tax_totals["base_amount"]`)
+
+## 2. Fix
+
+- [x] 2.1 `l10n_ve_payment_extension/models/account_move.py:577`:
+      `abs(line.price_unit)` → `abs(line.price_subtotal)`
+
+## 3. Verificación
+
+- [x] 3.1 Test nuevo `test_16b_get_payment_concepts_from_invoice_multi_line_qty_discount`
+      (`tests/test_payment_retention.py`): dos líneas ISLR con cantidad y
+      descuento distintos de 1/0, verifica que el monto base sea
+      `price_subtotal` y no `price_unit`
+- [x] 3.2 Corrido en contenedor Docker (`proj`) sobre una base de datos de
+      prueba descartable (creada y eliminada para esta verificación,
+      sin tocar `testing`): `test_16` y `test_16b` pasan con el fix
+- [ ] 3.3 Revisar si hay retenciones ISLR ya emitidas con base mal
+      calculada (facturas multi-línea con cantidad ≠ 1 o descuento) en las
+      instancias productivas de clientes con ISLR habilitado — pendiente,
+      requiere data-fix aparte si aplica
+
+## 4. Manifest
+
+- [x] 4.1 `l10n_ve_payment_extension` 19.0.2.0.28 → 19.0.2.0.29
+
+## 5. OpenSpec
+
+- [x] 5.1 `proposal.md` + spec delta

--- a/l10n_ve_payment_extension/tests/test_payment_retention.py
+++ b/l10n_ve_payment_extension/tests/test_payment_retention.py
@@ -1,4 +1,4 @@
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 from odoo import Command, fields
 from odoo.exceptions import UserError, ValidationError
 from .test_withholding_common_VEF import RetentionTestCommon
@@ -300,6 +300,47 @@ class TestPaymentRetention(RetentionTestCommon):
         concepts = invoice._get_payment_concepts_from_invoice()
         self.assertGreater(len(concepts), 0)
         _logger.info("========= test_16 passed =========")
+
+    def test_16b_get_payment_concepts_from_invoice_multi_line_qty_discount(self):
+        # Two ISLR-eligible lines force use_price_unit=True. Each line has
+        # quantity > 1 and a discount, so price_unit alone (without qty/discount)
+        # would not match the real base amount for the retention.
+        with Form(self.env["account.move"].with_context(
+            default_move_type="in_invoice", default_journal_id=self.purchase_journal.id,
+        )) as inv_form:
+            inv_form.partner_id = self.partner_pnr_75
+            inv_form.invoice_date = fields.Date.today()
+            inv_form.currency_id = self.currency_vef
+            inv_form.correlative = "10000000000001"
+
+        invoice = inv_form.save()
+        with Form(invoice) as inv_form_edit:
+            with inv_form_edit.invoice_line_ids.new() as line:
+                line.product_id = self.product_islr_one
+                line.quantity = 3
+                line.price_unit = 100.0
+                line.discount = 10.0
+            with inv_form_edit.invoice_line_ids.new() as line:
+                line.product_id = self.product_islr_iva_one
+                line.quantity = 5
+                line.price_unit = 50.0
+                line.discount = 20.0
+        invoice = inv_form_edit.save()
+        invoice.write({"foreign_rate": 1.0, "foreign_inverse_rate": 1.0})
+
+        concepts = invoice._get_payment_concepts_from_invoice()
+        self.assertEqual(len(concepts), 2)
+
+        base_amounts = {line_id: amount for _concept_id, amount, line_id in concepts}
+        for line in invoice.invoice_line_ids:
+            self.assertIn(line.id, base_amounts)
+            self.assertAlmostEqual(
+                base_amounts[line.id], abs(line.price_subtotal), places=2,
+            )
+            self.assertNotAlmostEqual(
+                base_amounts[line.id], abs(line.price_unit), places=2,
+            )
+        _logger.info("========= test_16b passed =========")
 
     def test_17_view_third_party_iva_retentions(self):
         invoice = self._create_invoice_reten_iva(


### PR DESCRIPTION
[FIX] l10n_ve_payment_extension: base imponible ISLR usa subtotal de línea
Corrige el cálculo del monto base de retención ISLR cuando una factura tiene más de una línea con concepto de pago: usaba price_unit (sin cantidad ni descuento) en vez de price_subtotal (el importe real de la línea), generando retenciones mal calculadas con cantidad ≠ 1 o descuento ≠ 0.

Afecta por igual a la creación manual (action_create_islr_from_invoice) y automática (auto_create_islr_retention) de retención ISLR, ya que ambas comparten _get_payment_concepts_from_invoice().

Incluye:

models/account_move.py: abs(line.price_unit) → abs(line.price_subtotal).
tests/test_payment_retention.py: test de regresión test_16b_get_payment_concepts_from_invoice_multi_line_qty_discount (dos líneas ISLR, cantidad y descuento distintos de 1/0).
openspec/changes/l10n-ve-payment-islr-retention-base-subtotal/: proposal, tasks y spec delta del cambio.
References:

Ticket:  15194 https://binaural.odoo.com/odoo/all-tickets/15158
